### PR TITLE
[IMP/FIX] deltatech_purchase_price: port 6 gaps from 18.0 (v19.0.1.2.6)

### DIFF
--- a/deltatech_purchase_price/__manifest__.py
+++ b/deltatech_purchase_price/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Purchase Price",
     "summary": "Update vendor price after reception",
-    "version": "19.0.1.2.5",
+    "version": "19.0.1.2.6",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_purchase_price/migrations/19.0.1.2.6/pre-migration.py
+++ b/deltatech_purchase_price/migrations/19.0.1.2.6/pre-migration.py
@@ -1,0 +1,42 @@
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Copy last_purchase_price from product_template to product_product (company_dependent jsonb).
+
+    Previously the field lived on product_template as a plain float.
+    Now it lives on product_product as company_dependent (jsonb column).
+    Copy data for templates with a single variant so no price is lost.
+    """
+    # Drop stale column on product_template — Odoo will recreate it as computed (no store)
+    cr.execute(
+        """
+        SELECT column_name
+        FROM information_schema.columns
+        WHERE table_name = 'product_template'
+          AND column_name = 'last_purchase_price'
+        """
+    )
+    if cr.fetchone():
+        # Copy value to single-variant products before dropping
+        cr.execute(
+            """
+            UPDATE product_product pp
+               SET last_purchase_price = pt.last_purchase_price
+              FROM product_template pt
+             WHERE pp.product_tmpl_id = pt.id
+               AND pt.last_purchase_price IS NOT NULL
+               AND pt.last_purchase_price != 0
+               AND (
+                   SELECT COUNT(*) FROM product_product pp2
+                    WHERE pp2.product_tmpl_id = pt.id
+                      AND pp2.active = TRUE
+               ) = 1
+            """
+        )
+        rows = cr.rowcount
+        _logger.info("deltatech_purchase_price migration: copied last_purchase_price to %d product_product rows", rows)
+        cr.execute("ALTER TABLE product_template DROP COLUMN IF EXISTS last_purchase_price")
+        _logger.info("deltatech_purchase_price migration: dropped last_purchase_price from product_template")

--- a/deltatech_purchase_price/migrations/19.0.1.2.6/pre-migration.py
+++ b/deltatech_purchase_price/migrations/19.0.1.2.6/pre-migration.py
@@ -3,24 +3,69 @@ import logging
 _logger = logging.getLogger(__name__)
 
 
-def migrate(cr, version):
-    """Copy last_purchase_price from product_template to product_product (company_dependent jsonb).
-
-    Previously the field lived on product_template as a plain float.
-    Now it lives on product_product as company_dependent (jsonb column).
-    Copy data for templates with a single variant so no price is lost.
-    """
-    # Drop stale column on product_template — Odoo will recreate it as computed (no store)
+def _col_type(cr, table, column):
     cr.execute(
         """
-        SELECT column_name
-        FROM information_schema.columns
-        WHERE table_name = 'product_template'
-          AND column_name = 'last_purchase_price'
-        """
+        SELECT data_type FROM information_schema.columns
+         WHERE table_name = %s AND column_name = %s
+        """,
+        (table, column),
     )
