### PR TITLE
[FIX] deltatech_sale_commission: prioritate BoM variantă, filtru dată și commission_paid

### DIFF
--- a/deltatech_sale_commission/__manifest__.py
+++ b/deltatech_sale_commission/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Commission",
     "summary": "Compute sale commission",
-    "version": "19.0.1.4.3",
+    "version": "19.0.1.4.4",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_commission/models/account_invoice.py
+++ b/deltatech_sale_commission/models/account_invoice.py
@@ -31,6 +31,7 @@ class AccountInvoiceLine(models.Model):
     )
 
     commission = fields.Float(string="Commission", default=0.0)
+    commission_paid = fields.Boolean(string="Commission Paid", default=False)
 
     @api.depends("sale_line_ids")
     def _compute_sale_user_id(self):
@@ -89,7 +90,10 @@ class AccountInvoiceLine(models.Model):
         moves = self.env["stock.move"].search(domain)
         mrp_mod = self.env["ir.module.module"].search([("name", "=", "mrp"), ("state", "=", "installed")])
         if mrp_mod and self.product_id.bom_count:
-            bom = self.product_id.bom_ids.filtered(lambda b: b.type == "phantom")
+            # prioritizează BoM-ul phantom specific variantei, apoi orice BoM phantom
+            bom = self.product_id.bom_ids.filtered(lambda b: b.type == "phantom" and b.product_id == self.product_id)
+            if not bom:
+                bom = self.product_id.bom_ids.filtered(lambda b: b.type == "phantom")
             if bom:
                 purchase_price = 0
                 moved_qty = 0

--- a/deltatech_sale_commission/report/sale_margin_report.py
+++ b/deltatech_sale_commission/report/sale_margin_report.py
@@ -49,6 +49,7 @@ class SaleMarginReport(models.Model):
     commission_director_computed = fields.Float("Commission Director Computed", readonly=True)
 
     commission = fields.Float("Real Commission")
+    commission_paid = fields.Boolean("Commission Paid", default=False)
     partner_id = fields.Many2one("res.partner", "Partner", readonly=True)
     commercial_partner_id = fields.Many2one("res.partner", "Commercial Partner", readonly=True)
 
@@ -125,6 +126,7 @@ class SaleMarginReport(models.Model):
                 sub.director_rate * (sale_val    - stock_val )  as commission_director_computed,
 
                 commission,
+                commission_paid,
                 partner_id, commercial_partner_id,  state_id, user_id, manager_user_id, director_user_id,   sub.company_id,
                 move_type,  state , payment_state, journal_id,
                  sub.currency_id
@@ -166,6 +168,7 @@ class SaleMarginReport(models.Model):
 
 
                     sum(l.commission) as commission,
+                    bool_and(l.commission_paid) as commission_paid,
                     cu.rate, cu.manager_rate, cu.director_rate, cu.manager_user_id, cu.director_user_id,
 
                     s.partner_id as partner_id,
@@ -278,7 +281,11 @@ class SaleMarginReport(models.Model):
 
     def write(self, vals):
         invoice_line = self.env["account.move.line"].sudo().browse(self.id)
-        value = {"commission": vals.get("commission", False)}
+        value = {}
+        if "commission" in vals:
+            value["commission"] = vals["commission"]
+        if "commission_paid" in vals:
+            value["commission_paid"] = vals["commission_paid"]
         if invoice_line.purchase_price == 0 and invoice_line.product_id:
             if invoice_line.product_id.standard_price > 0:
                 value["purchase_price"] = invoice_line.product_id.standard_price
@@ -291,6 +298,10 @@ class SaleMarginReport(models.Model):
         if 1 == 2:
             super().write(vals)
         return True
+
+    def action_set_commission_paid(self):
+        for record in self:
+            record.write({"commission_paid": True})
 
     @api.model
     def cron_update_purchase_price(self):

--- a/deltatech_sale_commission/report/sale_margin_report.xml
+++ b/deltatech_sale_commission/report/sale_margin_report.xml
@@ -7,6 +7,15 @@
         <field name="type">list</field>
         <field name="arch" type="xml">
             <list create="false">
+                <header>
+                    <button
+                        name="action_set_commission_paid"
+                        aria-label="Set Paid"
+                        string="Set Paid"
+                        type="object"
+                        icon="fa-check"
+                    />
+                </header>
                 <field name="date" column_invisible="True" />
                 <field name="due_date" />
                 <field name="payment_term_id" />
@@ -20,6 +29,7 @@
                 <field name="sale_val" sum="Sale value" />
                 <field name="stock_val" sum="Stock value" />
                 <field name="profit_val" sum="Profit" />
+                <field name="commission_paid" />
                 <field name="company_id" column_invisible="1" groups="base.group_multi_company" />
                 <field name="move_type" column_invisible="True" />
                 <field name="state" column_invisible="True" />
