### PR TITLE
[add] separate picking_ids in sale.order for mrp_simple pickings

### DIFF
--- a/deltatech_mrp_simple/__init__.py
+++ b/deltatech_mrp_simple/__init__.py
@@ -3,3 +3,4 @@
 
 
 from . import wizard
+from . import models

--- a/deltatech_mrp_simple/__manifest__.py
+++ b/deltatech_mrp_simple/__manifest__.py
@@ -9,7 +9,7 @@
     "category": "Manufacturing",
     "depends": ["stock", "sale"],
     "license": "LGPL-3",
-    "data": ["wizard/mrp_simple_view.xml", "security/ir.model.access.csv"],
+    "data": ["wizard/mrp_simple_view.xml", "security/ir.model.access.csv", "views/sale_order.xml"],
     "images": ["static/description/main_screenshot.png"],
     "installable": True,
     "development_status": "Mature",

--- a/deltatech_mrp_simple/models/__init__.py
+++ b/deltatech_mrp_simple/models/__init__.py
@@ -1,0 +1,5 @@
+# ©  2015-2021 Deltatech
+# See README.rst file on addons root folder for license details
+
+from . import sale_order
+from . import stock_picking

--- a/deltatech_mrp_simple/models/sale_order.py
+++ b/deltatech_mrp_simple/models/sale_order.py
@@ -1,0 +1,44 @@
+# ©  2015-2021 Deltatech
+# See README.rst file on addons root folder for license details
+
+
+from odoo import api, fields, models
+
+
+class SaleOrder(models.Model):
+    _inherit = "sale.order"
+
+    simple_mrp_picking_ids = fields.One2many("stock.picking", "sale_simple_mrp_id", string="Simple MRP Transfers")
+    simple_mrp_count = fields.Integer(string="MRP Simple", compute="_compute_simple_mrp_picking_ids")
+
+    @api.depends("simple_mrp_picking_ids")
+    def _compute_simple_mrp_picking_ids(self):
+        for order in self:
+            order.simple_mrp_count = len(order.simple_mrp_picking_ids) / 2
+
+    def action_view_mrp_transfers(self):
+        action = self.env.ref("stock.action_picking_tree_all").read()[0]
+        pickings = self.mapped("simple_mrp_picking_ids")
+        if len(pickings) > 1:
+            action["domain"] = [("id", "in", pickings.ids)]
+        elif pickings:
+            form_view = [(self.env.ref("stock.view_picking_form").id, "form")]
+            if "views" in action:
+                action["views"] = form_view + [(state, view) for state, view in action["views"] if view != "form"]
+            else:
+                action["views"] = form_view
+            action["res_id"] = pickings.id
+        # Prepare the context.
+        picking_id = pickings.filtered(lambda l: l.picking_type_id.code == "outgoing")
+        if picking_id:
+            picking_id = picking_id[0]
+        else:
+            picking_id = pickings[0]
+        action["context"] = dict(
+            self._context,
+            default_partner_id=self.partner_id.id,
+            default_picking_type_id=picking_id.picking_type_id.id,
+            default_origin=self.name,
+            default_group_id=picking_id.group_id.id,
+        )
+        return action

--- a/deltatech_mrp_simple/models/stock_picking.py
+++ b/deltatech_mrp_simple/models/stock_picking.py
@@ -1,0 +1,11 @@
+# ©  2015-2021 Deltatech
+# See README.rst file on addons root folder for license details
+
+
+from odoo import fields, models
+
+
+class StockPicking(models.Model):
+    _inherit = "stock.picking"
+
+    sale_simple_mrp_id = fields.Many2one("sale.order", string="Sales Order", store=True, readonly=False)

--- a/deltatech_mrp_simple/views/sale_order.xml
+++ b/deltatech_mrp_simple/views/sale_order.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" ?>
+<odoo>
+    <data>
+        <record id="view_order_form_inherit_simple_mrp" model="ir.ui.view">
+            <field name="name">sale.order.form.sale.stock</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//button[@name='action_view_invoice']" position="before">
+                    <field name="simple_mrp_picking_ids" invisible="1" />
+                    <button
+                        type="object"
+                        name="action_view_mrp_transfers"
+                        class="oe_stat_button"
+                        icon="fa-random"
+                        attrs="{'invisible': [('simple_mrp_count', '=', 0)]}"
+                        groups="base.group_user"
+                    >
+                        <field name="simple_mrp_count" widget="statinfo" string="MRP Simple" />
+                    </button>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/deltatech_mrp_simple/wizard/mrp_simple.py
+++ b/deltatech_mrp_simple/wizard/mrp_simple.py
@@ -71,8 +71,8 @@ class MRPSimple(models.TransientModel):
 
         # adaugare picking ids in sale order
         if self.sale_order_id:
-            self.sale_order_id.update({"picking_ids": [(4, picking_in.id, False)]})
-            self.sale_order_id.update({"picking_ids": [(4, picking_out.id, False)]})
+            self.sale_order_id.update({"simple_mrp_picking_ids": [(4, picking_in.id, False)]})
+            self.sale_order_id.update({"simple_mrp_picking_ids": [(4, picking_out.id, False)]})
 
         # se face consumul
         if picking_out.move_lines:


### PR DESCRIPTION
Expected behaviour: Mrp Simple button in sale.order form view that points to all mrp simple pickings linked