### PR TITLE
[IMP] Ștergere cheie inutilă din `ir_config_parameter`

### DIFF
--- a/deltatech_test_system/data/neutralize.sql
+++ b/deltatech_test_system/data/neutralize.sql
@@ -2,3 +2,5 @@ INSERT INTO ir_config_parameter (key, value)
 VALUES ('database.is_neutralized', 'True')
 ON CONFLICT (key) DO UPDATE
 SET value = 'True';
+
+DELETE FROM ir_config_parameter WHERE key = 'database_notification_banner';


### PR DESCRIPTION
Elimină înregistrarea cu cheia `database_notification_banner` din tabelul `ir_config_parameter`. Această modificare curăță datele redundante și previne potențiale conflicte sau mesaje necorespunzătoare în timpul utilizării sistemului.