### PR TITLE
[FIX] deltatech_stock_report: restaurează aliasul coloanei date în view-ul SQL

### DIFF
--- a/deltatech_stock_report/__manifest__.py
+++ b/deltatech_stock_report/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Reports",
     "summary": "Report with positions from picking lists",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.0.4",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Generic Modules",

--- a/deltatech_stock_report/report/stock_picking_report.py
+++ b/deltatech_stock_report/report/stock_picking_report.py
@@ -44,7 +44,7 @@ class StockPickingReport(models.Model):
     def _select(self):
         select_str = """
             SELECT min(sm.id) as id, sp.id as picking_id,
-            sp.partner_id, rp.commercial_partner_id, sp.picking_type_id,   sp.state, sp.date_done,  sp.company_id,
+            sp.partner_id, rp.commercial_partner_id, sp.picking_type_id,   sp.state, sp.date_done as date,  sp.company_id,
             pt.categ_id, sm.product_id,  pt.uom_id as product_uom,
             sm.location_id,sm.location_dest_id,sl.usage as dest_usage, sum(pt.weight*sm.product_qty) as product_weight,
             CASE WHEN sl.usage='internal' THEN sum(sm.product_qty) ELSE -1*sum(sm.product_qty) END as product_qty,


### PR DESCRIPTION
## Context

Verificare drift 18.0 → 19.0: în `report/stock_picking_report.py`, `_select()` selecta `sp.date_done` fără alias după migrare (`sp.date` redenumit `date_done` în O19).

## Problemă

Câmpul ORM `date = fields.Datetime("Date")` se mapează pe o coloană numită `date` din view-ul SQL, care nu mai exista → câmpul returna **NULL** pentru toate înregistrările, rupând filtrarea, gruparea și afișarea după dată în raportul de transferuri.

## Fix

Aliasat `sp.date_done as date` în `_select()`. `GROUP BY` păstrează `sp.date_done` (aliasul e necesar doar în SELECT pentru maparea ORM).

## Test plan

- [ ] Deschide raportul Stock Picking → coloana/filtrul „Date" afișează data validării transferului (nu gol)
- [ ] Grupare după dată funcționează

🤖 Generated with [Claude Code](https://claude.com/claude-code)