### PR TITLE
[FIX] deltatech_stock_inventory: restaurează data inventar și cantitatea de retur

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "19.0.2.3.9",
+    "version": "19.0.2.4.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/models/stock_quant.py
+++ b/deltatech_stock_inventory/models/stock_quant.py
@@ -78,6 +78,7 @@ class StockQuant(models.Model):
         inventory = self.filtered(lambda q: q.inventory_quantity_set).create_inventory_lines()
         res = super(StockQuant, self.with_context(apply_inventory=True)).action_apply_inventory()
         for quant in self:
+            quant.last_inventory_date = fields.Date.today()
             inventor_line = quant.inventory_line_id
             if inventor_line:
                 inventor_line.write({"is_ok": True})

--- a/deltatech_stock_inventory/wizard/__init__.py
+++ b/deltatech_stock_inventory/wizard/__init__.py
@@ -10,3 +10,4 @@ from . import stock_inventory_adjustment_name
 from . import stock_confirm_inventory
 from . import stock_inventory_merge
 from . import product_replenish
+from . import stock_picking_return

--- a/deltatech_stock_inventory/wizard/product_replenish.py
+++ b/deltatech_stock_inventory/wizard/product_replenish.py
@@ -8,6 +8,9 @@ from odoo import models
 class ProductReplenish(models.TransientModel):
     _inherit = "product.replenish"
 
+    # NOTĂ O19: modelul `procurement.group` și `stock.move.group_id` au fost eliminate
+    # în Odoo 19, deci garda anti-duplicare pe grup de procurement (prezentă în 18.0)
+    # nu este portabilă. Lăsată dezactivată intenționat până la un echivalent O19.
     # group_id = fields.Many2one("procurement.group", string="Group")
     #
     # def _prepare_run_values(self):
@@ -24,6 +27,7 @@ class ProductReplenish(models.TransientModel):
     #         "warehouse_id": self.warehouse_id,
     #         "route_ids": self.route_id,
     #         "date_planned": self.date_planned,
+    #         "force_uom": True,
     #         "group_id": self.group_id,
     #     }
     #     return values

--- a/deltatech_stock_inventory/wizard/product_replenish_views.xml
+++ b/deltatech_stock_inventory/wizard/product_replenish_views.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="stock.view_product_replenish" />
         <field name="arch" type="xml">
             <field name="company_id" position="after">
-<!--                <field name="group_id" />-->
+                <!-- group_id eliminat: procurement.group nu mai există în O19 -->
             </field>
         </field>
     </record>

--- a/deltatech_stock_inventory/wizard/stock_picking_return.py
+++ b/deltatech_stock_inventory/wizard/stock_picking_return.py
@@ -1,0 +1,24 @@
+# ©  2024 Deltatech
+# See README.rst file on addons root folder for license details
+
+from odoo import models
+from odoo.tools.float_utils import float_round
+
+
+class ReturnPicking(models.TransientModel):
+    _inherit = "stock.return.picking"
+
+    def _prepare_stock_return_picking_line_vals_from_move(self, stock_move):
+        vals = super()._prepare_stock_return_picking_line_vals_from_move(stock_move)
+        quantity = stock_move.quantity
+        for move in stock_move.move_dest_ids:
+            if (
+                not move.origin_returned_move_id
+                or move.origin_returned_move_id != stock_move
+                or stock_move.picking_id.picking_type_code == "incoming"
+            ):
+                continue
+            quantity -= move.quantity
+        quantity = float_round(quantity, precision_rounding=stock_move.product_id.uom_id.rounding)
+        vals["quantity"] = quantity
+        return vals


### PR DESCRIPTION
## Context

Verificare drift 18.0 → 19.0 a găsit 3 regresii candidate în `deltatech_stock_inventory`. Două sunt pe calea de import și se restaurează; a treia nu e portabilă în O19.

## Goluri reparate

1. **`last_inventory_date` nescris la `action_apply_inventory()`** — bucla post-`super()` pierduse `quant.last_inventory_date = fields.Date.today()`, deci câmpul rămânea gol și filtrul din `action_confirm_inventory` (`not quant.last_inventory_date`) se potrivea mereu. Restaurat.
2. **`wizard/stock_picking_return.py` eliminat** — override-ul lui `_prepare_stock_return_picking_line_vals_from_move` care deduce cantitățile deja returnate fusese pierdut, permițând retururi peste cantitatea disponibilă. Restaurat, adaptat la O19 (pornește de la vals-ul core, suprascrie doar `quantity`; core a renunțat la cheia `uom_id`).

## NU se backportează (breaking change O19)

Garda anti-duplicare `group_id` din `product.replenish` (prezentă în 18.0) **nu** e portabilă: modelul `procurement.group` și `stock.move.group_id` au fost **eliminate în Odoo 19**. Câmpul rămâne comentat, cu notă explicativă în cod.

## Test plan

- [ ] Aplicare ajustare inventar → `last_inventory_date` pe quant se setează la data curentă
- [ ] Retur parțial repetat → cantitatea propusă scade cu ce s-a returnat deja (nu permite peste disponibil)
- [ ] Modulul se instalează fără eroare (fără referință la `procurement.group`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)