### PR TITLE
[FIX] deltatech_sale_stage: add git URL for deltatech_widget_many2one_badge in pyproject.toml

### DIFF
--- a/deltatech_sale_stage/pyproject.toml
+++ b/deltatech_sale_stage/pyproject.toml
@@ -6,3 +6,6 @@ build-backend = "whool.buildapi"
 
 [project]
 name = "odoo-addon-deltatech-sale-stage"
+dependencies = [
+    "odoo-addon-deltatech-widget-many2one-badge @ git+https://github.com/dhongu/deltatech.git@19.0#subdirectory=deltatech_widget_many2one_badge"
+]


### PR DESCRIPTION
## Summary

- Adaugă URL git explicit pentru `deltatech_widget_many2one_badge` în `pyproject.toml`
- `deltatech_widget_many2one_badge` nu e pe OCA wheelhouse; pip nu poate rezolva constraint-ul `==19.0.*` generat automat de whool
- Pattern preluat de la alte module bitshop care referențiază dep-uri non-wheelhouse (ex. `deltatech_marketplace_sale_stage/pyproject.toml`)

## Context

PR bitshop#2430 a eșuat la CI cu:
```
ERROR: Could not find a version that satisfies the requirement odoo-addon-deltatech_widget_many2one_badge==19.0.*
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)