### PR TITLE
[ADD] deltatech_product_dimension: add HISTORY.md noting 19.0 alignment

### DIFF
--- a/deltatech_product_dimension/readme/HISTORY.md
+++ b/deltatech_product_dimension/readme/HISTORY.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## [19.0.1.0.0] - 2026-06-15
+
+### Changed
+- Ported to Odoo 19.0. Fully aligned with 18.0: fields `product_length`, `product_width`, `product_height`, `_onchange_dimension`, views, tests, and i18n/ro.po are all present and equivalent.


### PR DESCRIPTION
## Summary

- Adaugă `readme/HISTORY.md` pentru modulul `deltatech_product_dimension`
- Documentează că modulul este complet aliniat cu versiunea 18.0 (câmpuri, view-uri, teste, i18n/ro.po)
- Urmează convenția din suită (format `# Changelog` cu secțiuni `## [versiune] - data`)

## Test plan

- [ ] Verificat drift 18→19: 0 goluri funcționale reale

🤖 Generated with [Claude Code](https://claude.com/claude-code)