### PR TITLE
fix pentru downpayments in valute diferite

### DIFF
--- a/deltatech_sale_currency/models/sale.py
+++ b/deltatech_sale_currency/models/sale.py
@@ -35,3 +35,21 @@ class SaleOrderLine(models.Model):
                 res["price_unit"] = price_unit
 
         return res
+    
+
+    def _get_downpayment_line_price_unit(self, invoices):
+        self.ensure_one()
+        amount = 0.0
+        for line in self.invoice_lines.filtered(
+                lambda l: l.move_id.state == 'posted' and l.move_id not in invoices
+        ):
+            price_unit = line.price_unit
+            if line.currency_id and line.currency_id != self.currency_id:
+                price_unit = line.currency_id._convert(
+                    price_unit,
+                    self.currency_id,
+                    line.company_id,
+                    line.move_id.invoice_date or line.move_id.date or fields.Date.context_today(line),
+                )
+            amount += price_unit if line.move_id.move_type == 'out_invoice' else -price_unit
+        return amount


### PR DESCRIPTION
in cazul in care comanda este in alta valuta fata de factura, la validarea unei facturi de avans, valoarea liniei de avans de pe comanda se modifica cu valoarea liniei de pe factura fara sa se verifice daca valuta este la fel.

modificarea propusa rezolva aceasta problema