### PR TITLE
[ADD] Introduce "Avoid Putaway Rules" setting for pickings

### DIFF
--- a/deltatech_putaway_strategy/__manifest__.py
+++ b/deltatech_putaway_strategy/__manifest__.py
@@ -9,6 +9,7 @@
     "depends": ["stock"],
     "data": [
         "views/stock_location_views.xml",
+        "views/stock_picking_type_views.xml",
     ],
     "development_status": "Beta",
     "maintainers": ["dhongu"],

--- a/deltatech_putaway_strategy/__manifest__.py
+++ b/deltatech_putaway_strategy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Deltatech Putaway Strategy",
-    "version": "17.0.1.0.3",
+    "version": "17.0.1.0.4",
     "summary": "Location capacities and enhanced putaway strategy for Inventory",
     "author": "Deltatech, Terrabit",
     "website": "https://www.terrabit.ro",

--- a/deltatech_putaway_strategy/models/__init__.py
+++ b/deltatech_putaway_strategy/models/__init__.py
@@ -1,2 +1,3 @@
 from . import stock_location
 from . import stock_move_line
+from . import stock_picking

--- a/deltatech_putaway_strategy/models/stock_location.py
+++ b/deltatech_putaway_strategy/models/stock_location.py
@@ -67,41 +67,7 @@ class StockLocation(models.Model):
 
         planned_qty_by_loc = {}
         if leaves:
-            # Mișcări de stoc care nu sunt finalizate (planificate)
-            # Luăm în calcul atât stock.move cât și stock.move.line care nu au move_id sau sunt legate de move-uri active
-            # Dar cel mai sigur este să ne uităm la move_line-urile care nu sunt încă 'done' sau 'cancel'
 
-            # 1. Cantități din stock.move (pentru cele care nu au încă move lines detaliate sau sunt în stare de așteptare)
-            # planned_sums = Move.read_group(
-            #     [
-            #         ("location_dest_id", "in", leaves.ids),
-            #         ("state", "not in", ["done", "cancel"]),
-            #         ("location_id", "!=", "location_dest_id"),
-            #     ],
-            #     ["product_uom_qty:sum"],
-            #     ["location_dest_id"],
-            #     lazy=False,
-            # )
-            # for rec in planned_sums:
-            #     loc_id = rec["location_dest_id"][0]
-            #     planned_qty_by_loc[loc_id] = planned_qty_by_loc.get(loc_id, 0.0) + rec.get("product_uom_qty", 0.0)
-
-            # 2. Cantități din stock.move.line (pentru cele care au deja locații de destinație specifice)
-            # Dacă un move are move_lines, product_uom_qty din move s-ar putea să fie redundant sau să includă aceste linii.
-            # În Odoo 17, stock.move.product_uom_qty este cererea totală.
-            # Când facem action_assign, se creează move_lines.
-            # Dacă folosim și move și move_line, riscăm dubla numărare dacă move.location_dest_id este aceeași cu move_line.location_dest_id.
-
-            # Strategie mai bună:
-            # - Mișcările (moves) care au destinația într-o locație frunză sunt luate în calcul prin move.product_uom_qty.
-            # - Move line-urile care au destinația într-o locație frunză (și al căror move are destinația în altă parte, ex: părinte)
-            #   trebuie adunate, iar din move-ul părinte trebuie scăzut ce a fost deja distribuit în frunze.
-
-            # Dar metoda read_group pe move deja filtrează după location_dest_id.
-            # Dacă move are dest_id = PARENT, el nu apare în planned_sums pentru LEAVES.
-            # Dacă move are dest_id = LEAF1, el apare în planned_sums pentru LEAF1.
-
-            # Deci trebuie să adăugăm move_lines care au dest_id = LEAF1 dar move.dest_id != LEAF1
             domain = [
                 ("location_dest_id", "in", leaves.ids),
                 ("state", "not in", ["done", "cancel"]),

--- a/deltatech_putaway_strategy/models/stock_location.py
+++ b/deltatech_putaway_strategy/models/stock_location.py
@@ -52,6 +52,11 @@ class StockLocation(models.Model):
     )
 
     def _compute_planned_products(self):
+        """Calculează cantitatea planificată prin agregarea liniilor de mișcare de stoc (stock.move.line).
+        Sunt luate în calcul doar liniile care nu sunt în stările 'done' (finalizat) sau 'cancel' (anulat).
+        """
+        if not self:
+            return
         self.env["stock.move"].sudo()
         MoveLine = self.env["stock.move.line"].sudo()
         if not self:
