### PR TITLE
[FIX] Evită procesarea facturilor de tip diferit de "out_invoice"

### DIFF
--- a/deltatech_account_edi_ubl_advice/__manifest__.py
+++ b/deltatech_account_edi_ubl_advice/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech UBL despatch advice",
     "summary": "Deltatech Account UBL despatch advice",
-    "version": "18.0.1.0.2",
+    "version": "18.0.1.0.3",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_account_edi_ubl_advice/models/account_edi_ubl.py
+++ b/deltatech_account_edi_ubl_advice/models/account_edi_ubl.py
@@ -35,6 +35,8 @@ class AccountEdiXmlUBL20(models.AbstractModel):
     def _add_invoice_header_nodes(self, document_node, vals):
         res = super()._add_invoice_header_nodes(document_node, vals)
         invoice = vals["invoice"]
+        if invoice.type != "out_invoice":
+            return res
         pickings = self.env["stock.picking"]
         for line in invoice.invoice_line_ids:
             for sale_line in line.sale_line_ids:


### PR DESCRIPTION
Adaugat o verificare pentru a preveni procesarea inutilă sau incorectă a facturilor care nu sunt de tip "out_invoice" în metoda `_add_invoice_header_nodes`. Actualizat fișierul `__manifest__.py` pentru a reflecta incrementarea versiunii modulului la 18.0.1.0.3.