### PR TITLE
[IMP] deltatech_contact: bump version to 19.0.1.4.8

### DIFF
--- a/deltatech_contact/__manifest__.py
+++ b/deltatech_contact/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Deltatech Contacts",
     "summary": "New fields in partner",
-    "version": "19.0.1.4.7",
+    "version": "19.0.1.4.8",
     "author": "Terrabit,Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Administration",


### PR DESCRIPTION
## Summary
- Aliniază versiunea modulului `deltatech_contact` pe branch-ul `19.0` cu branch-ul `18.0`
- Pe 18.0, restructurarea tab-ului „Personal Data" (commit `b314663e2`) a dus versiunea la `1.4.8`
- Pe 19.0 aceeași modificare fusese portată anterior fără bump de versiune

## Test plan
- [ ] Verificat că pre-commit trece (hooks: pylint, ruff, checks modules)
- [ ] Nicio schimbare funcțională — doar bump versiune în `__manifest__.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)