### PR TITLE
Disable Create Edit Too

### DIFF
--- a/deltatech_no_quick_create/static/src/js/fields.esm.js
+++ b/deltatech_no_quick_create/static/src/js/fields.esm.js
@@ -12,11 +12,15 @@ patch(Many2OneField.prototype, {
     },
     setup() {
         this.props.canQuickCreate = false;
+        // diabled create edit too
+        this.props.canCreateEdit = false;
         super.setup();
     },
     extractProps({attrs}) {
         const props = super.extractProps(...arguments);
         if (attrs.options.no_quick_create === undefined) props.canQuickCreate = false;
+        // diabled create edit too
+        if (attrs.options.no_create_edit === undefined) props.canCreateEdit = false;
         return props;
     },
 });


### PR DESCRIPTION
As an Odoo user with client experience, I noticed that the quick create/edit feature sometimes leads to users accidentally creating unnecessary records. This small change disables that option in certain fields to help keep the data cleaner and more intentional.