### PR TITLE
[CI] Elimină environment manual-approval din workflow-uri

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -12,7 +12,6 @@ on:
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
-    environment: manual-approval
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,6 @@ on:
 jobs:
   unreleased-deps:
     runs-on: ubuntu-latest
-    environment: manual-approval
     name: Detect unreleased dependencies
     steps:
       - uses: actions/checkout@v4
@@ -31,7 +30,6 @@ jobs:
           done
   test:
     runs-on: ubuntu-22.04
-    environment: manual-approval
     container: ${{ matrix.container }}
     name: ${{ matrix.name }}
     strategy:


### PR DESCRIPTION
Elimină cheia `environment: manual-approval` din job-urile workflow-urilor:

- `pre-commit.yml` — job `pre-commit`
- `test.yml` — job-urile `unreleased-deps` și `test`

Astfel CI rulează automat la push/PR pe `19.0`, fără să mai aștepte aprobare manuală pe environment.

> Notă: environment-ul `manual-approval` rămâne definit în Settings → Environments (acum nereferențiat). Poate fi șters separat dacă nu mai e folosit de alte workflow-uri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)