### PR TITLE
[FIX] deltatech_sale_currency: convert invoice lines on company currency fallback

### DIFF
--- a/deltatech_sale_currency/models/sale.py
+++ b/deltatech_sale_currency/models/sale.py
@@ -26,10 +26,9 @@ class SaleOrderLine(models.Model):
 
         if res.get("display_type") == "product":
             company = self.order_id.company_id
-            journal = self.order_id.journal_id
-            if journal:
-                to_currency = journal.currency_id or company.currency_id
-                from_currency = self.order_id.pricelist_id.currency_id
+            to_currency = self.order_id.journal_id.currency_id or company.currency_id
+            from_currency = self.order_id.pricelist_id.currency_id
+            if from_currency and to_currency and from_currency != to_currency:
                 date_eval = fields.Date.context_today(self)
                 price_unit = from_currency._convert(res["price_unit"], to_currency, company, date_eval)
                 res["price_unit"] = price_unit

--- a/deltatech_sale_currency/tests/test_sale_currency.py
+++ b/deltatech_sale_currency/tests/test_sale_currency.py
@@ -14,6 +14,23 @@ class TestSaleCurrency(common.TransactionCase):
         cls.company = cls.env.company
         cls.currency_eur = cls.env.ref("base.EUR")
         cls.currency_usd = cls.env.ref("base.USD")
+        cls.income_account = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", cls.company.id),
+                ("account_type", "=", "income"),
+                ("deprecated", "=", False),
+            ],
+            limit=1,
+        )
+        if not cls.income_account:
+            cls.income_account = cls.env["account.account"].create(
+                {
+                    "name": "Test Income",
+                    "code": "XSALE",
+                    "account_type": "income",
+                    "company_ids": [(6, 0, [cls.company.id])],
+                }
+            )
 
         # Create a pricelist in USD
         cls.pricelist_usd = cls.env["product.pricelist"].create(
@@ -29,6 +46,7 @@ class TestSaleCurrency(common.TransactionCase):
                 "name": "Test Product",
                 "type": "consu",
                 "list_price": 100.0,
+                "property_account_income_id": cls.income_account.id,
             }
         )
 
@@ -102,5 +120,43 @@ class TestSaleCurrency(common.TransactionCase):
         from_currency = sale_order.pricelist_id.currency_id
         to_currency = invoice.currency_id
         expected_price = from_currency._convert(so_line.price_unit, to_currency, self.company, fields.Date.today())
+
+        self.assertAlmostEqual(inv_line.price_unit, expected_price)
+
+    def test_02_sale_to_invoice_company_currency_fallback(self):
+        sale_order = self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "pricelist_id": self.pricelist_usd.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": 100.0,
+                        },
+                    )
+                ],
+            }
+        )
+
+        if "journal_id" in sale_order._fields:
+            sale_order.journal_id = False
+
+        sale_order.action_confirm()
+        invoice = sale_order._create_invoices()
+
+        self.assertEqual(invoice.currency_id, self.company.currency_id)
+
+        so_line = sale_order.order_line[0]
+        inv_line = invoice.invoice_line_ids.filtered(lambda l: l.display_type == "product")
+        expected_price = self.pricelist_usd.currency_id._convert(
+            so_line.price_unit,
+            self.company.currency_id,
+            self.company,
+            fields.Date.today(),
+        )
 
         self.assertAlmostEqual(inv_line.price_unit, expected_price)

--- a/deltatech_sale_currency/tests/test_sale_currency.py
+++ b/deltatech_sale_currency/tests/test_sale_currency.py
@@ -18,7 +18,6 @@ class TestSaleCurrency(common.TransactionCase):
             [
                 ("company_ids", "in", cls.company.id),
                 ("account_type", "=", "income"),
-                ("deprecated", "=", False),
             ],
             limit=1,
         )
@@ -28,6 +27,40 @@ class TestSaleCurrency(common.TransactionCase):
                     "name": "Test Income",
                     "code": "XSALE",
                     "account_type": "income",
+                    "company_ids": [(6, 0, [cls.company.id])],
+                }
+            )
+        cls.receivable_account = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", cls.company.id),
+                ("account_type", "=", "asset_receivable"),
+            ],
+            limit=1,
+        )
+        if not cls.receivable_account:
+            cls.receivable_account = cls.env["account.account"].create(
+                {
+                    "name": "Test Receivable",
+                    "code": "XREC",
+                    "account_type": "asset_receivable",
+                    "reconcile": True,
+                    "company_ids": [(6, 0, [cls.company.id])],
+                }
+            )
+        cls.payable_account = cls.env["account.account"].search(
+            [
+                ("company_ids", "in", cls.company.id),
+                ("account_type", "=", "liability_payable"),
+            ],
+            limit=1,
+        )
+        if not cls.payable_account:
+            cls.payable_account = cls.env["account.account"].create(
+                {
+                    "name": "Test Payable",
+                    "code": "XPAY",
+                    "account_type": "liability_payable",
+                    "reconcile": True,
                     "company_ids": [(6, 0, [cls.company.id])],
                 }
             )
@@ -54,6 +87,8 @@ class TestSaleCurrency(common.TransactionCase):
         cls.partner = cls.env["res.partner"].create(
             {
                 "name": "Test Partner",
+                "property_account_receivable_id": cls.receivable_account.id,
+                "property_account_payable_id": cls.payable_account.id,
             }
         )
 


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in `deltatech_sale_currency` when creating
an invoice from a sales order in a foreign currency.

The invoice header currency was already computed with:

```python
self.journal_id.currency_id or self.company_id.currency_id
```

but invoice line conversion in `_prepare_invoice_line()` only ran when
`sale.order.journal_id` was explicitly set.

Because of that, when the sales order journal was empty and the invoice
currency fell back to the company currency, the generated invoice got
the correct `currency_id` but the invoice lines kept the original
`price_unit` values from the sales order currency.

## Observed behavior

Example:
- sales order pricelist in `EUR`
- company currency in `RON`
- `sale.order.journal_id` is empty

Current behavior before this fix:
- invoice is created in `RON`
- invoice lines still keep `price_unit` from `EUR`
- manually changing the invoice currency and switching it back triggers
  the onchange and recomputes line prices correctly

This means the issue happens specifically in the `Create Invoice` flow,
where onchange logic is not executed.

## Fix

The journal-only guard was removed from `_prepare_invoice_line()` so
invoice lines always convert toward the same target currency as the
invoice header, including the fallback to the company currency.

## Tests

This PR also improves the test setup by assigning a valid income account
to the test product so invoice creation works reliably in test
environments, and adds coverage for the fallback-to-company-currency
scenario.

## Result

Invoice currency and invoice line prices now stay aligned both when:
- a sales journal currency is explicitly set
- the invoice currency falls back to the company currency
- tests pass on odoo.sh
