### PR TITLE
[IMP] Marchează modulele GLN ca fiind învechite

### DIFF
--- a/deltatech_account_edi_ubl_gln/__manifest__.py
+++ b/deltatech_account_edi_ubl_gln/__manifest__.py
@@ -1,9 +1,9 @@
 # ©  2015-2019 Deltatech
 # See README.rst file on addons root folder for license details
 {
-    "name": "Deltatech UBL GLN",
+    "name": "Deltatech UBL GLN - Obsolete",
     "summary": "Deltatech Account UBL GLN",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_gln/__manifest__.py
+++ b/deltatech_gln/__manifest__.py
@@ -3,13 +3,13 @@
 # See README.rst file on addons root folder for license details
 
 {
-    "name": "Deltatech Partner GLN ",
-    "summary": "Partner Global Location Number",
-    "version": "18.0.1.0.0",
+    "name": "Deltatech Partner GLN - Obsolete",
+    "summary": "Obsolete - Use account_add_gln",
+    "version": "18.0.1.0.1",
     "author": "Terrabit,Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Administration",
-    "depends": ["base"],
+    "depends": ["base", "account_add_gln"],
     "license": "OPL-1",
     "data": [
         "views/res_partner_view.xml",

--- a/deltatech_gln/models/res_partner.py
+++ b/deltatech_gln/models/res_partner.py
@@ -10,3 +10,4 @@ class Partner(models.Model):
     _inherit = "res.partner"
 
     gln = fields.Char(string="GLN", help="Global Location Number")
+    # in modulul standard campul se numeste gln global_location_number

--- a/deltatech_gln/readme/DESCRIPTION.md
+++ b/deltatech_gln/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
 Features:
 
 - This module adds field for GLN (Global Location Number) in partner form.
+
+ToDo: de integrat cu account_add_gln


### PR DESCRIPTION
Adaugă mențiuni referitoare la învechirea modulelor `deltatech_gln` și `deltatech_account_edi_ubl_gln`, sugerând utilizarea modulului `account_add_gln`. Actualizează versiunea modulelor, introduce noi dependențe și adaugă explicații în documentație pentru integrarea ulterioară.