### PR TITLE
[18.0][FIX] deltatech_sale_payment: populate fields before _auto_init to sk…

### DIFF
--- a/deltatech_alternative/models/product.py
+++ b/deltatech_alternative/models/product.py
@@ -12,6 +12,27 @@ from odoo.tools.sql import create_index, index_exists
 _logger = logging.getLogger(__name__)
 
 
+def _ensure_unaccent_immutable(cr):
+    """Install the unaccent extension and (re)create its 1-arg IMMUTABLE wrapper.
+
+    Without an IMMUTABLE unaccent(text) function PostgreSQL refuses to build
+    expression indexes, which causes _create_trgm_index to fail silently.
+    This is commonly missing in CI databases or fresh PostgreSQL clusters.
+    """
+    try:
+        with cr.savepoint():
+            cr.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
+        with cr.savepoint():
+            cr.execute("""
+                CREATE OR REPLACE FUNCTION public.unaccent(text)
+                RETURNS text LANGUAGE sql IMMUTABLE AS
+                $$ SELECT public.unaccent('unaccent', $1) $$
+            """)
+        return True
+    except Exception:
+        return False
+
+
 def _create_trgm_index(cr, indexname, tablename, expression):
     """Create a GIN trigram index on an ``unaccent(...)`` expression.
 
@@ -20,9 +41,9 @@ def _create_trgm_index(cr, indexname, tablename, expression):
     that predicate, so PostgreSQL falls back to a sequential scan. This helper
     builds an index whose expression matches the search exactly.
 
-    It tolerates environments where the ``unaccent`` function is not declared
-    IMMUTABLE (creating an expression index would then fail): in that case it
-    only logs a warning instead of breaking the module install/upgrade.
+    If the first attempt fails (unaccent missing or not IMMUTABLE) it tries to
+    install the extension and create the IMMUTABLE wrapper, then retries once.
+    Only if that also fails does it fall back to logging a warning.
     """
     if index_exists(cr, indexname):
         return
@@ -30,6 +51,13 @@ def _create_trgm_index(cr, indexname, tablename, expression):
         with cr.savepoint():
             create_index(cr, indexname, tablename, [expression], method="gin")
     except Exception:
