### PR TITLE
[IMP] Reorganizează plasarea fișierului pentru Data Sheet

### DIFF
--- a/deltatech_data_sheet_website/__manifest__.py
+++ b/deltatech_data_sheet_website/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Product Data Sheet Website",
     "summary": "Data Sheet",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_data_sheet_website/views/templates.xml
+++ b/deltatech_data_sheet_website/views/templates.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
     <template id="product_data_sheet" inherit_id="website_sale.product" name="Show Data Sheet">
-        <xpath expr="//div[@id='product_documents']" position="inside">
+        <xpath expr="//div[@id='product_documents']" position="before">
             <hr t-if='product.data_sheet_id'>
                 <a role="button" class="btn btn-primary" t-attf-href="/web/content/{{product.data_sheet_id.id}}">
                     Show Data Sheet


### PR DESCRIPTION
Modifică poziția butonului „Show Data Sheet” pentru a apărea înaintea secțiunii documentelor. Această schimbare îmbunătățește claritatea vizuală și ușurința utilizării. Actualizează versiunea modulului pentru a reflecta modificarea.