### PR TITLE
[ADD] Improve removal priority with default values and category rules

### DIFF
--- a/deltatech_stock_removal_priority/__manifest__.py
+++ b/deltatech_stock_removal_priority/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Stock Removal Location by Priority",
     "summary": "Stock Removal Location by Priority",
-    "version": "17.0.1.0.2",
+    "version": "17.0.1.0.3",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_removal_priority/models/stock_quant.py
+++ b/deltatech_stock_removal_priority/models/stock_quant.py
@@ -2,31 +2,50 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 from odoo import api, fields, models
+from odoo.tools.safe_eval import safe_eval
 
 
 class StockQuant(models.Model):
     _inherit = "stock.quant"
 
     removal_priority = fields.Integer(
-        compute="_compute_removal_priority", store=True, string="Removal Priority", default=1
+        compute="_compute_removal_priority",
+        store=True,
+        string="Removal Priority",
     )
 
     @api.depends("product_id", "location_id")
     def _compute_removal_priority(self):
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        default_priority = get_param("stock.removal_priority.default", default="999")
+        default_priority = safe_eval(default_priority)
+
         internal_quants = self.filtered(lambda q: q.location_id.usage == "internal")
-        (self - internal_quants).removal_priority = 0
+        (self - internal_quants).removal_priority = default_priority
         for quant in internal_quants:
-            domain = [("product_id", "=", quant.product_id.id), ("location_in_id", "=", quant.location_id.id)]
-            putaway_rule = self.env["stock.putaway.rule"].search(domain, limit=1, order="sequence asc")
+            # Căutăm regulile atât după location_out_id cât și după location_in_id pentru
+            # a acoperi ambele scenarii de configurare.
+            domain_product = [
+                ("product_id", "=", quant.product_id.id),
+                ("location_out_id", "=", quant.location_id.id),
+            ]
+            putaway_rule = self.env["stock.putaway.rule"].search(domain_product, limit=1, order="sequence asc")
+            if not putaway_rule:
+                domain_categ = [
+                    ("category_id", "=", quant.product_id.categ_id.id),
+                    ("location_out_id", "=", quant.location_id.id),
+                ]
+                putaway_rule = self.env["stock.putaway.rule"].search(domain_categ, limit=1, order="sequence asc")
+
             if putaway_rule:
                 quant.removal_priority = putaway_rule.sequence
             else:
-                quant.removal_priority = 0
+                quant.removal_priority = default_priority
 
     @api.model
     def _get_removal_strategy_domain_order(self, domain, removal_strategy, qty):
         if removal_strategy == "priority":
-            domain = domain + [("removal_priority", ">=", 0)]
+            # domain = domain + [("removal_priority", ">=", 0)]
             return domain, "removal_priority, location_id, id"
         return super()._get_removal_strategy_domain_order(domain, removal_strategy, qty)
 

--- a/deltatech_stock_removal_priority/tests/test_stock_removal_priority.py
+++ b/deltatech_stock_removal_priority/tests/test_stock_removal_priority.py
@@ -20,22 +20,31 @@ class TestStockRemovalPriority(TransactionCase):
 
         cls.loc_1 = cls.env["stock.location"].create({"name": "Loc 1", "location_id": cls.stock_location.id})
         cls.loc_2 = cls.env["stock.location"].create({"name": "Loc 2", "location_id": cls.stock_location.id})
+        cls.loc_3 = cls.env["stock.location"].create({"name": "Loc 3", "location_id": cls.stock_location.id})
+        cls.env["stock.putaway.rule"].create(
+            [
+                {
+                    "product_id": cls.product.id,
+                    "location_in_id": cls.loc_1.id,
+                    "location_out_id": cls.loc_2.id,
+                    "sequence": 5,
+                },
+                {
+                    "category_id": cls.product.categ_id.id,
+                    "location_in_id": cls.loc_1.id,
+                    "location_out_id": cls.loc_3.id,
+                    "sequence": 7,
+                },
+            ]
+        )
 
     def test_01_quant_priority_from_putaway(self):
         """Test ca prioritatea cuantului este luata din regula de putaway"""
         # Cream o regula de putaway
-        self.env["stock.putaway.rule"].create(
-            {
-                "product_id": self.product.id,
-                "location_in_id": self.loc_1.id,
-                "location_out_id": self.loc_2.id,
-                "sequence": 5,
-            }
-        )
 
         # Cream un cuant
         quant = self.env["stock.quant"].create(
-            {"product_id": self.product.id, "location_id": self.loc_1.id, "inventory_quantity": 10}
+            {"product_id": self.product.id, "location_id": self.loc_2.id, "inventory_quantity": 10}
         )
         quant.action_apply_inventory()
 
@@ -44,12 +53,6 @@ class TestStockRemovalPriority(TransactionCase):
 
     def test_02_removal_strategy_priority(self):
         """Test strategia de eliminare 'Priority'"""
-        # Verificam ca metoda de domain order returneaza valorile asteptate
-        # domain = [("product_id", "=", self.product.id)]
-        # new_domain, order = self.env["stock.quant"]._get_removal_strategy_domain_order(domain, "priority", 100)
-        #
-        # self.assertIn(("removal_priority", ">", 0), new_domain)
-        # self.assertEqual(order, "removal_priority, location_id, id")
 
         # Verificam sort_key
         key, reverse = self.env["stock.quant"]._get_removal_strategy_sort_key("priority")
@@ -67,3 +70,15 @@ class TestStockRemovalPriority(TransactionCase):
 
         # q2 are prioritate mai mica (deci mai importanta), deci ar trebui sa fie primul
         self.assertLess(key(q2), key(q1))
+
+    def test_03_quant_priority_from_category_putaway(self):
+        """Daca nu exista regula pe produs, se foloseste regula pe categorie."""
+
+        # Cream un cuant fara sa existe o regula pe produs
+        quant = self.env["stock.quant"].create(
+            {"product_id": self.product.id, "location_id": self.loc_3.id, "inventory_quantity": 3}
+        )
+        quant.action_apply_inventory()
+
+        # Ar trebui sa ia prioritatea din regula pe categorie (7)
+        self.assertEqual(quant.removal_priority, 7)


### PR DESCRIPTION
Enhanced the stock quant removal priority calculation by adding default priority values and category-based fallback rules. Updated the logic to account for missing product-specific rules and included new test cases to validate the changes. Incremented the module version to 17.0.1.0.3.