@@ -55,6 +65,7 @@
                         <group>
                             <field name="commission_computed" />
                             <field name="commission" />
+                            <field name="commission_paid" />
                         </group>
                         <group name="managers">
                             <field name="manager_user_id" />
@@ -75,6 +86,15 @@
         <field name="type">list</field>
         <field name="arch" type="xml">
             <list delete="false" create="false">
+                <header>
+                    <button
+                        name="action_set_commission_paid"
+                        aria-label="Set Paid"
+                        string="Set Paid"
+                        type="object"
+                        icon="fa-check"
+                    />
+                </header>
                 <field name="date" column_invisible="1" />
                 <field name="due_date" />
                 <field name="payment_term_id" />
@@ -92,6 +112,7 @@
                 <field name="profit_val" sum="Profit" />
                 <field name="commission_computed" sum="Commission Computed" />
                 <field name="commission" sum="Commission" />
+                <field name="commission_paid" optional="show" />
                 <field name="markup" optional="hide" />
                 <field name="payment_state" optional="hide" />
                 <field name="profit_margin" optional="hide" />
@@ -157,6 +178,13 @@
                 <filter string="My Sales" name="mysale" domain="[('user_id','=',uid)]" />
                 <filter string="Paid" name="paid" domain="[('payment_state','=','paid')]" />
                 <filter string="Open" name="open" domain="[('payment_state','!=','paid')]" />
+                <separator />
+                <filter
+                    string="Commission Not Paid"
+                    name="commission_not_paid"
+                    domain="[('commission_paid','=',False)]"
+                />
+                <filter string="Commission Paid" name="commission_paid" domain="[('commission_paid','=',True)]" />
                 <field name="partner_id" />
                 <field name="commercial_partner_id" />
                 <field name="product_id" />
@@ -181,6 +209,11 @@
                     <filter string="Category of Product" name="category" context="{'group_by':'categ_id'}" />
                     <filter string="Account" name="account" context="{'group_by':'account_id'}" />
                     <filter string="Status" name="status" context="{'group_by':'state'}" />
+                    <filter
+                        string="Commission Paid"
+                        name="group_by_commission_paid"
+                        context="{'group_by':'commission_paid'}"
+                    />
                     <!--
                     <filter string="Period"   context="{'group_by':'period_id'}"/>
                     -->
@@ -206,7 +239,7 @@
         <field name="view_id" ref="view_sale_margin_report_list" />
         <field name="search_view_id" ref="view_sale_margin_report_filter" />
         <field name="help">This report performs analysis on your invoices.</field>
-        <field name="context">{"search_default_date":1,
+        <field name="context">{"search_default_filter_date":1,
             'search_default_product':1,'group_by_no_leaf':1,'group_by':['user_id']}
         </field>
     </record>
@@ -262,7 +295,7 @@
         <field name="view_mode">list,form</field>
         <field name="view_id" ref="view_sale_margin_report_commission_list" />
         <field name="search_view_id" ref="view_sale_margin_report_filter" />
-        <field name="context">{"search_default_date":1, 'search_default_paid':1}</field>
+        <field name="context">{"search_default_filter_date":1, 'search_default_paid':1}</field>
         <field name="domain">[('move_type','in',['out_invoice','out_refund','out_receipt'])]</field>
     </record>
 


### PR DESCRIPTION
## Context

Verificare drift 18.0 → 19.0 a găsit 3 regresii reale în `deltatech_sale_commission` (a 4-a raportată — deposit product `ValueError` — s-a dovedit fals pozitiv: logica `ir.config_parameter` e identică între 18.0 și 19.0 final).

## Goluri reparate

1. **Prioritate BoM variantă** (`get_purchase_price`) — 18.0 căuta întâi un BoM phantom specific variantei (`b.product_id == self.product_id`), cu fallback pe orice BoM phantom; 19.0 păstrase doar fallback-ul → produsele-kit cu BoM-uri distincte per variantă calculau costul greșit. Restaurată căutarea prioritizată.
2. **Filtru dată în acțiuni** — acțiunile aveau context `search_default_date`, dar filtrul din view e `filter_date` → filtrul implicit „luna precedentă" nu se activa. Corectat la `search_default_filter_date` în ambele acțiuni.
3. **Funcționalitate `commission_paid`** — boolean pe `account.move.line` + coloană SQL `bool_and` în view-ul raport + `action_set_commission_paid` + buton „Set Paid", coloane, filtre și group-by. Eliminată la migrare. Backportată din commit `add0d7099`.

## Test plan

- [ ] Produs-kit cu BoM specific variantei → cost de achiziție corect pe comision
- [ ] Deschidere raport marjă/comision → filtrul „luna precedentă" e activ implicit
- [ ] Buton „Set Paid" pe liniile de comision → `commission_paid=True`; filtrele Commission Paid/Unpaid funcționează

🤖 Generated with [Claude Code](https://claude.com/claude-code)