### PR TITLE
[FIX] website_country, website_city: TypeError on /shop/address

### DIFF
--- a/deltatech_website_city/__manifest__.py
+++ b/deltatech_website_city/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Website City",
     "category": "Website/Website",
     "summary": "City extension",
-    "version": "18.0.1.1.3",
+    "version": "18.0.1.1.4",
     "author": "Terrabit, Dorin Hongu",
     "license": "LGPL-3",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_city/controller/website_sale.py
+++ b/deltatech_website_city/controller/website_sale.py
@@ -35,10 +35,8 @@ class WebsiteSaleCity(WebsiteSale):
             form_data["city"] = request.env["res.city"].sudo().browse(int(city_id)).name
         return super()._parse_form_data(form_data)
 
-    def _prepare_address_form_values(self, order_sudo, partner_sudo, address_type, **kwargs):
-        rendering_values = super()._prepare_address_form_values(
-            order_sudo, partner_sudo, address_type=address_type, **kwargs
-        )
+    def _prepare_address_form_values(self, order_sudo, partner_sudo, *args, **kwargs):
+        rendering_values = super()._prepare_address_form_values(order_sudo, partner_sudo, *args, **kwargs)
         state = request.env["res.country.state"].browse(rendering_values["state_id"])
         city = partner_sudo.city_id
         ResCity = request.env["res.city"].sudo()

--- a/deltatech_website_city/readme/HISTORY.md
+++ b/deltatech_website_city/readme/HISTORY.md
@@ -1,0 +1,3 @@
+## 18.0.1.1.4 (2026-06-10)
+
+- Fix `TypeError` (500 Internal Server Error) on `/shop/address`: `_prepare_address_form_values()` now uses a tolerant `*args, **kwargs` signature, compatible with newer Odoo 18 builds that pass `use_delivery_as_billing` positionally.

--- a/deltatech_website_country/__manifest__.py
+++ b/deltatech_website_country/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Country",
     "category": "Website",
     "summary": "eCommerce extension",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.0.2",
     "author": "Terrabit, Dorin Hongu",
     "license": "LGPL-3",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_country/controllers/main.py
+++ b/deltatech_website_country/controllers/main.py
@@ -7,7 +7,7 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 
 class WebsiteSale(WebsiteSale):
-    def _prepare_address_form_values(self, order_sudo, partner_sudo, address_type, **kwargs):
-        result = super()._prepare_address_form_values(order_sudo, partner_sudo, address_type=address_type, **kwargs)
+    def _prepare_address_form_values(self, order_sudo, partner_sudo, *args, **kwargs):
+        result = super()._prepare_address_form_values(order_sudo, partner_sudo, *args, **kwargs)
         result["country"] = result.get("country") or request.website.company_id.country_id
         return result

--- a/deltatech_website_country/readme/HISTORY.md
+++ b/deltatech_website_country/readme/HISTORY.md
@@ -1,0 +1,3 @@
+## 18.0.1.0.2 (2026-06-10)
+
+- Fix `TypeError` (500 Internal Server Error) on `/shop/address`: `_prepare_address_form_values()` now uses a tolerant `*args, **kwargs` signature, compatible with newer Odoo 18 builds that pass `use_delivery_as_billing` positionally.


### PR DESCRIPTION
## Problem

On newer Odoo 18 builds, `/shop/address` fails with **500 Internal Server Error**:

```
TypeError: WebsiteSaleCity._prepare_address_form_values() takes 4 positional arguments but 5 were given
```

The core `website_sale` controller now passes `use_delivery_as_billing` as a separate positional argument to `_prepare_address_form_values()`, while the overrides in `deltatech_website_country` and `deltatech_website_city` still used the old `(order_sudo, partner_sudo, address_type, **kwargs)` signature.

## Fix

Use a tolerant `(order_sudo, partner_sudo, *args, **kwargs)` signature and pass everything through to `super()` — the same pattern Odoo uses in its own l10n website_sale modules (e.g. `l10n_br_website_sale`). Neither override actually uses `address_type` in its body, so no functionality is lost and the modules stay compatible with both older (keyword) and newer (positional) call conventions.

- `deltatech_website_country` → 18.0.1.0.2
- `deltatech_website_city` → 18.0.1.1.4
- added `readme/HISTORY.md` to both modules

## Testing

- `-u deltatech_website_country,deltatech_website_city` runs clean on a local 18.0 database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)