### PR TITLE
[FIX] deltatech_stock_negative: Properly separate words in error message

### DIFF
--- a/deltatech_stock_negative/i18n/ro.po
+++ b/deltatech_stock_negative/i18n/ro.po
@@ -21,6 +21,11 @@ msgid "<span class=\"fa fa-lg fa-building-o\" title=\"Values set here are compan
 msgstr "<span class=\"fa fa-lg fa-building-o\" title=\"Valorile stabilite aici sunt specifice companiei.\" aria-label=\"Valorile stabilite aici sunt specifice companiei.\" groups=\"base.group_multi_company\" role=\"img\"/>"
 
 #. module: deltatech_stock_negative
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_location__allow_negative_stock
+msgid "Allow Negative Stock"
+msgstr ""
+
+#. module: deltatech_stock_negative
 #: model:ir.model.fields,help:deltatech_stock_negative.field_res_company__no_negative_stock
 #: model:ir.model.fields,help:deltatech_stock_negative.field_res_config_settings__no_negative_stock
 msgid "Allows you to prohibit negative stock quantities."
@@ -35,6 +40,11 @@ msgstr "Companii"
 #: model:ir.model,name:deltatech_stock_negative.model_res_config_settings
 msgid "Config Settings"
 msgstr "Setări de configurare"
+
+#. module: deltatech_stock_negative
+#: model:ir.model,name:deltatech_stock_negative.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
 
 #. module: deltatech_stock_negative
 #: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_company__no_negative_stock
@@ -53,7 +63,13 @@ msgid "Quants"
 msgstr "Poziții de stoc"
 
 #. module: deltatech_stock_negative
-#: code:addons/deltatech_stock_negative/models/stock.py:22
+#: code:addons/deltatech_stock_negative/models/stock.py:0
 #, python-format
-msgid "You have chosen to avoid negative stock.                         %s pieces of %s are remaining in location %s  but you want to transfer                          %s pieces. Please adjust your quantities or                         correct your stock with an inventory adjustment."
+msgid "You have chosen to avoid negative stock. %s pieces of %s are remaining in location %s, but you want to transfer %s pieces. Please adjust your quantities or correct your stock with an inventory adjustment."
 msgstr "Ați ales să evitați stocurile negative.   %s din %s există în locația %s dar dvs vreți să transferați %s. Ajustați cantitățile sau corectați stocul cu o ajustare de inventar."
+
+#. module: deltatech_stock_negative
+#: code:addons/deltatech_stock_negative/models/stock.py:0
+#, python-format
+msgid "You have chosen to avoid negative stock. %s pieces of %s are remaining in location %s, lot %s, but you want to transfer %s pieces. Please adjust your quantities or correct your stock with an inventory adjustment."
+msgstr ""

--- a/deltatech_stock_negative/models/stock.py
+++ b/deltatech_stock_negative/models/stock.py
@@ -31,7 +31,7 @@ class StockQuant(models.Model):
                 if location_id.company_id.no_negative_stock:
                     if not lot_id:
                         err = _(
-                            "You have chosen to avoid negative stock. %s pieces of %s are remaining in location %s"
+                            "You have chosen to avoid negative stock. %s pieces of %s are remaining in location %s, "
                             "but you want to transfer %s pieces. "
                             "Please adjust your quantities or correct your stock with an inventory adjustment."
                         ) % (product_id.qty_available, product_id.name, location_id.name, quantity)


### PR DESCRIPTION
Fixes a minor typo in an error message. Also fixes the Romanian translation for this error, which wasn't working before.