### PR TITLE
[IMP] Comentează logica de post-procesare a tranzacțiilor

### DIFF
--- a/deltatech_sale_payment/wizard/sale_confirm_payment.py
+++ b/deltatech_sale_payment/wizard/sale_confirm_payment.py
@@ -110,8 +110,8 @@ class SaleConfirmPayment(models.TransientModel):
             transaction._set_pending()
             if transaction.amount > 0:
                 transaction._set_done()
-            if transaction.provider_id.code not in ["none", "custom", "on_delivery"]:
-                transaction._finalize_post_processing()
+            # if transaction.provider_id.code not in ["none", "custom", "on_delivery"]:
+            # transaction._finalize_post_processing()
 
             # transaction._reconcile_after_transaction_done()
             # transaction.write({'is_post_processed':True})


### PR DESCRIPTION
Elimină executarea metodei `_finalize_post_processing` prin comentare. Această modificare poate fi utilă pentru a preveni comportamente nedorite în timpul tranzacțiilor cu anumiți provideri.