### PR TITLE
[18.0][FIX]website_city: fix positional arguments error

### DIFF
--- a/deltatech_website_city/__manifest__.py
+++ b/deltatech_website_city/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Website City",
     "category": "Website/Website",
     "summary": "City extension",
-    "version": "18.0.1.1.2",
+    "version": "18.0.1.1.3",
     "author": "Terrabit, Dorin Hongu",
     "license": "LGPL-3",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_city/controller/portal.py
+++ b/deltatech_website_city/controller/portal.py
@@ -23,7 +23,7 @@ class CustomerPortalCity(CustomerPortal):
                 values["city_id"] = False
         return super().on_account_update(values, partner)
 
-    def details_form_validate(self, data, **kwargs):
+    def details_form_validate(self, data, partner_creation):
         if "country_id" in data:
             request.update_context(portal_form_country_id=data["country_id"])
         if "city_id" in data:
@@ -40,7 +40,7 @@ class CustomerPortalCity(CustomerPortal):
                 # which shouldn't be processed further.
                 _logger.debug("Invalid city ID provided in form data: %s", data.get("city_id"))
 
-        return super().details_form_validate(data, **kwargs)
+        return super().details_form_validate(data, partner_creation)
 
     def _get_mandatory_fields(self):
         # EXTENDS 'portal'


### PR DESCRIPTION
  File "/home/odoo/src/user/dhongu/deltatech/deltatech_website_vat_validation/controllers/portal.py", line 17, in details_form_validate
    error, error_message = super().details_form_validate(data, partner_creation)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: CustomerPortalCity.details_form_validate() takes 2 positional arguments but 3 were given