### PR TITLE
Actualizează permisiunile din `record_type_security.xml`

### DIFF
--- a/deltatech_record_type/security/record_type_security.xml
+++ b/deltatech_record_type/security/record_type_security.xml
@@ -2,12 +2,9 @@
 <odoo>
     <record id="group_confirm_order_without_record_type" model="res.groups">
         <field name="name">Can Confirm Orders Without Record Type</field>
-        <field name="category_id" ref="base.module_category_hidden" />
-        <field
-            name="users"
-            eval="[(4, ref('base.user_root')), (4, ref('base.user_admin')), (4, ref('base.default_user'))]"
-        />
+        <field name="user_ids" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]" />
     </record>
+
     <record model="ir.rule" id="record_type_comp_rule">
         <field name="name">Record type multi-company</field>
         <field name="model_id" ref="model_record_type" />


### PR DESCRIPTION
Câmpul `users` a fost înlocuit cu `user_ids` în definiția unei reguli de securitate pentru utilizatori. Modificarea corectează utilizarea unui atribut depreciat și asigură compatibilitatea cu noile standarde ale platformei.