-    if cr.fetchone():
-        # Copy value to single-variant products before dropping
+    row = cr.fetchone()
+    return row[0] if row else None
+
+
+def migrate(cr, version):
+    """Migrate last_purchase_price: product_template (float) → product_product (company_dependent jsonb).
+
+    Steps:
+    1. If product_product.last_purchase_price already exists as plain float,
+       convert it to company_dependent jsonb via util or SQL fallback.
+    2. If product_template.last_purchase_price is a plain float,
+       copy to product_product (for single-variant products), then drop from template.
+    Odoo will create product_product.last_purchase_price as jsonb automatically
+    if the column does not exist yet.
+    """
+    try:
+        from odoo.upgrade import util
+    except ImportError:
+        util = None
+
+    cr.execute("SELECT array_agg(id) FROM res_company")
+    company_ids = cr.fetchone()[0] or []
+
+    # --- Step 1: convert product_product.last_purchase_price float → jsonb if present ---
+    pp_type = _col_type(cr, "product_product", "last_purchase_price")
+    if pp_type and pp_type != "jsonb":
+        _logger.info(
+            "deltatech_purchase_price: converting product_product.last_purchase_price float → company_dependent jsonb"
+        )
+        if util is not None:
+            util.make_field_company_dependent(cr, "product.product", "last_purchase_price", "float")
+        else:
+            _logger.info("odoo.upgrade.util not available, using SQL fallback")
+            cr.execute(
+                'ALTER TABLE product_product RENAME COLUMN "last_purchase_price" TO "last_purchase_price_old_tmp"'
+            )
+            cr.execute('ALTER TABLE product_product ADD COLUMN "last_purchase_price" jsonb')
+            for company_id in company_ids:
+                cr.execute(
+                    """
+                    UPDATE product_product
+                       SET last_purchase_price = COALESCE(last_purchase_price, '{}'::jsonb)
+                                                 || jsonb_build_object(%s, last_purchase_price_old_tmp)
+                     WHERE last_purchase_price_old_tmp IS NOT NULL
+                       AND last_purchase_price_old_tmp != 0
+                    """,
+                    (str(company_id),),
+                )
+            cr.execute('ALTER TABLE product_product DROP COLUMN "last_purchase_price_old_tmp"')
+
+    # --- Step 2: copy template values to product_product, then drop template column ---
+    pt_type = _col_type(cr, "product_template", "last_purchase_price")
+    if pt_type and pt_type != "jsonb":
+        _logger.info("deltatech_purchase_price: copying last_purchase_price from product_template to product_product")
+        # Copy to single-variant products only; multi-variant products keep 0 (no safe default)
         cr.execute(
             """
             UPDATE product_product pp
@@ -31,12 +76,10 @@ def migrate(cr, version):
                AND pt.last_purchase_price != 0
                AND (
                    SELECT COUNT(*) FROM product_product pp2
-                    WHERE pp2.product_tmpl_id = pt.id
-                      AND pp2.active = TRUE
+                    WHERE pp2.product_tmpl_id = pt.id AND pp2.active = TRUE
                ) = 1
             """
         )
-        rows = cr.rowcount
-        _logger.info("deltatech_purchase_price migration: copied last_purchase_price to %d product_product rows", rows)
+        _logger.info("deltatech_purchase_price: copied %d rows", cr.rowcount)
         cr.execute("ALTER TABLE product_template DROP COLUMN IF EXISTS last_purchase_price")
-        _logger.info("deltatech_purchase_price migration: dropped last_purchase_price from product_template")
+        _logger.info("deltatech_purchase_price: dropped last_purchase_price from product_template")

--- a/deltatech_purchase_price/models/product.py
+++ b/deltatech_purchase_price/models/product.py
@@ -11,6 +11,7 @@ class ProductProduct(models.Model):
     _inherit = "product.product"
 
     standard_price = fields.Float(tracking=True)
+    last_purchase_price = fields.Float(digits="Product Price", tracking=True, company_dependent=True)
 
     @api.onchange("last_purchase_price", "trade_markup")
     def onchange_last_purchase_price(self):
@@ -22,7 +23,24 @@ class ProductTemplate(models.Model):
 
     standard_price = fields.Float(tracking=True)
     list_price = fields.Float(tracking=True)
-    last_purchase_price = fields.Float(digits="Product Price", tracking=True)
+    last_purchase_price = fields.Float(
+        digits="Product Price",
+        compute="_compute_last_purchase_price",
+        inverse="_inverse_last_purchase_price",
+        search="_search_last_purchase_price",
+        tracking=True,
+        company_dependent=True,
+    )
+
+    @api.depends_context("company")
+    def _compute_last_purchase_price(self):
+        self._compute_template_field_from_variant_field("last_purchase_price")
+
+    def _inverse_last_purchase_price(self):
+        self._set_product_variant_field("last_purchase_price")
+
+    def _search_last_purchase_price(self, operator, value):
+        return [("product_variant_ids.last_purchase_price", operator, value)]
 
     @api.onchange("list_price")
     def onchange_list_price(self):
