### PR TITLE
[deltatech_sale_stage] revert phase_ids — use many2one_badge on phase_id

### DIFF
--- a/deltatech_sale_stage/__manifest__.py
+++ b/deltatech_sale_stage/__manifest__.py
@@ -5,13 +5,13 @@
 
 {
     "name": "Deltatech Sale Order Stage",
-    "version": "19.0.1.2.4",
+    "version": "19.0.1.2.5",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",
     "summary": "Sale Order Stage",
     "category": "Sales",
-    "depends": ["sale_stock"],
+    "depends": ["sale_stock", "deltatech_widget_many2one_badge"],
     "data": [
         "security/ir.model.access.csv",
         "views/sale_view.xml",

--- a/deltatech_sale_stage/models/sale.py
+++ b/deltatech_sale_stage/models/sale.py
@@ -11,22 +11,6 @@ class SaleOrder(models.Model):
     _inherit = "sale.order"
 
     phase_id = fields.Many2one("sale.order.phase", string="Phase", copy=False, tracking=True)
-    phase_ids = fields.Many2many(
-        "sale.order.phase",
-        string="Phases",
-        readonly=False,
-        compute="_compute_phase_ids",
-        inverse="_inverse_phase_ids",
-    )
-
-    @api.depends("phase_id")
-    def _compute_phase_ids(self):
-        for order in self:
-            order.phase_ids = order.phase_id
-
-    def _inverse_phase_ids(self):
-        for order in self:
-            order.phase_id = order.phase_ids[0] if order.phase_ids else False
 
     def _get_invoice_status(self):
         res = super()._get_invoice_status()

--- a/deltatech_sale_stage/tests/test_sale_phase.py
+++ b/deltatech_sale_stage/tests/test_sale_phase.py
@@ -112,20 +112,3 @@ class TestSaleOrder(common.TransactionCase):
 
         self.sale_order.action_quotation_sent()
         self.assertEqual(self.sale_order.phase_id.send_email, True)
-
-    def test_compute_phase_ids(self):
-        # Test the _compute_phase_ids method
-        self.sale_order._compute_phase_ids()
-        self.assertEqual(self.sale_order.phase_ids, self.sale_order.phase_id)
-
-    def test_inverse_phase_ids(self):
-        # Test the _inverse_phase_ids method
-        new_phase = self.env["sale.order.phase"].create(
-            {
-                "name": "New phase",
-                "sequence": 2,
-            }
-        )
-        self.sale_order.phase_ids = new_phase
-        self.sale_order._inverse_phase_ids()
-        self.assertEqual(self.sale_order.phase_id, new_phase)

--- a/deltatech_sale_stage/views/sale_view.xml
+++ b/deltatech_sale_stage/views/sale_view.xml
@@ -75,8 +75,7 @@
             <field name="inherit_id" ref="sale.view_order_tree" />
             <field name="arch" type="xml">
                 <field name="partner_id" position="after">
-                    <field name="phase_id" column_invisible="1" />
-                    <field name="phase_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
+                    <field name="phase_id" widget="many2one_badge" options="{'color_field': 'color'}" />
                 </field>
 
             </field>
@@ -93,8 +92,7 @@
                     <field name="date_order" widget="date" optional="show" />
                 </field>
                 <field name="state" position="after">
-<!--                     <field name="phase_id" options="{'color_field': 'color'}" />-->
-                    <field name="phase_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
+                    <field name="phase_id" widget="many2one_badge" options="{'color_field': 'color'}" />
                 </field>
 
             </field>
@@ -110,8 +108,7 @@
             <field name="inherit_id" ref="sale.view_order_form" />
             <field name="arch" type="xml">
                 <xpath expr="//sheet/group/group" position="inside">
-<!--                    <field name="phase_id" options="{'color_field': 'color'}" />-->
-                    <field name="phase_ids" widget="many2many_tags" options="{'color_field': 'color'}" />
+                    <field name="phase_id" widget="many2one_badge" options="{'color_field': 'color'}" />
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
## Summary

- Revert workaround `phase_ids` Many2many introdus în 19.0; revenim la `phase_id` Many2one cu `widget="many2one_badge"` (comportamentul din 18.0).
- Adăugat `deltatech_widget_many2one_badge` în `depends`.
- Eliminat câmpul `phase_ids`, metodele `_compute_phase_ids` / `_inverse_phase_ids` și testele aferente.

## Test plan

- [ ] List view vânzări — badge colorat pe faza comenzii vizibil corect
- [ ] Form view — câmpul Phase afișat ca badge colorat
- [ ] Quotation list — badge vizibil după câmpul State

🤖 Generated with [Claude Code](https://claude.com/claude-code)