@@ -123,11 +128,9 @@ class StockLocation(models.Model):
                 loc.planned_products = sum(child.planned_products for child in loc.child_ids)
 
     def _compute_warehouse_occupancy(self):
-        """Optimized compute using batched read_group and bottom-up aggregation.
-
-        - For leaf locations: perform a single read_group over all leaves in the batch
-          to fetch current quantities from stock.quant (quantity > 0)
-        - For parent locations: aggregate values from children in memory.
+        """Calcul optimizat al ocupării depozitului folosind batch read_group.
+        - Pentru locații frunză: preia cantitățile actuale din stock.quant (unde qty > 0).
+        - Pentru locații părinte: agregă valorile din copii în memorie.
         """
         Quant = self.env["stock.quant"].sudo()
 
@@ -167,10 +170,14 @@ class StockLocation(models.Model):
                 loc.occupancy_ratio = ratio
 
     def _check_can_be_used(self, product, quantity=0, package=None, location_qty=0):
+        """Extinde verificarea standard a locației pentru a include limitările de capacitate definite pe frunze.
+        Verifică atât stocul fizic actual cât și pe cel planificat (incoming).
+        """
         can_be_used = super()._check_can_be_used(product, quantity, package, location_qty)
         if self.env.context.get("putaway_location_standard"):
             return can_be_used
 
+        # Excludem locațiile marcate în context (de exemplu, cele care s-au umplut în timpul aceleiași operațiuni)
         exclude_location = self.env.context.get("exclude_location", self.env["stock.location"])
         if self in exclude_location:
             return False
@@ -179,23 +186,13 @@ class StockLocation(models.Model):
             return False
 
         if self.max_products_leaf:
-            # daca celula e ecupata
+            # Verificăm dacă locația este deja plină la nivel de stoc fizic
             if self.current_products >= self.max_products_leaf:
                 return False
-            # Capacitate pe frunză: nu depășim max_products_leaf
-            # Luăm în calcul atât stocul actual cât și cel planificat
-            self._compute_planned_products()
+
+            # Verificăm capacitatea luând în calcul și marfa planificată să ajungă în această locație
+            # Folosim valoarea calculată în batch (din cache-ul Odoo) pentru performanță
             planned_qty = self.planned_products
-
-            # # Adăugăm cantitatea din context (putaway_additional_qty) dacă există
-            # context_additional_qty = self.env.context.get("putaway_additional_qty")
-            # if context_additional_qty is None:
-            #     context_additional_qty = self.env.context.get("additional_qty")
-
-            # if isinstance(context_additional_qty, dict):
-            #     planned_qty += context_additional_qty.get(self.id, 0.0)
-            # elif isinstance(context_additional_qty, int | float):
-            #     planned_qty += context_additional_qty
 
             if (self.current_products + planned_qty) >= self.max_products_leaf:
                 return False
@@ -203,6 +200,9 @@ class StockLocation(models.Model):
         return True
 
     def _get_putaway_strategy(self, product, quantity=0, package=None, packaging=None, additional_qty=None):
+        """Suprascrie strategia de putaway pentru a căuta automat sub-locații disponibile
+        dacă locația de destinație configurată este plină sau are copii.
+        """
         putaway_location = super()._get_putaway_strategy(product, quantity, package, packaging, additional_qty)
         if self.env.context.get("putaway_location_standard"):
             return putaway_location
@@ -215,6 +215,7 @@ class StockLocation(models.Model):
         search_sublocation = safe_eval(search_sublocation)
 
         if search_sublocation and putaway_location.child_ids:
+            # Încercăm mai întâi locațiile unde există deja același produs
             quants = self.env["stock.quant"].search(
                 [
                     ("product_id", "=", product.id),
@@ -230,6 +231,7 @@ class StockLocation(models.Model):
                 if candidate._check_can_be_used(product, quantity, package):
                     return candidate
 
+            # Dacă nu am găsit o locație cu același produs, căutăm orice locație frunză disponibilă
             leaf_locations = self.env["stock.location"].search(
                 [
                     ("id", "child_of", putaway_location.id),
@@ -244,8 +246,5 @@ class StockLocation(models.Model):
                 # Transmitem contextul pentru a vedea ocuparea temporară
                 if leaf._check_can_be_used(product, quantity, package):
                     return leaf
-            # Daca nici o locatie nu e disponibila (toate pline), returnam originalul putaway_location
-            # sau prima frunza daca vrem sa fortam macar o locatie interna.
-            # Pentru a respecta ideea de "plin", returnam putaway_location si lasam splitarea sa se ocupe
-            # sau super() sa decida.
+
         return putaway_location

--- a/deltatech_putaway_strategy/models/stock_move_line.py
+++ b/deltatech_putaway_strategy/models/stock_move_line.py
@@ -123,5 +123,3 @@ class StockMoveLine(models.Model):
             new_lines.with_context(exclude_location=exclude_location)._apply_putaway_strategy()
             to_reprocess |= new_lines
         return is_split, to_reprocess
-
-

--- a/deltatech_putaway_strategy/models/stock_move_line.py
+++ b/deltatech_putaway_strategy/models/stock_move_line.py
@@ -71,15 +71,7 @@ class StockMoveLine(models.Model):
 
         return super()._apply_putaway_strategy()
 
-    # @api.model_create_multi
-    # def create(self, vals_list):
-    #     for vals in vals_list:
-    #         location_id = vals.get("location_dest_id")
-    #         location = self.env["stock.location"].browse(location_id)
-    #         quantity = vals.get("quantity", 0.0)
-    #         if location.max_products_leaf and quantity > location.max_products_leaf:
-    #             vals["quantity"] = location.max_products_leaf
-    #     return super().create(vals_list)
+
 
     def _split_by_putaway_capacity(self):
         # Logica de splitare a liniilor care depășesc capacitatea locației
@@ -141,20 +133,9 @@ class StockMoveLine(models.Model):
                         }
                     )
 
-                    # # Re-aplicăm strategia de putaway pe noua linie, excluzând locațiile pline
-                    # new_line.with_context(exclude_location=exclude_location)._apply_putaway_strategy()
-                    #
-                    # # Dacă locația destinație a noii linii este aceeași cu cea a liniei curente,
-                    # # înseamnă că nu s-a găsit o altă locație prin putaway strategy și riscăm buclă infinită.
-                    # if new_line.location_dest_id != line.location_dest_id:
-                    #     new_line._split_by_putaway_capacity()
-
         if new_lines:
             new_lines.with_context(exclude_location=exclude_location)._apply_putaway_strategy()
             to_reprocess |= new_lines
         return is_split, to_reprocess
 
-    # def write(self, vals):
-    #     if vals.get("quantity"):
-    #         self._split_by_putaway_capacity()
-    #     return super().write(vals)
+

--- a/deltatech_putaway_strategy/models/stock_move_line.py
+++ b/deltatech_putaway_strategy/models/stock_move_line.py
@@ -1,4 +1,5 @@
 import logging
+import time
 
 from odoo import _, models
 from odoo.exceptions import UserError
@@ -10,6 +11,10 @@ class StockMove(models.Model):
     _inherit = "stock.move"
 
     def _action_assign(self, force_qty=False):
+        """Suprascrie atribuirea pentru a aplica automat splitarea liniilor de mișcare
+        în funcție de capacitatea locațiilor de destinație.
+        """
+        start_time = time.time()
         res = super()._action_assign(force_qty=force_qty)
         # Apelăm splitarea pe toate liniile de mișcare implicate
         # Facem o buclă până când nu mai sunt necesare splitări
@@ -20,17 +25,25 @@ class StockMove(models.Model):
             _logger.info("Processing %d move lines", len(lines_to_process))
             is_split, to_reprocess = lines_to_process._split_by_putaway_capacity()
             if is_split:
+                # Dacă am făcut split, verificăm să nu fi intrat într-o buclă infinită
                 if lines_to_process == to_reprocess:
                     raise UserError(_("Cannot assign move lines to locations"))
                 lines_to_process = to_reprocess
             else:
                 lines_to_process = False
+
+        # Curățăm liniile care au rămas cu cantitate zero în urma splitării
         lines_with_zero_qty = self.move_line_ids.filtered(lambda line: line.quantity == 0)
         if lines_with_zero_qty:
             lines_with_zero_qty.unlink()
+
+        _logger.info("_action_assign executed in %.3f seconds", time.time() - start_time)
         return res
 
     def _action_done(self, cancel_backorder=False):
+        """La finalizarea mișcării, verificăm încă o dată dacă nu s-a depășit capacitatea.
+        Aceasta este o ultimă barieră de siguranță împotriva depășirii limitelor.
+        """
         res = super()._action_done(cancel_backorder=cancel_backorder)
         for move in res:
             if move.location_dest_id.usage == "internal" and move.location_dest_id.max_products_leaf:

--- a/deltatech_putaway_strategy/models/stock_move_line.py
+++ b/deltatech_putaway_strategy/models/stock_move_line.py
@@ -71,8 +71,6 @@ class StockMoveLine(models.Model):
 
         return super()._apply_putaway_strategy()
 
-
-
     def _split_by_putaway_capacity(self):
         # Logica de splitare a liniilor care depășesc capacitatea locației
         is_split = False

--- a/deltatech_putaway_strategy/models/stock_move_line.py
+++ b/deltatech_putaway_strategy/models/stock_move_line.py
@@ -32,18 +32,13 @@ class StockMove(models.Model):
 class StockMoveLine(models.Model):
     _inherit = "stock.move.line"
 
-    # def _apply_putaway_strategy(self):
-    #     # Suprascriem pentru a gestiona ocuparea temporară în timpul batch-ului
-    #     if self._context.get("avoid_putaway_rules") or not self:
-    #         return super()._apply_putaway_strategy()
-    #
-    #     # În Odoo 17, procesăm liniile una câte una pentru a putea folosi un context actualizat între linii
-    #     additional_qty = dict(self.env.context.get("putaway_additional_qty", {}))
-    #     for line in self:
-    #         line.with_context(putaway_additional_qty=additional_qty, avoid_putaway_rules=True)._apply_putaway_strategy_one()
-    #         # Actualizăm ocuparea pentru următoarea linie
-    #         qty = line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
-    #         additional_qty[line.location_dest_id.id] = additional_qty.get(line.location_dest_id.id, 0.0) + qty
+    def _apply_putaway_strategy(self):
+        if self._context.get("avoid_putaway_rules") or not self:
+            return super()._apply_putaway_strategy()
+        if any(self.mapped("picking_type_id.avoid_putaway_rules")):
+            return super(StockMoveLine, self.with_context(avoid_putaway_rules=True))._apply_putaway_strategy()
+
+        return super()._apply_putaway_strategy()
 
     def _split_by_putaway_capacity(self):
         # Logica de splitare a liniilor care depășesc capacitatea locației

--- a/deltatech_putaway_strategy/models/stock_picking.py
+++ b/deltatech_putaway_strategy/models/stock_picking.py
@@ -1,0 +1,7 @@
+from odoo import fields, models
+
+
+class PickingType(models.Model):
+    _inherit = "stock.picking.type"
+
+    avoid_putaway_rules = fields.Boolean(string="Avoid Putaway Rules")

--- a/deltatech_putaway_strategy/readme/DESCRIPTION.md
+++ b/deltatech_putaway_strategy/readme/DESCRIPTION.md
@@ -7,13 +7,17 @@ This module extends Odoo Inventory locations with simple capacity tracking and e
   - `Max products (leaf)`: manual capacity for leaf locations.
   - `Max products`: computed capacity for any location (sum of children for non‑leaf locations).
   - `Current quantity`: computed on‑hand quantity per location.
+  - `Planned quantity`: computed incoming quantity per location based on pending moves.
   - `Occupancy`: computed ratio `current/max` (clamped to [0, 1]).
 - Optimized computation for large hierarchies:
   - Single batched `read_group` on `stock.quant` for all leaf locations in the batch.
+  - Batched `read_group` on `stock.move.line` for planned quantities.
   - Bottom‑up in‑memory aggregation for parent locations.
 - Smarter putaway:
   - Respects capacity on leaf locations when suggesting destinations.
-  - Prefers empty child locations when possible.
+  - Automatically splits move lines if a destination location reaches its maximum capacity.
+  - Prefers empty child locations when possible (if search sublocation is enabled).
+  - Optimized rule lookup with database indexes on `product_id` and `sequence` for `stock.putaway.rule`.
   - Keeps full compatibility with Odoo’s storage category rules (max weight, product/pack capacities, allow new product rules, etc.).
 
 ## Usage
@@ -31,9 +35,11 @@ This module extends Odoo Inventory locations with simple capacity tracking and e
 - Designed to work alongside modules that display warehouse maps or dashboards. The module `deltatech_warehouse_map` can depend on this one to display the capacity and occupancy KPIs.
 
 ## Tests
-- Includes minimal TransactionCase tests that validate:
+- Includes TransactionCase tests that validate:
   - capacity enforcement via `_check_can_be_used`,
-  - putaway preference for empty child locations via `_get_putaway_strategy`.
+  - putaway preference for empty child locations via `_get_putaway_strategy`,
+  - automatic splitting of move lines when capacity is reached,
+  - planned quantity calculations.
 
 ## Screenshots
 The app store gallery uses the images from `static/description/`.

--- a/deltatech_putaway_strategy/tests/__init__.py
+++ b/deltatech_putaway_strategy/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_putaway_strategy
 from . import test_validation
+from . import test_avoid_putaway

--- a/deltatech_putaway_strategy/tests/test_avoid_putaway.py
+++ b/deltatech_putaway_strategy/tests/test_avoid_putaway.py
@@ -1,0 +1,111 @@
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestAvoidPutaway(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.StockLocation = self.env["stock.location"].sudo()
+        self.Product = self.env["product.product"].sudo()
+
+        # Creează o locație părinte și o locație destinație (putaway)
+        self.parent_loc = self.StockLocation.create(
+            {
+                "name": "PARENT",
+                "usage": "internal",
+            }
+        )
+        self.putaway_loc = self.StockLocation.create(
+            {
+                "name": "PUTAWAY",
+                "usage": "internal",
+                "location_id": self.parent_loc.id,
+            }
+        )
+
+        # Creează un produs
+        self.product = self.Product.create(
+            {
+                "name": "Test Avoid Putaway Product",
+                "type": "product",
+            }
+        )
+
+        # Regulă de putaway: PARENT -> PUTAWAY
+        self.env["stock.putaway.rule"].create(
+            {
+                "product_id": self.product.id,
+                "location_in_id": self.parent_loc.id,
+                "location_out_id": self.putaway_loc.id,
+            }
+        )
+
+        # Tip de operație
+        self.picking_type = self.env["stock.picking.type"].search([("code", "=", "incoming")], limit=1)
+        if not self.picking_type:
+            self.picking_type = self.env.ref("stock.picking_type_in")
+
+        self.supplier_location = self.env.ref("stock.stock_location_suppliers")
+
+    def test_avoid_putaway_rules_false(self):
+        """Verifică dacă putaway se aplică normal când avoid_putaway_rules este False."""
+        self.picking_type.avoid_putaway_rules = False
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.parent_loc.id,
+            }
+        )
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Move",
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "picking_id": picking.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.parent_loc.id,
+            }
+        )
+        picking.action_confirm()
+        picking.action_assign()
+
+        self.assertEqual(
+            move.move_line_ids[0].location_dest_id.id,
+            self.putaway_loc.id,
+            "Strategia de putaway ar fi trebuit să se aplice.",
+        )
+
+    def test_avoid_putaway_rules_true(self):
+        """Verifică dacă putaway este evitat când avoid_putaway_rules este True."""
+        self.picking_type.avoid_putaway_rules = True
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": self.picking_type.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.parent_loc.id,
+            }
+        )
+        move = self.env["stock.move"].create(
+            {
+                "name": "Test Move Avoid",
+                "product_id": self.product.id,
+                "product_uom_qty": 1,
+                "product_uom": self.product.uom_id.id,
+                "picking_id": picking.id,
+                "location_id": self.supplier_location.id,
+                "location_dest_id": self.parent_loc.id,
+            }
+        )
+        picking.action_confirm()
+        picking.action_assign()
+
+        self.assertEqual(
+            move.move_line_ids[0].location_dest_id.id,
+            self.parent_loc.id,
+            "Strategia de putaway ar fi trebuit să fie evitată.",
+        )

--- a/deltatech_putaway_strategy/views/stock_picking_type_views.xml
+++ b/deltatech_putaway_strategy/views/stock_picking_type_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_picking_type_form" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.inherit</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.view_picking_type_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@name='first']//group[1]" position="inside">
+                <field name="avoid_putaway_rules" />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Added a new `avoid_putaway_rules` field to `stock.picking.type`, controlling whether putaway rules should be bypassed. Updated the `_apply_putaway_strategy` logic and created detailed unit tests to validate functionality.