### PR TITLE
[FIX] deltatech_sale_margin: ignoră liniile de recompensă loyalty în check_sale_price

### DIFF
--- a/deltatech_sale_margin/__manifest__.py
+++ b/deltatech_sale_margin/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Margin",
     "summary": "Check price in sale order",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_margin/models/sale.py
+++ b/deltatech_sale_margin/models/sale.py
@@ -146,6 +146,9 @@ class SaleOrderLine(models.Model):
 
             #
             if line.product_id and line.price_unit == 0:
+                # liniile generate de recompense de loialitate au preț 0 intenționat
+                if hasattr(line, "reward_id") and line.reward_id:
+                    continue
                 if not self.env.user.has_group("deltatech_sale_margin.group_sale_below_purchase_price"):
                     raise UserError(self.env._("You can not sell %s without price.") % line.product_id.name)
                 else:


### PR DESCRIPTION
## Context

Verificare drift 18.0 → 19.0: garda care sărea liniile de comandă provenite dintr-o recompensă de loialitate (`line.reward_id`) a fost pierdută din `check_sale_price()` la migrare.

## Problemă

Liniile de recompensă au `price_unit = 0` intenționat. Fără gardă, confirmarea unei comenzi cu un produs-recompensă ridica `UserError("You can not sell %s without price.")` chiar și pentru utilizatorii cu drept de vânzare sub cost.

## Fix

Restaurat guard-ul `hasattr(line, "reward_id") and line.reward_id` → `continue` (folosește `hasattr`, deci nu necesită dependență de `sale_loyalty`).

## Test plan

- [ ] Cu `sale_loyalty` instalat: comandă cu produs-recompensă (preț 0) se confirmă fără `UserError`
- [ ] Produs normal cu preț 0 → comportamentul de gardă rămâne neschimbat

🤖 Generated with [Claude Code](https://claude.com/claude-code)