+        if _ensure_unaccent_immutable(cr):
+            try:
+                with cr.savepoint():
+                    create_index(cr, indexname, tablename, [expression], method="gin")
+                return
+            except Exception:
+                pass
         _logger.warning(
             "Could not create trigram index %s on %s; product search may be "
             "slow. Make sure the 'unaccent' function is declared IMMUTABLE.",

--- a/deltatech_alternative/models/product.py
+++ b/deltatech_alternative/models/product.py
@@ -12,14 +12,16 @@ from odoo.tools.sql import create_index, index_exists
 _logger = logging.getLogger(__name__)
 
 
-def _ensure_unaccent_immutable(cr):
-    """Install the unaccent extension and (re)create its 1-arg IMMUTABLE wrapper.
+def _ensure_trgm_prerequisites(cr):
+    """Ensure pg_trgm and unaccent are installed and unaccent is IMMUTABLE.
 
-    Without an IMMUTABLE unaccent(text) function PostgreSQL refuses to build
-    expression indexes, which causes _create_trgm_index to fail silently.
-    This is commonly missing in CI databases or fresh PostgreSQL clusters.
+    Both extensions are required for the GIN trigram indexes used by the
+    website product search. They are commonly absent in CI databases or fresh
+    PostgreSQL clusters.
     """
     try:
+        with cr.savepoint():
+            cr.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm")
         with cr.savepoint():
             cr.execute("CREATE EXTENSION IF NOT EXISTS unaccent")
         with cr.savepoint():
@@ -51,7 +53,7 @@ def _create_trgm_index(cr, indexname, tablename, expression):
         with cr.savepoint():
             create_index(cr, indexname, tablename, [expression], method="gin")
     except Exception:
-        if _ensure_unaccent_immutable(cr):
+        if _ensure_trgm_prerequisites(cr):
             try:
                 with cr.savepoint():
                     create_index(cr, indexname, tablename, [expression], method="gin")

--- a/deltatech_alternative/models/product.py
+++ b/deltatech_alternative/models/product.py
@@ -57,7 +57,7 @@ def _create_trgm_index(cr, indexname, tablename, expression):
                     create_index(cr, indexname, tablename, [expression], method="gin")
                 return
             except Exception:
-                pass
+                _logger.debug("Retry of trigram index %s failed after unaccent setup.", indexname, exc_info=True)
         _logger.warning(
             "Could not create trigram index %s on %s; product search may be "
             "slow. Make sure the 'unaccent' function is declared IMMUTABLE.",

--- a/deltatech_sale_payment/migrations/18.0.1.2.0/post-migrate.py
+++ b/deltatech_sale_payment/migrations/18.0.1.2.0/post-migrate.py
@@ -1,144 +1,165 @@
-import logging
-
-_logger = logging.getLogger(__name__)
-
-# Rulat DUPĂ ce Odoo a adăugat coloanele payment_amount și payment_status
-# (adică după activarea store=True pe câmpurile computate din sale.py).
-#
-# Replicăm logica din _compute_payment direct în SQL pentru performanță:
-# - O singură trecere peste toate comenzile (nu 1 query/comandă)
-# - Procesare în batch-uri de 10.000 pentru a nu bloca DB-ul
-#
-# Simplificare față de _compute_payment Python:
-# - Nu deducem tranzacțiile post-procesate pe facturi (edge-case rar, se
-#   recompute automat data viitoare când comanda e accesată)
-# - Suma plătită = tranzacții done + plăți reconciliate pe facturi paid/partial
-# - Facturile "in_payment" sunt excluse — plata lor apare deja în done_tx
+# Mutat în pre-migrate.py — coloanele sunt create și populate acolo, înainte ca
+# _auto_init să ruleze, astfel Odoo nu mai face queue la recompute ORM.
 
 
 def migrate(cr, version):
-    _logger.info("Migrare payment_amount / payment_status pe sale.order — start")
+    pass
 
-    # Pasul 1: suma plătită din tranzacții done
-    cr.execute("""
-        UPDATE sale_order so
-        SET payment_amount = COALESCE((
-            SELECT SUM(pt.amount)
-            FROM sale_order_transaction_rel rel
-            JOIN payment_transaction pt ON pt.id = rel.transaction_id
-            WHERE rel.sale_order_id = so.id
-              AND pt.state = 'done'
-        ), 0.0)
-    """)
-    _logger.info("payment_amount actualizat din tranzacții done (%d rânduri)", cr.rowcount)
-
-    # Pasul 2: adăugăm suma plătită pe facturile complet reconciliate (paid/partial).
-    # Legătura sale.order → account.move se face prin:
-    #   sale_order_line → sale_order_line_invoice_rel → account_move_line → account_move
-    # Facturile "in_payment" sunt excluse — plata lor apare deja în done_tx (pasul 1).
-    cr.execute("""
-        UPDATE sale_order so
-        SET payment_amount = GREATEST(so.payment_amount + COALESCE((
-            SELECT SUM(sub.paid_amount)
-            FROM (
-                SELECT DISTINCT am.id,
-                       am.amount_total_signed - am.amount_residual_signed AS paid_amount
-                FROM sale_order_line sol
-                JOIN sale_order_line_invoice_rel slir ON slir.order_line_id = sol.id
-                JOIN account_move_line aml ON aml.id = slir.invoice_line_id
-                JOIN account_move am ON am.id = aml.move_id
-                WHERE sol.order_id = so.id
-                  AND am.state = 'posted'
-                  AND am.payment_state IN ('paid', 'partial')
-                  AND am.move_type IN ('out_invoice', 'out_refund')
-                  AND am.amount_total_signed != am.amount_residual_signed
-            ) sub
-        ), 0.0), 0.0)
-        WHERE EXISTS (
-            SELECT 1
-            FROM sale_order_line sol
-            JOIN sale_order_line_invoice_rel slir ON slir.order_line_id = sol.id
-            JOIN account_move_line aml ON aml.id = slir.invoice_line_id
-            JOIN account_move am ON am.id = aml.move_id
-            WHERE sol.order_id = so.id
-              AND am.state = 'posted'
-              AND am.payment_state IN ('paid', 'partial')
-        )
-    """)
-
-    # Pasul 3: calculăm payment_status pe baza payment_amount și stărilor tranzacțiilor
-    cr.execute("""
-        UPDATE sale_order so
-        SET payment_status = CASE
-            -- Plătit complet (cu toleranță de rotunjire 0.01)
-            WHEN so.payment_amount >= so.amount_total - 0.01
-              AND so.payment_amount > 0
-                THEN 'done'
-
-            -- Plătit parțial
-            WHEN so.payment_amount > 0
-                THEN 'partial'
-
-            -- Fără nicio tranzacție
-            WHEN NOT EXISTS (
-                SELECT 1 FROM sale_order_transaction_rel rel
-                WHERE rel.sale_order_id = so.id
-            )
-                THEN 'without'
-
-            -- Autorizat (are prioritate față de pending și cancel)
-            WHEN EXISTS (
-                SELECT 1 FROM sale_order_transaction_rel rel
-                JOIN payment_transaction pt ON pt.id = rel.transaction_id
-                WHERE rel.sale_order_id = so.id AND pt.state = 'authorized'
-            )
-                THEN 'authorized'
-
-            -- Pending
-            WHEN EXISTS (
-                SELECT 1 FROM sale_order_transaction_rel rel
-                JOIN payment_transaction pt ON pt.id = rel.transaction_id
-                WHERE rel.sale_order_id = so.id AND pt.state = 'pending'
-            )
-                THEN 'pending'
-
-            -- Anulat
-            WHEN EXISTS (
-                SELECT 1 FROM sale_order_transaction_rel rel
-                JOIN payment_transaction pt ON pt.id = rel.transaction_id
-                WHERE rel.sale_order_id = so.id AND pt.state = 'cancel'
-            )
-                THEN 'cancelled'
-
-            -- Draft / error
-            ELSE 'initiated'
-        END
-    """)
-    _logger.info("payment_status actualizat (%d rânduri)", cr.rowcount)
-
-    # Pasul 4: populăm provider_id — prioritate: done > authorized > pending > cancel > orice
-    cr.execute("""
-        UPDATE sale_order so
-        SET provider_id = (
-            SELECT pt.provider_id
-            FROM sale_order_transaction_rel rel
-            JOIN payment_transaction pt ON pt.id = rel.transaction_id
-            WHERE rel.sale_order_id = so.id
-            ORDER BY
-                CASE pt.state
-                    WHEN 'done'       THEN 1
-                    WHEN 'authorized' THEN 2
-                    WHEN 'pending'    THEN 3
-                    WHEN 'cancel'     THEN 4
-                    ELSE 5
-                END,
-                pt.id DESC
-            LIMIT 1
-        )
-        WHERE EXISTS (
-            SELECT 1 FROM sale_order_transaction_rel rel
-            WHERE rel.sale_order_id = so.id
-        )
-    """)
-    _logger.info("provider_id actualizat (%d rânduri)", cr.rowcount)
-    _logger.info("Migrare payment_amount / payment_status / provider_id — finalizată")
+# import logging
+#
+# from odoo import SUPERUSER_ID, api
+#
+# _logger = logging.getLogger(__name__)
+#
+# # Rulat DUPĂ ce Odoo a adăugat coloanele payment_amount și payment_status
+# # (adică după activarea store=True pe câmpurile computate din sale.py).
+# #
+# # Replicăm logica din _compute_payment direct în SQL pentru performanță:
+# # - O singură trecere peste toate comenzile (nu 1 query/comandă)
+# # - Procesare în batch-uri de 10.000 pentru a nu bloca DB-ul
+# #
+# # Simplificare față de _compute_payment Python:
+# # - Nu deducem tranzacțiile post-procesate pe facturi (edge-case rar, se
+# #   recompute automat data viitoare când comanda e accesată)
+# # - Suma plătită = tranzacții done + plăți reconciliate pe facturi paid/partial
+# # - Facturile "in_payment" sunt excluse — plata lor apare deja în done_tx
+#
+#
+# def migrate(cr, version):
+#     _logger.info("Migrare payment_amount / payment_status pe sale.order — start")
+#
+#     # Pasul 1: suma plătită din tranzacții done
+#     cr.execute("""
+#         UPDATE sale_order so
+#         SET payment_amount = COALESCE((
+#             SELECT SUM(pt.amount)
+#             FROM sale_order_transaction_rel rel
+#             JOIN payment_transaction pt ON pt.id = rel.transaction_id
+#             WHERE rel.sale_order_id = so.id
+#               AND pt.state = 'done'
+#         ), 0.0)
+#     """)
+#     _logger.info("payment_amount actualizat din tranzacții done (%d rânduri)", cr.rowcount)
+#
+#     # Pasul 2: adăugăm suma plătită pe facturile complet reconciliate (paid/partial).
+#     # Legătura sale.order → account.move se face prin:
+#     #   sale_order_line → sale_order_line_invoice_rel → account_move_line → account_move
+#     # Facturile "in_payment" sunt excluse — plata lor apare deja în done_tx (pasul 1).
+#     cr.execute("""
+#         UPDATE sale_order so
+#         SET payment_amount = GREATEST(so.payment_amount + COALESCE((
+#             SELECT SUM(sub.paid_amount)
+#             FROM (
+#                 SELECT DISTINCT am.id,
+#                        am.amount_total_signed - am.amount_residual_signed AS paid_amount
+#                 FROM sale_order_line sol
+#                 JOIN sale_order_line_invoice_rel slir ON slir.order_line_id = sol.id
+#                 JOIN account_move_line aml ON aml.id = slir.invoice_line_id
+#                 JOIN account_move am ON am.id = aml.move_id
+#                 WHERE sol.order_id = so.id
+#                   AND am.state = 'posted'
+#                   AND am.payment_state IN ('paid', 'partial')
+#                   AND am.move_type IN ('out_invoice', 'out_refund')
+#                   AND am.amount_total_signed != am.amount_residual_signed
+#             ) sub
+#         ), 0.0), 0.0)
+#         WHERE EXISTS (
+#             SELECT 1
+#             FROM sale_order_line sol
+#             JOIN sale_order_line_invoice_rel slir ON slir.order_line_id = sol.id
+#             JOIN account_move_line aml ON aml.id = slir.invoice_line_id
+#             JOIN account_move am ON am.id = aml.move_id
+#             WHERE sol.order_id = so.id
+#               AND am.state = 'posted'
+#               AND am.payment_state IN ('paid', 'partial')
+#         )
+#     """)
+#
+#     # Pasul 3: calculăm payment_status pe baza payment_amount și stărilor tranzacțiilor
+#     cr.execute("""
+#         UPDATE sale_order so
+#         SET payment_status = CASE
+#             -- Plătit complet (cu toleranță de rotunjire 0.01)
+#             WHEN so.payment_amount >= so.amount_total - 0.01
+#               AND so.payment_amount > 0
+#                 THEN 'done'
+#
+#             -- Plătit parțial
+#             WHEN so.payment_amount > 0
+#                 THEN 'partial'
+#
+#             -- Fără nicio tranzacție
+#             WHEN NOT EXISTS (
+#                 SELECT 1 FROM sale_order_transaction_rel rel
+#                 WHERE rel.sale_order_id = so.id
+#             )
+#                 THEN 'without'
+#
+#             -- Autorizat (are prioritate față de pending și cancel)
+#             WHEN EXISTS (
+#                 SELECT 1 FROM sale_order_transaction_rel rel
+#                 JOIN payment_transaction pt ON pt.id = rel.transaction_id
+#                 WHERE rel.sale_order_id = so.id AND pt.state = 'authorized'
+#             )
+#                 THEN 'authorized'
+#
+#             -- Pending
+#             WHEN EXISTS (
+#                 SELECT 1 FROM sale_order_transaction_rel rel
+#                 JOIN payment_transaction pt ON pt.id = rel.transaction_id
+#                 WHERE rel.sale_order_id = so.id AND pt.state = 'pending'
+#             )
+#                 THEN 'pending'
+#
+#             -- Anulat
+#             WHEN EXISTS (
+#                 SELECT 1 FROM sale_order_transaction_rel rel
+#                 JOIN payment_transaction pt ON pt.id = rel.transaction_id
+#                 WHERE rel.sale_order_id = so.id AND pt.state = 'cancel'
+#             )
+#                 THEN 'cancelled'
+#
+#             -- Draft / error
+#             ELSE 'initiated'
+#         END
+#     """)
+#     _logger.info("payment_status actualizat (%d rânduri)", cr.rowcount)
+#
+#     # Pasul 4: populăm provider_id — prioritate: done > authorized > pending > cancel > orice
+#     cr.execute("""
+#         UPDATE sale_order so
+#         SET provider_id = (
+#             SELECT pt.provider_id
+#             FROM sale_order_transaction_rel rel
+#             JOIN payment_transaction pt ON pt.id = rel.transaction_id
+#             WHERE rel.sale_order_id = so.id
+#             ORDER BY
+#                 CASE pt.state
+#                     WHEN 'done'       THEN 1
+#                     WHEN 'authorized' THEN 2
+#                     WHEN 'pending'    THEN 3
+#                     WHEN 'cancel'     THEN 4
+#                     ELSE 5
+#                 END,
+#                 pt.id DESC
+#             LIMIT 1
+#         )
+#         WHERE EXISTS (
+#             SELECT 1 FROM sale_order_transaction_rel rel
+#             WHERE rel.sale_order_id = so.id
+#         )
+#     """)
+#     _logger.info("provider_id actualizat (%d rânduri)", cr.rowcount)
+#     _logger.info("Migrare payment_amount / payment_status / provider_id — finalizată")
+#
+#     # _auto_init already queued a full ORM recompute for the three stored computed
+#     # fields.  Since we just populated them via SQL, clear that queue so the ORM
+#     # never iterates over the existing rows and overwrites our results.
+#     env = api.Environment(cr, SUPERUSER_ID, {})
+#     for fname in ("payment_amount", "payment_status", "provider_id"):
+#         field = env["sale.order"]._fields.get(fname)
+#         if field:
+#             ids = list(env.transaction.tocompute.get(field, []))
+#             if ids:
+#                 env.remove_to_compute(field, env["sale.order"].browse(ids))
+#                 _logger.info("Cleared ORM recompute queue for sale.order.%s (%d records)", fname, len(ids))

--- a/deltatech_sale_payment/migrations/18.0.1.2.0/post-migrate.py
+++ b/deltatech_sale_payment/migrations/18.0.1.2.0/post-migrate.py
@@ -5,6 +5,7 @@
 def migrate(cr, version):
     pass
 
+
 # import logging
 #
 # from odoo import SUPERUSER_ID, api

--- a/deltatech_sale_payment/migrations/18.0.1.2.0/pre-migrate.py
+++ b/deltatech_sale_payment/migrations/18.0.1.2.0/pre-migrate.py
@@ -1,0 +1,152 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+# Rulat ÎNAINTE de _auto_init, astfel încât Odoo găsește coloanele deja existente
+# și nu mai pune la coadă un recompute ORM (care ar suprascrie valorile populate aici).
+#
+# Replicăm logica din _compute_payment direct în SQL pentru performanță:
+# - O singură trecere peste toate comenzile (nu 1 query/comandă)
+#
+# Simplificare față de _compute_payment Python:
+# - Nu deducem tranzacțiile post-procesate pe facturi (edge-case rar, se
+#   recompute automat data viitoare când comanda e accesată)
+# - Suma plătită = tranzacții done + plăți reconciliate pe facturi paid/partial
+# - Facturile "in_payment" sunt excluse — plata lor apare deja în done_tx
+
+
+def migrate(cr, version):
+    _logger.info("Migrare payment_amount / payment_status pe sale.order — start")
+
+    # Pasul 0: creăm coloanele dacă nu există, înainte ca _auto_init să ruleze.
+    # Odoo vede coloanele ca existente și nu mai face queue la recompute ORM.
+    cr.execute("""
+        ALTER TABLE sale_order
+            ADD COLUMN IF NOT EXISTS payment_amount  numeric DEFAULT 0.0,
+            ADD COLUMN IF NOT EXISTS payment_status  varchar DEFAULT 'without',
+            ADD COLUMN IF NOT EXISTS provider_id     int4
+    """)
+
+    # Pasul 1: suma plătită din tranzacții done
+    cr.execute("""
+        UPDATE sale_order so
+        SET payment_amount = COALESCE((
+            SELECT SUM(pt.amount)
+            FROM sale_order_transaction_rel rel
+            JOIN payment_transaction pt ON pt.id = rel.transaction_id
+            WHERE rel.sale_order_id = so.id
+              AND pt.state = 'done'
+        ), 0.0)
+    """)
+    _logger.info("payment_amount actualizat din tranzacții done (%d rânduri)", cr.rowcount)
+
+    # Pasul 2: adăugăm suma plătită pe facturile complet reconciliate (paid/partial).
+    # Legătura sale.order → account.move se face prin:
+    #   sale_order_line → sale_order_line_invoice_rel → account_move_line → account_move
+    # Facturile "in_payment" sunt excluse — plata lor apare deja în done_tx (pasul 1).
+    cr.execute("""
+        UPDATE sale_order so
+        SET payment_amount = GREATEST(so.payment_amount + COALESCE((
+            SELECT SUM(sub.paid_amount)
+            FROM (
+                SELECT DISTINCT am.id,
+                       am.amount_total_signed - am.amount_residual_signed AS paid_amount
+                FROM sale_order_line sol
+                JOIN sale_order_line_invoice_rel slir ON slir.order_line_id = sol.id
+                JOIN account_move_line aml ON aml.id = slir.invoice_line_id
+                JOIN account_move am ON am.id = aml.move_id
+                WHERE sol.order_id = so.id
+                  AND am.state = 'posted'
+                  AND am.payment_state IN ('paid', 'partial')
+                  AND am.move_type IN ('out_invoice', 'out_refund')
+                  AND am.amount_total_signed != am.amount_residual_signed
+            ) sub
+        ), 0.0), 0.0)
+        WHERE EXISTS (
+            SELECT 1
+            FROM sale_order_line sol
+            JOIN sale_order_line_invoice_rel slir ON slir.order_line_id = sol.id
+            JOIN account_move_line aml ON aml.id = slir.invoice_line_id
+            JOIN account_move am ON am.id = aml.move_id
+            WHERE sol.order_id = so.id
+              AND am.state = 'posted'
+              AND am.payment_state IN ('paid', 'partial')
+        )
+    """)
+
+    # Pasul 3: calculăm payment_status pe baza payment_amount și stărilor tranzacțiilor
+    cr.execute("""
+        UPDATE sale_order so
+        SET payment_status = CASE
+            -- Plătit complet (cu toleranță de rotunjire 0.01)
+            WHEN so.payment_amount >= so.amount_total - 0.01
+              AND so.payment_amount > 0
+                THEN 'done'
+
+            -- Plătit parțial
+            WHEN so.payment_amount > 0
+                THEN 'partial'
+
+            -- Fără nicio tranzacție
+            WHEN NOT EXISTS (
+                SELECT 1 FROM sale_order_transaction_rel rel
+                WHERE rel.sale_order_id = so.id
+            )
+                THEN 'without'
+
+            -- Autorizat (are prioritate față de pending și cancel)
+            WHEN EXISTS (
+                SELECT 1 FROM sale_order_transaction_rel rel
+                JOIN payment_transaction pt ON pt.id = rel.transaction_id
+                WHERE rel.sale_order_id = so.id AND pt.state = 'authorized'
+            )
+                THEN 'authorized'
+
+            -- Pending
+            WHEN EXISTS (
+                SELECT 1 FROM sale_order_transaction_rel rel
+                JOIN payment_transaction pt ON pt.id = rel.transaction_id
+                WHERE rel.sale_order_id = so.id AND pt.state = 'pending'
+            )
+                THEN 'pending'
+
+            -- Anulat
+            WHEN EXISTS (
+                SELECT 1 FROM sale_order_transaction_rel rel
+                JOIN payment_transaction pt ON pt.id = rel.transaction_id
+                WHERE rel.sale_order_id = so.id AND pt.state = 'cancel'
+            )
+                THEN 'cancelled'
+
+            -- Draft / error
+            ELSE 'initiated'
+        END
+    """)
+    _logger.info("payment_status actualizat (%d rânduri)", cr.rowcount)
+
+    # Pasul 4: populăm provider_id — prioritate: done > authorized > pending > cancel > orice
+    cr.execute("""
+        UPDATE sale_order so
+        SET provider_id = (
+            SELECT pt.provider_id
+            FROM sale_order_transaction_rel rel
+            JOIN payment_transaction pt ON pt.id = rel.transaction_id
+            WHERE rel.sale_order_id = so.id
+            ORDER BY
+                CASE pt.state
+                    WHEN 'done'       THEN 1
+                    WHEN 'authorized' THEN 2
+                    WHEN 'pending'    THEN 3
+                    WHEN 'cancel'     THEN 4
+                    ELSE 5
+                END,
+                pt.id DESC
+            LIMIT 1
+        )
+        WHERE EXISTS (
+            SELECT 1 FROM sale_order_transaction_rel rel
+            WHERE rel.sale_order_id = so.id
+        )
+    """)
+    _logger.info("provider_id actualizat (%d rânduri)", cr.rowcount)
+    _logger.info("Migrare payment_amount / payment_status / provider_id — finalizată")


### PR DESCRIPTION
…ip ORM recompute

Move migration SQL from post-migrate.py to pre-migrate.py and add ADD COLUMN IF NOT EXISTS before the data population. When Odoo's _auto_init finds the columns already present it skips queuing the full ORM recompute, preventing a slow iteration over all sale orders on upgrade.