@@ -61,12 +79,10 @@ class ProductTemplate(models.Model):
                         trade_markup = (list_price - product.last_purchase_price) / product.last_purchase_price * 100
                         product.trade_markup = trade_markup
                 list_price = product.last_purchase_price * (1 + product.trade_markup / 100)
-                list_price_tax = 0
                 if any(tax.price_include for tax in product.taxes_id):
-                    list_price_tax = product.taxes_id.with_context(force_price_include=False)._compute_amount(
-                        list_price, 1
-                    )
-                list_price = list_price + list_price_tax
+                    list_price = product.taxes_id.compute_all(list_price, quantity=1, handle_price_include=False)[
+                        "total_included"
+                    ]
 
                 list_price = currency._convert(list_price, product.currency_id, company, date)
                 list_price_round = safe_eval(get_param("sale.list_price_round", "2"))
@@ -87,21 +103,27 @@ class SupplierInfo(models.Model):
                 )
             price = from_uom._compute_price(item.price, to_uom)
 
+            company = item.company_id or self.env.company
             if item.currency_id:
-                to_currency = self.env.user.company_id.currency_id
-                company = self.env.user.company_id
+                to_currency = company.currency_id
                 price = item.currency_id._convert(price, to_currency, company, date)
             if price:
-                item.product_tmpl_id.last_purchase_price = price
-                item.product_tmpl_id.onchange_last_purchase_price()
+                if item.product_id:
+                    item.product_id.with_company(company).last_purchase_price = price
+                    item.product_id.with_company(company).onchange_last_purchase_price()
+                else:
+                    item.product_tmpl_id.with_company(company).last_purchase_price = price
+                    item.product_tmpl_id.with_company(company).onchange_last_purchase_price()
 
     def write(self, vals):
         res = super().write(vals)
         if "price" in vals:
-            self.update_last_purchase_price()
+            if not self.env.context.get("from_po_confirmation"):
+                self.update_last_purchase_price()
         return res
 
     def create(self, vals_list):
         res = super().create(vals_list)
-        res.update_last_purchase_price()
+        if not self.env.context.get("from_po_confirmation"):
+            res.update_last_purchase_price()
         return res

--- a/deltatech_purchase_price/models/purchase.py
+++ b/deltatech_purchase_price/models/purchase.py
@@ -17,6 +17,7 @@ class PurchaseOrder(models.Model):
             return super()._add_supplier_to_product()
 
     def button_confirm(self):
+        self = self.with_context(from_po_confirmation=True)
         res = super().button_confirm()
         get_param = self.env["ir.config_parameter"].sudo().get_param
         force_price = safe_eval(get_param("purchase.force_price_at_validation", "False"))

--- a/deltatech_purchase_price/models/stock_account.py
+++ b/deltatech_purchase_price/models/stock_account.py
@@ -21,18 +21,20 @@ class StockMove(models.Model):
             update_standard_price = get_param("purchase.update_standard_price", default="False")
             update_standard_price = safe_eval(update_standard_price)
 
+            company = self.company_id
             price_unit = self.purchase_line_id.with_context(date=self.date)._get_stock_move_price_unit()
-            self.product_id.write({"last_purchase_price": price_unit})
+            self.product_id.with_company(company).write({"last_purchase_price": price_unit})
             self.write({"price_unit": price_unit})  # mai trebuie sa pun o conditie de status ?
             # update price form last receipt
-            from_currency = self.env.user.company_id.currency_id
-            company = self.env.user.company_id
+            from_currency = company.currency_id
             seller_ids = self.product_id.seller_ids or self.product_id.product_tmpl_id.seller_ids
             for seller in seller_ids:
-                if seller.partner_id == self.purchase_line_id.order_id.partner_id.commercial_partner_id:
+                if seller.partner_id == self.purchase_line_id.order_id.partner_id.commercial_partner_id and (
+                    seller.product_id == self.product_id or not seller.product_id
+                ):
                     if seller.min_qty <= 1.0 and seller.date_start is False and seller.date_end is False:
                         # conversia ar trebui deja sa fie facuta de _get_stock_move_price_unit()
