### PR TITLE
Adaugă funcționalitatea de împărțire a codurilor multiple pentru produse

### DIFF
--- a/deltatech_alternative/__manifest__.py
+++ b/deltatech_alternative/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Products Alternative",
-    "version": "18.0.2.1.4",
+    "version": "18.0.2.1.5",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Alternative product codes",
@@ -12,6 +12,7 @@
     "depends": ["product", "stock", "sale", "purchase"],
     "license": "OPL-1",
     "data": [
+        "data/cron.xml",
         "views/product_template_view.xml",
         "views/product_product_view.xml",
         "views/product_alternative_view.xml",

--- a/deltatech_alternative/data/cron.xml
+++ b/deltatech_alternative/data/cron.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_split_alternative_codes" model="ir.cron">
+        <field name="name">Alternative: Split multi-code records</field>
+        <field name="model_id" ref="deltatech_alternative.model_product_alternative" />
+        <field name="state">code</field>
+        <field name="code">model.split_multi_codes()</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="active" eval="True" />
+    </record>
+</odoo>

--- a/deltatech_alternative/models/product.py
+++ b/deltatech_alternative/models/product.py
@@ -122,3 +122,34 @@ class ProductAlternative(models.Model):
     sequence = fields.Integer(string="sequence", default=10)
     product_tmpl_id = fields.Many2one("product.template", string="Product Template", ondelete="cascade")
     hide = fields.Boolean(string="Hide")
+
+    @api.model
+    def split_multi_codes(self):
+        import re
+
+        domain = [
+            ("name", "!=", False),
+            "|",
+            "|",
+            ("name", "like", ";"),
+            ("name", "like", ","),
+            ("name", "like", " "),
+        ]
+        records = self.search(domain, limit=5000)
+        for record in records:
+            name = (record.name or "").strip()
+            if not name:
+                continue
+            codes = [c for c in re.split(r"[;,\s]+", name) if c]
+            if len(codes) > 1:
+                record.write({"name": codes[0]})
+                new_records = [
+                    {
+                        "name": code,
+                        "product_tmpl_id": record.product_tmpl_id.id or False,
+                        "sequence": record.sequence,
+                        "hide": record.hide,
+                    }
+                    for code in codes[1:]
+                ]
+                self.create(new_records)

--- a/deltatech_alternative/readme/DESCRIPTION.md
+++ b/deltatech_alternative/readme/DESCRIPTION.md
@@ -1,15 +1,47 @@
-- Features:
+# Products Alternative
 
-  - - New model: product_catelog for big master data of products
+Module that extends the standard Odoo product with support for **alternative codes** (cross-references, supplier codes, customer codes, etc.).
 
-      - generate new product from catalog: If the search for a product by code does not return results, an additional
-        search is made in the product catalog and a product is automatically generated if it has been found
+## Features
 
-  - A module that adds an alternative on the product form
+### Alternative Codes on Product
 
-  - Search product by alternative code
+- Each product (template or variant) can have one or more alternative codes stored in the `product.alternative` model.
+- The `alternative_code` computed field on `product.template` / `product.product` displays all codes joined by `"; "` and allows inline editing when there is a single alternative record.
+- Codes can be marked as **hidden** (`hide = True`) so they are excluded from the displayed `alternative_code` value.
 
-  - A new product field (used for) to indicate what the product may be used for
+### Product Search by Alternative Code
 
-Camp adaugat in produs search_index in care se face cautarea daca este setat paramentrul
-deltatech_alternative_website.search_index
+- `name_search` on `product.template` and `product.product` is extended to also search through alternative codes.
+- `_search_display_name` is extended to include alternative codes in domain-based searches.
+- Search by alternative code is enabled via the system parameter `alternative.search_name` (set to `True` to activate).
+
+### Product Catalog (`product.catalog`)
+
+- New model for large master-data catalogs of products.
+- When searching for a product by code returns no results, an additional lookup is made in the catalog; if found, a new product is automatically generated from the catalog entry.
+
+### Used For Field
+
+- New `used_for` field on `product.template` to document what the product is typically used for (free-text).
+
+### Multi-code Split (Cron)
+
+- A scheduled action runs **daily** and processes batches of up to **5 000** `product.alternative` records at a time.
+- It detects records where the `name` field contains multiple codes on a single line, separated by **semicolons** (`;`), **commas** (`,`), or **spaces**.
+- Each such record is split into individual records — one per code — preserving `product_tmpl_id`, `sequence`, and `hide` from the original record.
+- The cron repeats on subsequent days until all multi-code records have been normalised.
+
+## Configuration
+
+| Parameter | Model | Default | Effect |
+|---|---|---|---|
+| `alternative.search_name` | `ir.config_parameter` | `False` | Enable search by alternative code |
+
+## Views Extended
+
+- Product Template form: alternative codes tab, `used_for` field
+- Product Variant form: alternative codes tab
+- Sale Order line: alternative code column
+- Purchase Order line: alternative code column
+- Stock Move / Picking: alternative code column

--- a/deltatech_alternative/tests/__init__.py
+++ b/deltatech_alternative/tests/__init__.py
@@ -4,3 +4,4 @@
 
 from . import test_product
 from . import test_archive
+from . import test_split_codes

--- a/deltatech_alternative/tests/test_split_codes.py
+++ b/deltatech_alternative/tests/test_split_codes.py
@@ -1,0 +1,138 @@
+# ©  2024 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests.common import TransactionCase
+
+
+class TestSplitMultiCodes(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.product = self.env["product.template"].create({"name": "Test Product for Split"})
+        self.Alternative = self.env["product.alternative"]
+
+    def _make(self, name, sequence=10, hide=False):
+        return self.Alternative.create(
+            {
+                "name": name,
+                "product_tmpl_id": self.product.id,
+                "sequence": sequence,
+                "hide": hide,
+            }
+        )
+
+    def _split_and_get(self, record):
+        self.Alternative.split_multi_codes()
+        return self.Alternative.search([("product_tmpl_id", "=", self.product.id)], order="id asc")
+
+    # ------------------------------------------------------------------
+    # Separatori simpli
+    # ------------------------------------------------------------------
+
+    def test_split_by_semicolon(self):
+        self._make("CODE1;CODE2;CODE3")
+        all_records = self._split_and_get(None)
+        names = all_records.mapped("name")
+        self.assertEqual(sorted(names), ["CODE1", "CODE2", "CODE3"])
+
+    def test_split_by_comma(self):
+        self._make("AAA,BBB,CCC")
+        all_records = self._split_and_get(None)
+        names = all_records.mapped("name")
+        self.assertEqual(sorted(names), ["AAA", "BBB", "CCC"])
+
+    def test_split_by_space(self):
+        self._make("X1 X2 X3")
+        all_records = self._split_and_get(None)
+        names = all_records.mapped("name")
+        self.assertEqual(sorted(names), ["X1", "X2", "X3"])
+
+    # ------------------------------------------------------------------
+    # Separatori cu spații suplimentare
+    # ------------------------------------------------------------------
+
+    def test_split_semicolon_with_spaces(self):
+        self._make("CODE1; CODE2; CODE3")
+        all_records = self._split_and_get(None)
+        names = all_records.mapped("name")
+        self.assertEqual(sorted(names), ["CODE1", "CODE2", "CODE3"])
+
+    def test_split_comma_with_spaces(self):
+        self._make("A1 , A2 , A3")
+        all_records = self._split_and_get(None)
+        names = all_records.mapped("name")
+        self.assertEqual(sorted(names), ["A1", "A2", "A3"])
+
+    # ------------------------------------------------------------------
+    # Separatori mixti
+    # ------------------------------------------------------------------
+
+    def test_split_mixed_separators(self):
+        self._make("C1; C2, C3 C4")
+        all_records = self._split_and_get(None)
+        names = all_records.mapped("name")
+        self.assertEqual(sorted(names), ["C1", "C2", "C3", "C4"])
+
+    # ------------------------------------------------------------------
+    # Record fără separator — nu trebuie atins
+    # ------------------------------------------------------------------
+
+    def test_no_split_single_code(self):
+        self._make("SINGLE")
+        self.Alternative.split_multi_codes()
+        remaining = self.Alternative.search([("product_tmpl_id", "=", self.product.id)])
+        self.assertEqual(len(remaining), 1)
+        self.assertEqual(remaining.name, "SINGLE")
+
+    # ------------------------------------------------------------------
+    # Atribute moștenite (sequence, hide)
+    # ------------------------------------------------------------------
+
+    def test_inherited_attributes(self):
+        self._make("P1;P2;P3", sequence=20, hide=True)
+        self.Alternative.split_multi_codes()
+        all_records = self.Alternative.search([("product_tmpl_id", "=", self.product.id)])
+        for rec in all_records:
+            self.assertEqual(rec.sequence, 20)
+            self.assertTrue(rec.hide)
+
+    # ------------------------------------------------------------------
+    # Primul cod rămâne pe înregistrarea originală
+    # ------------------------------------------------------------------
+
+    def test_first_code_stays_on_original_record(self):
+        rec = self._make("FIRST;SECOND;THIRD")
+        original_id = rec.id
+        self.Alternative.split_multi_codes()
+        updated = self.Alternative.browse(original_id)
+        self.assertEqual(updated.name, "FIRST")
+
+    # ------------------------------------------------------------------
+    # Înregistrare fără product_tmpl_id
+    # ------------------------------------------------------------------
+
+    def test_split_without_product_tmpl_id(self):
+        orphan = self.Alternative.create({"name": "ORF1;ORF2", "product_tmpl_id": False})
+        self.Alternative.split_multi_codes()
+        results = self.Alternative.search([("id", "in", [orphan.id]), ("name", "=", "ORF1")])
+        self.assertEqual(len(results), 1)
+        new_code = self.Alternative.search([("name", "=", "ORF2"), ("product_tmpl_id", "=", False)])
+        self.assertEqual(len(new_code), 1)
+
+    # ------------------------------------------------------------------
+    # Batch: maxim 5000 înregistrări procesate per apel
+    # ------------------------------------------------------------------
+
+    def test_batch_limit_not_exceeded(self):
+        # Creăm 10 înregistrări cu câte 2 coduri — toate eligibile pentru split
+        for i in range(10):
+            self._make(f"BATCH{i}A;BATCH{i}B")
+
+        # Prima execuție — toate 10 ar trebui procesate (sub limita de 5000)
+        self.Alternative.split_multi_codes()
+        all_records = self.Alternative.search([("product_tmpl_id", "=", self.product.id)])
+        names = all_records.mapped("name")
+        # Fiecare pereche a fost spartă, deci avem 20 de înregistrări individuale
+        self.assertEqual(len(names), 20)
+        for name in names:
+            self.assertNotIn(";", name)


### PR DESCRIPTION
Introduce metoda `split_multi_codes` în modelul `product.alternative`, care normalizează înregistrările cu multiple coduri alternative. Adaugă o acțiune programată (cron) pentru a automatiza acest proces zilnic și extinde testele pentru a valida funcționalitatea.