### PR TITLE
[ADD] Teste pentru căutarea produselor arhivate după cod alternativ

### DIFF
--- a/deltatech_alternative/__manifest__.py
+++ b/deltatech_alternative/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Products Alternative",
-    "version": "18.0.2.1.3",
+    "version": "18.0.2.1.4",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Alternative product codes",

--- a/deltatech_alternative/models/product.py
+++ b/deltatech_alternative/models/product.py
@@ -54,7 +54,7 @@ class ProductTemplate(models.Model):
             alternatives = self.env["product.alternative"].search(domain, limit=left)
             product_tmpl_ids = alternatives.mapped("product_tmpl_id")
             current_ids = {r[0] for r in res}
-            product_tmpl_ids = product_tmpl_ids.filtered(lambda p: p.id not in current_ids)
+            product_tmpl_ids = product_tmpl_ids.filtered(lambda p: p.id not in current_ids and p.active)
             product_tmpl_ids = product_tmpl_ids[:left]
             res += [(p.id, p.display_name) for p in product_tmpl_ids]
         if limit:
@@ -66,7 +66,7 @@ class ProductTemplate(models.Model):
         domain = super()._search_display_name(operator, value)
         get_param = self.env["ir.config_parameter"].sudo().get_param
         if value and safe_eval(get_param("alternative.search_name", "False")):
-            alternative_domain = [("alternative_ids.name", operator, value)]
+            alternative_domain = [("alternative_ids.name", operator, value), ("active", "=", True)]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = expression.AND([domain, alternative_domain])
             else:
@@ -93,7 +93,7 @@ class ProductProduct(models.Model):
 
             variants = product_tmpl_ids.mapped("product_variant_ids")
             current_ids = {r[0] for r in res}
-            variants = variants.filtered(lambda p: p.id not in current_ids)
+            variants = variants.filtered(lambda p: p.id not in current_ids and p.active)
             variants = variants[:left]
 
             res += [(p.id, p.name) for p in variants]
@@ -106,7 +106,7 @@ class ProductProduct(models.Model):
         domain = super()._search_display_name(operator, value)
         get_param = self.env["ir.config_parameter"].sudo().get_param
         if value and safe_eval(get_param("alternative.search_name", "False")):
-            alternative_domain = [("alternative_ids.name", operator, value)]
+            alternative_domain = [("alternative_ids.name", operator, value), ("active", "=", True)]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
                 domain = expression.AND([domain, alternative_domain])
             else:

--- a/deltatech_alternative/tests/__init__.py
+++ b/deltatech_alternative/tests/__init__.py
@@ -3,3 +3,4 @@
 # See README.rst file on addons root folder for license details
 
 from . import test_product
+from . import test_archive

--- a/deltatech_alternative/tests/test_archive.py
+++ b/deltatech_alternative/tests/test_archive.py
@@ -1,0 +1,73 @@
+# ©  2023 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests.common import TransactionCase
+
+
+class TestProductArchive(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.env["ir.config_parameter"].sudo().set_param("alternative.search_name", "True")
+
+    def test_search_archived_product_by_alternative_code(self):
+        # Creare produs activ cu cod alternativ
+        product_active = self.env["product.template"].create(
+            {
+                "name": "Active Product",
+                "alternative_code": "ALT_ACTIVE",
+                "active": True,
+            }
+        )
+
+        # Creare produs arhivat cu cod alternativ
+        product_archived = self.env["product.template"].create(
+            {
+                "name": "Archived Product",
+                "alternative_code": "ALT_ARCHIVED",
+                "active": False,
+            }
+        )
+
+        # Căutare după codul alternativ al produsului activ
+        res_active = self.env["product.template"].name_search("ALT_ACTIVE", operator="ilike")
+        ids_active = [r[0] for r in res_active]
+        self.assertIn(product_active.id, ids_active, "Produsul activ ar trebui să fie găsit după codul alternativ")
+
+        # Căutare după codul alternativ al produsului arhivat
+        res_archived = self.env["product.template"].name_search("ALT_ARCHIVED", operator="ilike")
+        ids_archived = [r[0] for r in res_archived]
+        self.assertNotIn(
+            product_archived.id, ids_archived, "Produsul arhivat NU ar trebui să fie găsit după codul alternativ"
+        )
+
+    def test_search_archived_variant_by_alternative_code(self):
+        # Creare produs activ cu cod alternativ
+        product_active = self.env["product.product"].create(
+            {
+                "name": "Active Variant",
+                "alternative_code": "VALT_ACTIVE",
+                "active": True,
+            }
+        )
+
+        # Creare produs arhivat cu cod alternativ
+        product_archived = self.env["product.product"].create(
+            {
+                "name": "Archived Variant",
+                "alternative_code": "VALT_ARCHIVED",
+                "active": False,
+            }
+        )
+
+        # Căutare după codul alternativ al produsului activ
+        res_active = self.env["product.product"].name_search("VALT_ACTIVE", operator="ilike")
+        ids_active = [r[0] for r in res_active]
+        self.assertIn(product_active.id, ids_active, "Varianta activă ar trebui să fie găsită după codul alternativ")
+
+        # Căutare după codul alternativ al produsului arhivat
+        res_archived = self.env["product.product"].name_search("VALT_ARCHIVED", operator="ilike")
+        ids_archived = [r[0] for r in res_archived]
+        self.assertNotIn(
+            product_archived.id, ids_archived, "Varianta arhivată NU ar trebui să fie găsită după codul alternativ"
+        )


### PR DESCRIPTION
Adaugă noi teste pentru a verifica comportamentul căutării produselor și variantelor arhivate folosind coduri alternative. Modificările includ ajustări în logica de filtrare pentru a exclude produsele inactive, asigurând o funcționalitate mai corectă și robustă. Versiunea modulului a fost actualizată pentru a reflecta aceste schimbări.