### PR TITLE
[FIX] deltatech_business_process: sync schema area_id (crash autovacuum)

### DIFF
--- a/deltatech_business_process/__manifest__.py
+++ b/deltatech_business_process/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Business process",
     "summary": "Business process",
-    "version": "19.0.1.5.0",
+    "version": "19.0.1.5.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",


### PR DESCRIPTION
## Problemă

Pe producție (odoo.sh, `terrabit-erp`) cron-ul de autovacuum cădea zilnic:

```
ERROR ... column business_process_library_import_line.area_id does not exist
... Failed business.process.library.import.line()._transient_vacuum()
```

## Cauză

Câmpul `area` (Char) al modelului tranzient `business.process.library.import.line` a fost schimbat în `area_id` (Many2one), iar `_order` a devenit `"area_id, code"` — dar commit-ul respectiv **nu a bumpat versiunea din manifest**. Pe odoo.sh modulul se actualizează doar la creșterea versiunii, deci schema tabelei tranziente nu s-a sincronizat: codul cere `area_id`, iar tabela are încă vechea coloană `area`. Autovacuum-ul rulează `search(order="area_id, code")` și pică.

## Fix

Bump `19.0.1.5.0` → `19.0.1.5.1`, ca să forțeze `-u deltatech_business_process` la următorul deploy. Update-ul adaugă coloana `area_id` și reimportă view-urile.

## Note

- Singurul model afectat de redenumire e cel **tranzient** → fără date persistente de migrat.
- Modelele persistente (`business.process`, `business.issue`, …) au avut `area_id` Many2one dintotdeauna → fără script de migrare.
- View-urile și `ir.model.access.csv` foloseau deja consecvent `area_id`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)