### PR TITLE
[14.0][FIX] fast_sale: removed force date

### DIFF
--- a/deltatech_fast_sale/__manifest__.py
+++ b/deltatech_fast_sale/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Fast Sale",
-    "version": "14.0.1.0.1",
+    "version": "14.0.1.0.2",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Vanzare rapida",

--- a/deltatech_fast_sale/models/sale.py
+++ b/deltatech_fast_sale/models/sale.py
@@ -41,11 +41,6 @@ class SaleOrder(models.Model):
         action["context"] = {"force_period_date": self.date_order}
         return action
 
-    def _prepare_invoice(self):
-        invoice_vals = super(SaleOrder, self)._prepare_invoice()
-        invoice_vals["invoice_date"] = self.date_order.date()
-        return invoice_vals
-
     def action_button_confirm_notice(self):
         self._prepare_pickings()
 


### PR DESCRIPTION
Nu ar trebui sa forteze in factura data comenzii. Oricum ia data curenta la postare