-                        to_currency = seller.currency_id or self.env.user.company_id.currency_id
+                        to_currency = seller.currency_id or company.currency_id
                         seller_price_unit = from_currency._convert(
                             price_unit,
                             to_currency,
@@ -44,7 +46,7 @@ class StockMove(models.Model):
                             seller.write({"price": seller_price_unit})
 
             if update_list_price:
-                self.product_id.product_tmpl_id.onchange_last_purchase_price()
+                self.product_id.product_tmpl_id.with_company(company).onchange_last_purchase_price()
 
             # pretul standard se actualizeaza prin rutinele standard. Aici este o fortare pe ultimul pret
             if update_standard_price:

--- a/deltatech_purchase_price/views/product_view.xml
+++ b/deltatech_purchase_price/views/product_view.xml
@@ -6,6 +6,33 @@
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
             <field name="categ_id" position="before">
+                <field
+                    name="last_purchase_price"
+                    groups="base.group_user"
+                    decoration-success="last_purchase_price &lt;= standard_price"
+                    decoration-danger="last_purchase_price &gt; standard_price"
+                />
+            </field>
+        </field>
+    </record>
+
+    <record id="product_product_tree_view" model="ir.ui.view">
+        <field name="name">product.product.tree</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_product_tree_view" />
+        <field name="arch" type="xml">
+            <field name="standard_price" position="after">
+                <field name="last_purchase_price" optional="show" />
+            </field>
+        </field>
+    </record>
+
+    <record id="product_variant_easy_edit_view" model="ir.ui.view">
+        <field name="name">product.product.view.form.easy</field>
+        <field name="model">product.product</field>
+        <field name="inherit_id" ref="product.product_variant_easy_edit_view" />
+        <field name="arch" type="xml">
+            <field name="standard_price" position="after">
                 <field name="last_purchase_price" />
             </field>
         </field>


### PR DESCRIPTION
## Summary

Port complet al 6 goluri identificate față de 18.0:

**G1+G2 — Arhitectural: `last_purchase_price` pe variantă + `company_dependent`**
- Câmpul mutat pe `ProductProduct` cu `company_dependent=True` (izolare multi-companie)
- `ProductTemplate.last_purchase_price` devine computed prin `_compute_template_field_from_variant_field`
- `SupplierInfo.update_last_purchase_price` folosește `with_company()` și gestionează separat `product_id` vs `product_tmpl_id`

**G3 — Fix calcul `list_price` cu TVA inclusă**
- Înlocuiește `_compute_amount + sum manual` cu `compute_all(handle_price_include=False)["total_included"]`

**G4 — Fix filtrul seller la recepție multi-variantă**
- Adaugă `(seller.product_id == self.product_id or not seller.product_id)`
- Folosește `self.company_id` + `with_company()` la write

**G5 — Context `from_po_confirmation` în `button_confirm`**
- Previne actualizarea prematură a prețului la confirmare PO (actualizare corectă doar la recepție)

**G6 — Fix views**
- `groups="base.group_user"` pe câmpul din form template
- Adaugă tree view `product.product` cu coloana `last_purchase_price`
- Adaugă variant easy edit view

**Migration `19.0.1.2.6`**
- Copiază datele existente din `product_template.last_purchase_price` → `product_product` (produse cu variantă unică)
- Drop coloana stale de pe `product_template`

## Test plan

- [ ] Recepție PO cu produs simplu → `last_purchase_price` actualizat pe variantă, izolat per companie
- [ ] Recepție PO cu produs multi-variantă → prețul merge pe varianta corectă, nu pe alte variante
- [ ] Confirmare PO → prețul NU se actualizează prematur (doar la recepție)
- [ ] `onchange_last_purchase_price` cu taxă `price_include` → `list_price` calculat corect
- [ ] Multi-companie: prețul ultimei achiziții diferit per companie

🤖 Generated with [Claude Code](https://claude.com/claude-code)