### PR TITLE
[IMP] Actualizează traducerile și îmbunătățește validarea formularului

### DIFF
--- a/deltatech_website_city/controller/portal.py
+++ b/deltatech_website_city/controller/portal.py
@@ -23,7 +23,7 @@ class CustomerPortalCity(CustomerPortal):
                 values["city_id"] = False
         return super().on_account_update(values, partner)
 
-    def details_form_validate(self, data, partner_creation):
+    def details_form_validate(self, data, partner_creation=False):
         if "country_id" in data:
             request.update_context(portal_form_country_id=data["country_id"])
         if "city_id" in data:

--- a/deltatech_website_city/i18n/ro.po
+++ b/deltatech_website_city/i18n/ro.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 18.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-10-06 16:25+0000\n"
-"PO-Revision-Date: 2025-10-06 16:25+0000\n"
+"POT-Creation-Date: 2026-03-11 13:13+0000\n"
+"PO-Revision-Date: 2026-03-11 13:13+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -21,12 +21,33 @@ msgid "<option value=\"\">City...</option>"
 msgstr "<option value=\"\">Localitate...</option>"
 
 #. module: deltatech_website_city
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.portal_my_details_fields
+msgid "<option value=\"\">Country...</option>"
+msgstr "<option value=\"\">Țară...</option>"
+
+#. module: deltatech_website_city
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.portal_my_details_fields
+msgid "<option value=\"\">select...</option>"
+msgstr "<option value=\"\">selectați...</option>"
+
+#. module: deltatech_website_city
 #: model:ir.model.fields,field_description:deltatech_website_city.field_res_country_state__city_ids
 #: model_terms:ir.ui.view,arch_db:deltatech_website_city.address
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.portal_my_details_fields
 msgid "City"
 msgstr "Localitate"
 
 #. module: deltatech_website_city
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.portal_my_details_fields
+msgid "Country"
+msgstr "Țară"
+
+#. module: deltatech_website_city
 #: model:ir.model,name:deltatech_website_city.model_res_country_state
 msgid "Country state"
+msgstr "Județ"
+
+#. module: deltatech_website_city
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.portal_my_details_fields
+msgid "State / Province"
 msgstr "Județ"


### PR DESCRIPTION
Adaugă traduceri pentru câmpurile selectabile, cum ar fi "Țară" și "Județ", în modulul `deltatech_website_city` pentru o experiență îmbunătățită a utilizatorului. De asemenea, corectează semnătura metodei `details_form_validate` din controller pentru a preveni posibile probleme de compatibilitate.