### PR TITLE
[ADD] Update manifest images for consistency across modules

### DIFF
--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -19,4 +19,5 @@
     ],
     "development_status": "Beta",
     "installable": True,
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_analytic_distribution/__manifest__.py
+++ b/deltatech_analytic_distribution/__manifest__.py
@@ -17,4 +17,5 @@
     ],
     "development_status": "Beta",
     "installable": True,
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_expenses/__manifest__.py
+++ b/deltatech_expenses/__manifest__.py
@@ -26,7 +26,7 @@
         "security/security.xml",
         "data/data.xml",
     ],
-    "images": ["images/main_screenshot.png"],
+    "images": ["static/description/main_screenshot.png"],
     "development_status": "Mature",
     "maintainers": ["dhongu"],
 }

--- a/deltatech_ledger/__manifest__.py
+++ b/deltatech_ledger/__manifest__.py
@@ -13,7 +13,7 @@
         "data/ir_sequence_data.xml",
         "views/ledger_view.xml",
     ],
-    "images": ["static/description/icon.png"],
+    "images": ["static/description/main_screenshot.png"],
     "development_status": "Alpha",
     "maintainers": ["VoicuStefan2001"],
     "application": True,

--- a/deltatech_picking_transit/__manifest__.py
+++ b/deltatech_picking_transit/__manifest__.py
@@ -15,4 +15,5 @@
     ],
     "development_status": "Beta",
     "maintainers": ["VoicuStefan2001"],
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_product_labels/__manifest__.py
+++ b/deltatech_product_labels/__manifest__.py
@@ -16,4 +16,5 @@
         # "views/product_view.xml",
     ],
     "development_status": "Mature",
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_purchase_mail/__manifest__.py
+++ b/deltatech_purchase_mail/__manifest__.py
@@ -16,4 +16,5 @@
         "views/purchase_order_actions.xml",
     ],
     "development_status": "Beta",
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -16,4 +16,5 @@
     ],
     "development_status": "Mature",
     "maintainers": ["dhongu"],
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_putaway_strategy/__manifest__.py
+++ b/deltatech_putaway_strategy/__manifest__.py
@@ -13,4 +13,5 @@
     ],
     "development_status": "Beta",
     "maintainers": ["dhongu"],
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_stock_picking_activity_report/__manifest__.py
+++ b/deltatech_stock_picking_activity_report/__manifest__.py
@@ -11,7 +11,7 @@
         "security/ir.model.access.csv",
         "views/stock_picking_activity_record_view.xml",
     ],
-    "images": ["static/description/icon.png"],
+    "images": ["static/description/main_screenshot.png"],
     "development_status": "Beta",
     "maintainers": ["VoicuStefan2001"],
 }

--- a/deltatech_warehouse_arrangement/__manifest__.py
+++ b/deltatech_warehouse_arrangement/__manifest__.py
@@ -24,4 +24,5 @@
     ],
     "development_status": "Beta",
     "installable": True,
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_warehouse_map/__manifest__.py
+++ b/deltatech_warehouse_map/__manifest__.py
@@ -12,4 +12,5 @@
         "views/stock_location_views.xml",
     ],
     "development_status": "Beta",
+    "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_warranty/__manifest__.py
+++ b/deltatech_warranty/__manifest__.py
@@ -15,7 +15,7 @@
         "views/sale_order.xml",
         "views/product_template.xml",
     ],
-    "images": ["images/main_screenshot.png"],
+    "images": ["static/description/main_screenshot.png"],
     "installable": True,
     "development_status": "Beta",
 }


### PR DESCRIPTION
Standardized the `images` field in manifest files to use `static/description/main_screenshot.png` for consistent representation across modules. This change improves clarity and user experience by aligning the visual documentation structure.