### PR TITLE
[FIX] deltatech_delivery_status: release postponed delivery on payment

### DIFF
--- a/deltatech_delivery_status/__manifest__.py
+++ b/deltatech_delivery_status/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech Delivery Status",
     "summary": "Carrier status on picking",
-    "version": "18.0.2.1.3",
+    "version": "18.0.2.1.4",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "support": "support@terrabit.ro",

--- a/deltatech_delivery_status/models/payment_transaction.py
+++ b/deltatech_delivery_status/models/payment_transaction.py
@@ -15,8 +15,12 @@ class PaymentTransaction(models.Model):
         txs_to_process = super()._set_done(state_message=state_message, extra_allowed_states=extra_allowed_states)
         for tx in txs_to_process:
             if tx.provider_id.postponed_delivery:
-                sale_order = tx.sale_order_id
-                if sale_order and sale_order.postponed_delivery:
-                    sale_order.release_delivery()
+                sale_orders = tx.sale_order_ids.filtered("postponed_delivery")
+                for sale_order in sale_orders:
+                    # a failure to release the delivery must not block the payment processing
+                    try:
+                        sale_order.release_delivery()
+                    except Exception:
+                        _logger.exception("Failed to release postponed delivery for order %s", sale_order.name)
 
         return txs_to_process

--- a/deltatech_delivery_status/models/sale.py
+++ b/deltatech_delivery_status/models/sale.py
@@ -2,7 +2,7 @@
 # See README.rst file on addons root folder for license details
 
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class SaleOrder(models.Model):
@@ -29,9 +29,10 @@ class SaleOrder(models.Model):
             pickings |= order.picking_ids
         pickings.write({"postponed": False})
 
+    @api.depends("picking_ids.postponed")
     def _compute_postponed_delivery(self):
         for order in self:
-            order.postponed_delivery = any([p.postponed for p in order.picking_ids])
+            order.postponed_delivery = any(p.postponed for p in order.picking_ids)
 
     def _action_confirm(self):
         res = super()._action_confirm()

--- a/deltatech_delivery_status/readme/HISTORY.md
+++ b/deltatech_delivery_status/readme/HISTORY.md
@@ -1,0 +1,13 @@
+## 18.0.2.1.4 (2026-06-11)
+
+- Fix: releasing a postponed delivery when the payment is confirmed never
+  worked — `_set_done` accessed the non-existent field
+  `payment.transaction.sale_order_id` (the correct field is
+  `sale_order_ids`), raising AttributeError for providers with
+  *Postponed Delivery* enabled. All linked postponed orders are now
+  released, and a failure to release no longer blocks the payment
+  processing (logged instead).
+- Added `@api.depends("picking_ids.postponed")` on
+  `_compute_postponed_delivery` so the value is recomputed within the same
+  transaction after postpone/release.
+- Added tests for the postpone/release flow and the payment-driven release.

--- a/deltatech_delivery_status/tests/test_sale.py
+++ b/deltatech_delivery_status/tests/test_sale.py
@@ -50,3 +50,48 @@ class TestSale(TransactionCase):
 
         self.so.postpone_delivery()
         self.so.release_delivery()
+
+    def _create_confirmed_order(self):
+        order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "order_line": [(0, 0, {"product_id": self.product_a.id, "product_uom_qty": 10})],
+            }
+        )
+        order.action_confirm()
+        return order
+
+    def test_postponed_delivery_recompute(self):
+        order = self._create_confirmed_order()
+        self.assertFalse(order.postponed_delivery)
+
+        order.postpone_delivery()
+        self.assertTrue(order.postponed_delivery)
+
+        order.release_delivery()
+        self.assertFalse(order.postponed_delivery)
+
+    def test_release_delivery_on_payment_done(self):
+        provider = self.env["payment.provider"].create(
+            {
+                "name": "Test Provider",
+                "code": "none",
+                "postponed_delivery": True,
+            }
+        )
+        order = self._create_confirmed_order()
+        order.postpone_delivery()
+        self.assertTrue(order.postponed_delivery)
+
+        tx = self.env["payment.transaction"].create(
+            {
+                "provider_id": provider.id,
+                "payment_method_id": self.env.ref("payment.payment_method_unknown").id,
+                "amount": order.amount_total,
+                "currency_id": order.currency_id.id,
+                "partner_id": self.partner_a.id,
+                "sale_order_ids": [(6, 0, order.ids)],
+            }
+        )
+        tx._set_done()
+        self.assertFalse(order.postponed_delivery)


### PR DESCRIPTION
## Summary

- **Fix a bug that made payment-driven delivery release dead code**: the `_set_done` override read `payment.transaction.sale_order_id`, a field that does not exist (the standard field is the many2many `sale_order_ids`). Any transaction confirmed on a provider with *Postponed Delivery* enabled raised `AttributeError`, so postponed deliveries were never auto-released on payment. Now all linked postponed orders are released, and a release failure is logged instead of blocking the payment processing.
- Added the missing `@api.depends("picking_ids.postponed")` on `_compute_postponed_delivery`, so the computed value is fresh within the same transaction after `postpone_delivery()` / `release_delivery()` — `_set_done` reads it right after.
- Version bump to 18.0.2.1.4 + `readme/HISTORY.md`.

## Test plan

- New tests: `test_postponed_delivery_recompute` (postpone/release recompute) and `test_release_delivery_on_payment_done` (transaction `_set_done` on a postponed-delivery provider releases the order).
- Ran locally: `--test-tags=/deltatech_delivery_status` → 5 tests, 0 failed, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)