### PR TITLE
Activează etapa "manual" pentru hook-urile `oca-gen-addon-readme`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
     hooks:
       # Use each script's `--help` to understand the args
       - id: oca-gen-addon-readme
-#        stages: [manual]
+        stages: [manual]
         args:
           - --addons-dir=.
           - --org-name=dhongu


### PR DESCRIPTION
---

Actualizată configurația pre-commit pentru hook-urile `oca-gen-addon-readme` prin includerea etapei "manual". Acest lucru permite rularea explicită și controlată a generatorului de fișiere README.