### PR TITLE
[IMP] Refactorizarea validării adreselor și adăugarea de teste

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,7 +63,7 @@ repos:
           /test_|
           _test\.py$
         # Opțional, dacă ai addons-ul Odoo local:
-        args: [--addons-path, ./odoo/odoo/addons, ./odoo/addons]
+        args: [--addons-path, "../../odoo/odoo/addons,../../odoo/addons"]
 
   - repo: https://github.com/sbidoul/whool
     rev: v1.2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,20 @@ repos:
         language: fail
         files: '[a-zA-Z0-9_]*/i18n/en\.po$'
 
+      - id: check-super-methods
+        name: Odoo — verificare metode super()
+        language: python
+        entry: python check_super_methods.py
+        types: [python]
+        pass_filenames: true
+        exclude: |
+          (?x)
+          tests/|
+          /test_|
+          _test\.py$
+        # Opțional, dacă ai addons-ul Odoo local:
+        args: [--addons-path, ./odoo/odoo/addons, ./odoo/addons]
+
   - repo: https://github.com/sbidoul/whool
     rev: v1.2
     hooks:

--- a/check_super_methods.py
+++ b/check_super_methods.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""
+check_super_methods - pre-commit hook pentru Odoo
+==================================================
+Verifică dacă metodele apelate prin super() există în clasele părinte.
+
+Mod de utilizare ca pre-commit hook (automat primește fișierele staged):
+    pre-commit run check-super-methods
+
+Mod manual:
+    python check_super_methods.py models/sale_order.py models/res_partner.py
+    python check_super_methods.py models/ --addons-path /opt/odoo/addons
+"""
+
+import argparse
+import ast
+import logging
+import os
+import sys
+from dataclasses import dataclass, field
+
+# Configurare logger de bază
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Structuri de date
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class SuperCall:
+    class_name: str
+    method_name: str
+    super_method: str
+    lineno: int
+    col_offset: int
+
+
+@dataclass
+class ClassInfo:
+    name: str
+    bases: list
+    methods: list
+    super_calls: list = field(default_factory=list)
+    lineno: int = 0
+
+
+@dataclass
+class CheckResult:
+    super_call: SuperCall
+    filepath: str
+    status: str  # "OK" | "MISSING" | "UNKNOWN_BASE" | "BUILTIN"
+    found_in: str | None = None
+    message: str = ""
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Vizitator AST
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class SuperCallVisitor(ast.NodeVisitor):
+    def __init__(self):
+        self.classes: dict = {}
+        self._current_class: str | None = None
+        self._current_method: str | None = None
+
+    def visit_ClassDef(self, node: ast.ClassDef):
+        bases = [self._expr_to_str(b) for b in node.bases]
+        self.classes[node.name] = ClassInfo(name=node.name, bases=bases, methods=[], lineno=node.lineno)
+        prev = self._current_class
+        self._current_class = node.name
+        self.generic_visit(node)
+        self._current_class = prev
+
+    def visit_FunctionDef(self, node: ast.FunctionDef):
+        if self._current_class:
+            self.classes[self._current_class].methods.append(node.name)
+        prev = self._current_method
+        self._current_method = node.name
+        self.generic_visit(node)
+        self._current_method = prev
+
+    visit_AsyncFunctionDef = visit_FunctionDef
+
+    def visit_Call(self, node: ast.Call):
+        if (
+            self._current_class
+            and self._current_method
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Call)
+            and self._is_super(node.func.value)
+        ):
+            self.classes[self._current_class].super_calls.append(
+                SuperCall(
+                    class_name=self._current_class,
+                    method_name=self._current_method,
+                    super_method=node.func.attr,
+                    lineno=node.lineno,
+                    col_offset=node.col_offset,
+                )
+            )
+        self.generic_visit(node)
+
+    @staticmethod
+    def _is_super(node: ast.Call) -> bool:
+        return isinstance(node.func, ast.Name) and node.func.id == "super"
+
+    @staticmethod
+    def _expr_to_str(expr) -> str:
+        if isinstance(expr, ast.Name):
+            return expr.id
+        if isinstance(expr, ast.Attribute):
+            return f"{SuperCallVisitor._expr_to_str(expr.value)}.{expr.attr}"
+        return "<unknown>"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Registru global (addons-path opțional)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def build_global_registry(addons_path: str) -> dict:
+    registry = {}
+    for root, dirs, files in os.walk(addons_path):
+        dirs[:] = [d for d in dirs if d not in {".git", "__pycache__", "node_modules", ".venv", "venv", "static"}]
+        for fn in files:
+            if not fn.endswith(".py"):
+                continue
+            fp = os.path.join(root, fn)
+            try:
+                with open(fp, encoding="utf-8", errors="ignore") as fh:
+                    src = fh.read()
+                v = SuperCallVisitor()
+                v.visit(ast.parse(src, filename=fp))
+                for name, info in v.classes.items():
+                    if name not in registry:
+                        registry[name] = info
+                    else:
+                        registry[name].methods = list(set(registry[name].methods + info.methods))
+            except Exception as e:
+                logger.debug("Eroare la procesarea fisierului %s: %s", fp, e)
+    return registry
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Rezolvare metode în ierarhia de baze
+# ─────────────────────────────────────────────────────────────────────────────
+
+BUILTIN_METHODS = {
+    # Python dunder
+    "__init__",
+    "__new__",
+    "__str__",
+    "__repr__",
+    "__eq__",
+    "__hash__",
+    "__lt__",
+    "__le__",
+    "__gt__",
+    "__ge__",
+    "__bool__",
+    "__len__",
+    "__getitem__",
+    "__setitem__",
+    "__delitem__",
+    "__contains__",
+    "__iter__",
+    "__next__",
+    "__enter__",
+    "__exit__",
+    "__getattr__",
+    "__setattr__",
+    "__delattr__",
+    "__call__",
+    # Odoo ORM standard
+    "create",
+    "write",
+    "unlink",
+    "read",
+    "search",
+    "browse",
+    "copy",
+    "name_get",
+    "name_search",
+    "fields_get",
+    "fields_view_get",
+    "default_get",
+    "onchange",
+    "load",
+    "export_data",
+    "action_confirm",
+    "action_cancel",
+    "action_draft",
+    "action_done",
+    "_compute_display_name",
+    "_search",
+    "_read_group",
+}
+
+KNOWN_ODOO_BASES = {
+    "Model",
+    "TransientModel",
+    "AbstractModel",
+    "models.Model",
+    "models.TransientModel",
+    "models.AbstractModel",
+    "BaseModel",
+    "object",
+}
+
+
+def resolve(method: str, bases: list, local: dict, registry: dict, _visited: set | None = None) -> tuple:
+    if _visited is None:
+        _visited = set()
+
+    if method in BUILTIN_METHODS:
+        return "BUILTIN", None
+
+    for base in bases:
+        if base in _visited:
+            continue
+        _visited.add(base)
+
+        if base in KNOWN_ODOO_BASES:
+            return "OK", base
+
+        info = local.get(base) or registry.get(base)
+        if info is None:
+            return "UNKNOWN_BASE", base
+
+        if method in info.methods:
+            return "OK", base
+
+        status, found = resolve(method, info.bases, local, registry, _visited)
+        if status in ("OK", "BUILTIN"):
+            return status, found
+
+    return "MISSING", None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Verificare fișier
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def check_file(filepath: str, registry: dict) -> list:
+    try:
+        with open(filepath, encoding="utf-8") as fh:
+            src = fh.read()
+    except OSError as e:
+        logger.error("  [EROARE] Nu pot citi '%s': %s", filepath, e)
+        return []
+
+    try:
+        tree = ast.parse(src, filename=filepath)
+    except SyntaxError as e:
+        logger.error("  [EROARE] Sintaxă invalidă în '%s': %s", filepath, e)
+        return []
+
+    visitor = SuperCallVisitor()
+    visitor.visit(tree)
+
+    results = []
+    for _cls_name, cls_info in visitor.classes.items():
+        for sc in cls_info.super_calls:
+            status, found_in = resolve(sc.super_method, cls_info.bases, visitor.classes, registry)
+            if status == "OK":
+                msg = f"găsit în '{found_in}'"
+            elif status == "BUILTIN":
+                msg = "metodă built-in / Odoo ORM standard"
+            elif status == "UNKNOWN_BASE":
+                msg = (
+                    f"clasa de bază '{found_in}' nu a putut fi rezolvată "
+                    f"(import extern sau lipsă din --addons-path)"
+                )
+            else:
+                msg = f"'{sc.super_method}' NU există în nicio bază: " f"{cls_info.bases}"
+            results.append(
+                CheckResult(
+                    super_call=sc,
+                    filepath=filepath,
+                    status=status,
+                    found_in=found_in,
+                    message=msg,
+                )
+            )
+    return results
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Colectare fișiere
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def collect_python_files(paths: list) -> list:
+    files = []
+    for p in paths:
+        if os.path.isfile(p):
+            if p.endswith(".py"):
+                files.append(p)
+        elif os.path.isdir(p):
+            for root, dirs, fns in os.walk(p):
+                dirs[:] = [d for d in dirs if d not in {".git", "__pycache__", "node_modules", ".venv", "venv"}]
+                for fn in fns:
+                    if fn.endswith(".py"):
+                        files.append(os.path.join(root, fn))
+    return files
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Raport (scris pe stderr — standard pre-commit)
+# ─────────────────────────────────────────────────────────────────────────────
+
+USE_COLOR = sys.stderr.isatty()
+
+_C = {
+    "R": "\033[91m",
+    "G": "\033[92m",
+    "Y": "\033[93m",
+    "C": "\033[96m",
+    "B": "\033[1m",
+    "D": "\033[2m",
+    "X": "\033[0m",
+}
+
+
+def _c(key: str, text: str) -> str:
+    return (_C.get(key, "") + text + _C["X"]) if USE_COLOR else text
+
+
+def print_report(all_results: list, files_checked: int) -> int:
+    missing = [r for r in all_results if r.status == "MISSING"]
+    unknown = [r for r in all_results if r.status == "UNKNOWN_BASE"]
+    ok_total = [r for r in all_results if r.status in ("OK", "BUILTIN")]
+
+    # Se folosește sys.stderr pentru raport pentru a nu interfera cu output-ul pre-commit
+    sys.stderr.write("\n")
+    sys.stderr.write(_c("B", "  check-super-methods") + "\n")
+    sys.stderr.write(_c("D", f"  {files_checked} fișier(e) · {len(all_results)} apel(uri) super()") + "\n")
+
+    if missing:
+        sys.stderr.write("\n")
+        sys.stderr.write(_c("R", f"  ✘ METODE LIPSĂ ({len(missing)})") + "\n")
+        for r in missing:
+            sc = r.super_call
+            sys.stderr.write(
+                f"    {_c('D', f'{r.filepath}:{sc.lineno}:{sc.col_offset}')}  "
+                f"{_c('C', sc.class_name)}.{_c('B', sc.super_method)}  "
+                f"{_c('D', f'(în {sc.method_name!r})')}\n"
+            )
+            sys.stderr.write(_c("R", f"      → {r.message}") + "\n")
+
+    if unknown:
+        sys.stderr.write("\n")
+        sys.stderr.write(_c("Y", f"  ⚠ BAZE NECUNOSCUTE ({len(unknown)}) — neputând fi verificate") + "\n")
+        for r in unknown:
+            sc = r.super_call
+            sys.stderr.write(
+                f"    {_c('D', f'{r.filepath}:{sc.lineno}:{sc.col_offset}')}  "
+                f"{_c('C', sc.class_name)}.{_c('B', sc.super_method)}\n"
+            )
+            sys.stderr.write(_c("Y", f"      → {r.message}") + "\n")
+
+    sys.stderr.write("\n")
+    if missing:
+        sys.stderr.write(_c("R", f"  EȘUAT — {len(missing)} metodă/metode lipsă") + "\n\n")
+        return 1
+
+    suffix = f"  ⚠ {len(unknown)} baze necunoscute (folosiți --addons-path)" if unknown else ""
+    sys.stderr.write(_c("G", f"  ✔ OK — {len(ok_total)} apel(uri) super() verificate{suffix}") + "\n\n")
+    return 0
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+#  Entry-point
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="pre-commit hook: verifică metodele super() în fișiere Python Odoo.",
+    )
+    parser.add_argument(
+        "filenames",
+        nargs="*",
+        metavar="FILE",
+        help="Fișiere/directoare Python (furnizate automat de pre-commit).",
+    )
+    parser.add_argument(
+        "--addons-path",
+        metavar="PATH",
+        default=os.environ.get("ODOO_ADDONS_PATH", ""),
+        help=(
+            "Calea addons Odoo pentru rezolvarea claselor de bază. "
+            "Poate fi setat și prin variabila ODOO_ADDONS_PATH."
+        ),
+    )
+    parser.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Dezactivează culorile ANSI.",
+    )
+
+    args = parser.parse_args(argv)
+
+    global USE_COLOR
+    if args.no_color:
+        USE_COLOR = False
+
+    files = collect_python_files(args.filenames or ["."])
+    if not files:
+        sys.stderr.write("  [check-super-methods] Niciun fișier .py de verificat.\n")
+        return 0
+
+    registry = {}
+    if args.addons_path and os.path.isdir(args.addons_path):
+        sys.stderr.write(_c("D", f"  [check-super-methods] Indexez {args.addons_path} ...") + "\n")
+        registry = build_global_registry(args.addons_path)
+
+    all_results = []
+    for fp in files:
+        all_results.extend(check_file(fp, registry))
+
+    return print_report(all_results, len(files))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/check_super_methods.py
+++ b/check_super_methods.py
@@ -415,9 +415,14 @@ def main(argv=None):
         return 0
 
     registry = {}
-    if args.addons_path and os.path.isdir(args.addons_path):
-        sys.stderr.write(_c("D", f"  [check-super-methods] Indexez {args.addons_path} ...") + "\n")
-        registry = build_global_registry(args.addons_path)
+    if args.addons_path:
+        paths = [p.strip() for p in args.addons_path.split(",") if p.strip()]
+        for p in paths:
+            if os.path.isdir(p):
+                sys.stderr.write(_c("D", f"  [check-super-methods] Indexez {p} ...") + "\n")
+                registry.update(build_global_registry(p))
+            else:
+                logger.debug("Calea addons-path %s nu exista sau nu este director", p)
 
     all_results = []
     for fp in files:

--- a/deltatech_website_phone_validation/controllers/website_sale.py
+++ b/deltatech_website_phone_validation/controllers/website_sale.py
@@ -9,23 +9,34 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSalePhoneValidation(WebsiteSale):
-    def checkout_form_validate(self, mode, all_form_values, data):
-        error = dict()
-        error_message = []
+    def _validate_address_values(
+        self,
+        address_values,
+        partner_sudo,
+        address_type,
+        use_delivery_as_billing,
+        required_fields,
+        is_main_address,
+        **_kwargs,
+    ):
+        if address_values.get("phone"):
+            address_values["phone"] = address_values.get("phone").strip()
 
-        if data.get("phone"):
-            data["phone"] = data.get("phone").strip()
-        # todo: de gasit functia din 18
-        standard_error, standard_error_message = super().checkout_form_validate(mode, all_form_values, data)
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values,
+            partner_sudo,
+            address_type,
+            use_delivery_as_billing,
+            required_fields,
+            is_main_address,
+            **_kwargs,
+        )
 
-        error.update(standard_error)
-        error_message += standard_error_message
-
-        if data.get("phone"):
+        if address_values.get("phone") and "phone" not in invalid_fields:
             try:
-                phone = data.get("phone")
-                country = request.env["res.country"].sudo().browse(data.get("country_id"))
-                data["phone"] = phone_validation.phone_format(
+                phone = address_values.get("phone")
+                country = request.env["res.country"].sudo().browse(address_values.get("country_id"))
+                address_values["phone"] = phone_validation.phone_format(
                     phone,
                     country.code if country else None,
                     country.phone_code if country else None,
@@ -33,7 +44,7 @@ class WebsiteSalePhoneValidation(WebsiteSale):
                     raise_exception=True,
                 )
             except Exception as e:
-                error["phone"] = "error"
-                error_message.append(e)
+                invalid_fields.add("phone")
+                error_messages.append(getattr(e, "name", str(e)))
 
-        return error, error_message
+        return invalid_fields, missing_fields, error_messages

--- a/deltatech_website_phone_validation/controllers/website_sale.py
+++ b/deltatech_website_phone_validation/controllers/website_sale.py
@@ -2,6 +2,7 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+from odoo import _
 from odoo.http import request
 
 from odoo.addons.phone_validation.tools import phone_validation
@@ -45,6 +46,6 @@ class WebsiteSalePhoneValidation(WebsiteSale):
                 )
             except Exception as e:
                 invalid_fields.add("phone")
-                error_messages.append(getattr(e, "name", str(e)))
+                error_messages.append(_("The phone number is not valid: %s", getattr(e, "name", str(e))))
 
         return invalid_fields, missing_fields, error_messages

--- a/deltatech_website_phone_validation/i18n/ro.po
+++ b/deltatech_website_phone_validation/i18n/ro.po
@@ -1,0 +1,23 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following module:
+# 	* deltatech_website_phone_validation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-03-14 07:30+0000\n"
+"PO-Revision-Date: 2024-03-14 07:30+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||(n%100==0)&&(n!=0))?2:1));\n"
+
+#. module: deltatech_website_phone_validation
+#. python-format
+#: code:addons/deltatech_website_phone_validation/controllers/website_sale.py:0
+msgid "The phone number is not valid: %s"
+msgstr "Numărul de telefon nu este valid: %s"

--- a/deltatech_website_phone_validation/tests/test_website_sale.py
+++ b/deltatech_website_phone_validation/tests/test_website_sale.py
@@ -1,0 +1,56 @@
+# ©  2008-2021 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.website.tools import MockRequest
+
+from ..controllers.website_sale import WebsiteSalePhoneValidation
+
+
+@tagged("post_install", "-at_install")
+class TestWebsiteSalePhoneValidation(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.controller = WebsiteSalePhoneValidation()
+        self.country_ro = self.env.ref("base.ro")
+
+    def test_01_phone_validation_formatting(self):
+        address_values = {
+            "phone": " 0722123456 ",
+            "country_id": self.country_ro.id,
+        }
+        # MockRequest is needed because the controller uses request.env
+        with MockRequest(self.env):
+            invalid_fields, missing_fields, error_messages = self.controller._validate_address_values(
+                address_values,
+                partner_sudo=self.env.user.partner_id,
+                address_type="billing",
+                use_delivery_as_billing=False,
+                required_fields="phone",
+                is_main_address=True,
+            )
+
+            # Verificăm dacă telefonul a fost curățat de spații și formatat internațional
+            # Pentru România (+40), 0722123456 devine +40 722 123 456
+            self.assertEqual(address_values["phone"].replace(" ", ""), "+40722123456")
+            self.assertNotIn("phone", invalid_fields)
+
+    def test_02_phone_validation_invalid(self):
+        address_values = {
+            "phone": "invalid_phone",
+            "country_id": self.country_ro.id,
+        }
+        with MockRequest(self.env):
+            invalid_fields, missing_fields, error_messages = self.controller._validate_address_values(
+                address_values,
+                partner_sudo=self.env.user.partner_id,
+                address_type="billing",
+                use_delivery_as_billing=False,
+                required_fields="phone",
+                is_main_address=True,
+            )
+
+            self.assertIn("phone", invalid_fields)
+            self.assertTrue(error_messages)

--- a/deltatech_website_vat_validation/controllers/website_sale.py
+++ b/deltatech_website_vat_validation/controllers/website_sale.py
@@ -33,6 +33,37 @@ class WebsiteSaleVATValidation(WebsiteSale):
             **_kwargs,
         )
         partner = partner_sudo or request.env["res.users"].browse(request.uid).partner_id
+
+        # Integrare ANAF
+        if address_values.get("vat") and "vat" not in invalid_fields:
+            if address_type == "billing" or use_delivery_as_billing:
+                country = request.env["res.country"].sudo().browse(address_values.get("country_id"))
+                if country and country.code == "RO":
+                    vat = address_values["vat"].strip().upper()
+                    if vat.startswith("RO"):
+                        vat = vat[2:]
+                    if vat.isdigit():
+                        res_partner_sudo = request.env["res.partner"].sudo()
+                        if hasattr(res_partner_sudo, "_get_Anaf") and hasattr(res_partner_sudo, "_Anaf_to_Odoo"):
+                            anaf_error, result = res_partner_sudo._get_Anaf(vat)
+                            if not anaf_error and result:
+                                anaf_data = res_partner_sudo._Anaf_to_Odoo(result)
+                                # Actualizăm valorile adresei cu datele de la ANAF
+                                for field in ["name", "street", "city", "zip"]:
+                                    if anaf_data.get(field):
+                                        address_values[field] = anaf_data[field]
+                                if anaf_data.get("state_id") and not address_values.get("state_id"):
+                                    address_values["state_id"] = anaf_data["state_id"].id
+
+                                if anaf_data.get("company_type") == "company":
+                                    address_values["is_company"] = True
+                            else:
+                                invalid_fields.add("vat")
+                                error_messages.append(_("The VAT number is not valid according to ANAF"))
+                    else:
+                        invalid_fields.add("vat")
+                        error_messages.append(_("The VAT number must contain only digits (after the country code)"))
+
         for field in ["vat", "email", "phone"]:
             value = address_values.get(field, False)
             if value and field not in invalid_fields:

--- a/deltatech_website_vat_validation/controllers/website_sale.py
+++ b/deltatech_website_vat_validation/controllers/website_sale.py
@@ -9,27 +9,37 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSaleVATValidation(WebsiteSale):
-    def checkout_form_validate(self, mode, all_form_values, data):
-        error = dict()
-        error_message = []
-
+    def _validate_address_values(
+        self,
+        address_values,
+        partner_sudo,
+        address_type,
+        use_delivery_as_billing,
+        required_fields,
+        is_main_address,
+        **_kwargs,
+    ):
         for field in ["vat", "email", "phone"]:
-            if field in data and data.get(field):
-                data[field] = data.get(field).strip()
+            if address_values.get(field):
+                address_values[field] = address_values.get(field).strip()
 
-        standard_error, standard_error_message = super().checkout_form_validate(mode, all_form_values, data)
-
-        error.update(standard_error)
-        error_message += standard_error_message
-        partner = request.env["res.users"].browse(request.uid).partner_id
-
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values,
+            partner_sudo,
+            address_type,
+            use_delivery_as_billing,
+            required_fields,
+            is_main_address,
+            **_kwargs,
+        )
+        partner = partner_sudo or request.env["res.users"].browse(request.uid).partner_id
         for field in ["vat", "email", "phone"]:
-            value = data.get(field, False)
-            if value and field not in error:
+            value = address_values.get(field, False)
+            if value and field not in invalid_fields:
                 domain = [(field, "=", value), ("id", "!=", partner.id), ("parent_id", "=", False)]
-                partner_exists = request.env["res.partner"].search(domain, limit=1)
+                partner_exists = request.env["res.partner"].sudo().search(domain, limit=1)
                 if partner_exists:
-                    error[field] = "error"
-                    error_message.append(_(f"An other partner already exists with the same {value}"))
+                    invalid_fields.add(field)
+                    error_messages.append(_("An other partner already exists with the same %s", value))
 
-        return error, error_message
+        return invalid_fields, missing_fields, error_messages

--- a/deltatech_website_vat_validation/i18n/ro.po
+++ b/deltatech_website_vat_validation/i18n/ro.po
@@ -1,0 +1,35 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following module:
+# 	* deltatech_website_vat_validation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 18.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-03-14 07:30+0000\n"
+"PO-Revision-Date: 2024-03-14 07:30+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: nplurals=3; plural=(n==1?0:(((n%100>19)||(n%100==0)&&(n!=0))?2:1));\n"
+
+#. module: deltatech_website_vat_validation
+#. python-format
+#: code:addons/deltatech_website_vat_validation/controllers/website_sale.py:0
+msgid "An other partner already exists with the same %s"
+msgstr "Un alt partener există deja cu același %s"
+
+#. module: deltatech_website_vat_validation
+#. python-format
+#: code:addons/deltatech_website_vat_validation/controllers/website_sale.py:0
+msgid "The VAT number is not valid according to ANAF"
+msgstr "Codul TVA nu este valid conform ANAF"
+
+#. module: deltatech_website_vat_validation
+#. python-format
+#: code:addons/deltatech_website_vat_validation/controllers/website_sale.py:0
+msgid "The VAT number must contain only digits (after the country code)"
+msgstr "Codul TVA trebuie să conțină doar cifre (după codul țării)"

--- a/deltatech_website_vat_validation/tests/__init__.py
+++ b/deltatech_website_vat_validation/tests/__init__.py
@@ -2,5 +2,4 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
-
 from . import test_website_sale

--- a/deltatech_website_vat_validation/tests/test_website_sale.py
+++ b/deltatech_website_vat_validation/tests/test_website_sale.py
@@ -85,3 +85,53 @@ class TestWebsiteSaleVATValidation(TransactionCase):
 
             self.assertIn("phone", invalid_fields)
             self.assertTrue(any("already exists" in msg for msg in error_messages))
+
+    def test_04_anaf_integration(self):
+        # Simulăm datele ANAF folosind contextul, așa cum am văzut în l10n_ro_partner_create_by_vat/models/res_partner.py:_get_Anaf
+        anaf_data = {
+            "123456": {
+                "date_generale": {
+                    "denumire": "COMPANIA TEST ANAF SRL",
+                    "cui": "123456",
+                    "adresa": "STR. TEST NR. 1",
+                },
+                "adresa_sediu_social": {
+                    "sdenumire_Strada": "TEST",
+                    "snumar_Strada": "1",
+                    "sdenumire_Localitate": "BUCURESTI",
+                    "sdenumire_Judet": "BUCURESTI",
+                    "scod_JudetAuto": "B",
+                },
+                "adresa_domiciliu_fiscal": {
+                    "ddenumire_Strada": "TEST",
+                    "dnumar_Strada": "1",
+                    "ddenumire_Localitate": "BUCURESTI",
+                    "ddenumire_Judet": "BUCURESTI",
+                    "dcod_JudetAuto": "B",
+                    "adresa": "STR. TEST NR. 1",
+                },
+            }
+        }
+        address_values = {
+            "vat": "RO123456",
+            "country_id": self.country_ro.id,
+        }
+        # Trebuie să ne asigurăm că metodele ANAF există pe res.partner (adică modulul e instalat)
+        if not hasattr(self.env["res.partner"], "_get_Anaf"):
+            self.skipTest("Modulul l10n_ro_partner_create_by_vat nu este instalat.")
+
+        with MockRequest(self.env.with_context(anaf_data=anaf_data)):
+            # Ne asigurăm că adresa este pentru România
+            invalid_fields, missing_fields, error_messages = self.controller._validate_address_values(
+                address_values,
+                partner_sudo=self.env["res.partner"].sudo(),
+                address_type="billing",
+                use_delivery_as_billing=False,
+                required_fields="vat",
+                is_main_address=True,
+            )
+
+            self.assertEqual(address_values.get("name"), "COMPANIA TEST ANAF SRL")
+            self.assertEqual(address_values.get("city"), "Bucuresti")
+            self.assertEqual(address_values.get("street"), "Test Nr. 1")
+            self.assertTrue(address_values.get("is_company"))

--- a/deltatech_website_vat_validation/tests/test_website_sale.py
+++ b/deltatech_website_vat_validation/tests/test_website_sale.py
@@ -1,0 +1,87 @@
+# ©  2008-2021 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.website.tools import MockRequest
+
+from ..controllers.website_sale import WebsiteSaleVATValidation
+
+
+@tagged("post_install", "-at_install")
+class TestWebsiteSaleVATValidation(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.controller = WebsiteSaleVATValidation()
+        self.country_ro = self.env.ref("base.ro")
+
+        # Creăm un partener existent pentru teste de unicitate
+        self.existing_partner = self.env["res.partner"].create(
+            {
+                "name": "Existing Partner",
+                "vat": "RO12345678",
+                "email": "existing@example.com",
+                "phone": "+40711111111",
+                "country_id": self.country_ro.id,
+            }
+        )
+
+    def test_01_vat_uniqueness(self):
+        address_values = {
+            "name": "New Partner",
+            "vat": " RO12345678 ",  # Cu spații pentru a testa și striping
+            "country_id": self.country_ro.id,
+        }
+        with MockRequest(self.env):
+            invalid_fields, missing_fields, error_messages = self.controller._validate_address_values(
+                address_values,
+                partner_sudo=self.env["res.partner"].sudo(),  # Nou partener
+                address_type="billing",
+                use_delivery_as_billing=False,
+                required_fields="vat",
+                is_main_address=True,
+            )
+
+            self.assertIn("vat", invalid_fields)
+            self.assertTrue(any("already exists" in msg for msg in error_messages))
+
+    def test_02_email_uniqueness(self):
+        address_values = {
+            "name": "New Partner",
+            "email": " existing@example.com ",
+            "country_id": self.country_ro.id,
+        }
+        with MockRequest(self.env):
+            invalid_fields, missing_fields, error_messages = self.controller._validate_address_values(
+                address_values,
+                partner_sudo=self.env["res.partner"].sudo(),
+                address_type="billing",
+                use_delivery_as_billing=False,
+                required_fields="email",
+                is_main_address=True,
+            )
+
+            self.assertIn("email", invalid_fields)
+            self.assertTrue(any("already exists" in msg for msg in error_messages))
+
+    def test_03_phone_uniqueness(self):
+        # Pentru telefon, validarea unicității se face după striping în deltatech_website_vat_validation
+        # Dar atenție, phone_validation poate formata numărul în super()
+        address_values = {
+            "name": "New Partner",
+            "phone": " +40711111111 ",
+            "country_id": self.country_ro.id,
+        }
+        with MockRequest(self.env):
+            invalid_fields, missing_fields, error_messages = self.controller._validate_address_values(
+                address_values,
+                partner_sudo=self.env["res.partner"].sudo(),
+                address_type="billing",
+                use_delivery_as_billing=False,
+                required_fields="phone",
+                is_main_address=True,
+            )
+
+            self.assertIn("phone", invalid_fields)
+            self.assertTrue(any("already exists" in msg for msg in error_messages))

--- a/deltatech_website_vat_validation/tests/test_website_sale.py
+++ b/deltatech_website_vat_validation/tests/test_website_sale.py
@@ -20,7 +20,7 @@ class TestWebsiteSaleVATValidation(TransactionCase):
         self.existing_partner = self.env["res.partner"].create(
             {
                 "name": "Existing Partner",
-                "vat": "RO12345678",
+                "vat": "RO8001011234567",
                 "email": "existing@example.com",
                 "phone": "+40711111111",
                 "country_id": self.country_ro.id,
@@ -30,7 +30,7 @@ class TestWebsiteSaleVATValidation(TransactionCase):
     def test_01_vat_uniqueness(self):
         address_values = {
             "name": "New Partner",
-            "vat": " RO12345678 ",  # Cu spații pentru a testa și striping
+            "vat": " RO8001011234567 ",  # Cu spații pentru a testa și striping
             "country_id": self.country_ro.id,
         }
         with MockRequest(self.env):


### PR DESCRIPTION
Modifică semnătura metodei `_validate_address_values` pentru a înlocui `checkout_form_validate` și adaugă suport pentru validarea extensivă a câmpurilor, precum `phone`, `vat` și `email`. Introduce și teste unitare pentru a verifica formatul și corectitudinea numerelor de telefon, asigurând conformitatea și robustezza implementării.