### PR TITLE
[FIX] deltatech_sale_payment: gardă tranzacții NewId în _compute_payment

### DIFF
--- a/deltatech_sale_payment/__manifest__.py
+++ b/deltatech_sale_payment/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Payment",
     "summary": "Payment button in sale order",
-    "version": "19.0.1.1.2",
+    "version": "19.0.1.1.3",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_payment/models/sale.py
+++ b/deltatech_sale_payment/models/sale.py
@@ -49,7 +49,9 @@ class SaleOrder(models.Model):
             payment_status = "without"
 
             provider = self.env["payment.provider"]
-            all_transactions = order.sudo().transaction_ids.sorted(lambda a: a.id)
+            # filtrează tranzacțiile NewId (din onchange) înainte de sortare, ca să evităm
+            # TypeError la compararea NewId cu int
+            all_transactions = order.sudo().transaction_ids.filtered(lambda t: isinstance(t.id, int)).sorted("id")
             if all_transactions:
                 provider = all_transactions[-1].provider_id
 


### PR DESCRIPTION
## Context

Verificare drift 18.0 → 19.0. Din 3 „goluri" raportate inițial, doar unul e o regresie reală; celelalte două sunt o **reproiectare deliberată** validă.

## Fix aplicat

Restaurat filtrul `isinstance(t.id, int)` (prezent în 18.0) înainte de sortarea `order.transaction_ids` → evită `TypeError` la compararea înregistrărilor `NewId` (din onchange) cu id-uri `int`.

## NU se backportează (reproiectare deliberată, nu regresie)

`store=True` pe `payment_amount`/`payment_status`/`provider_id` și starea `pending`: 19.0 a trecut intenționat la `compute` + `_search_payment_status` (filtrare SQL dedicată) cu starea `initiated`. Design funcțional echivalent — filtrele funcționează prin `_search_payment_status`, logica de calcul (provider, reconciliere facturi, partial/done/initiated/cancelled/authorized) e completă. Migrarea SQL specifică 18.0.1.2.0 nu se aplică pe acest design.

## Test plan

- [ ] Comandă cu tranzacție în onchange (NewId) → `_compute_payment` nu mai dă `TypeError`
- [ ] Filtrele de status plată (fără/inițiat/autorizat/efectuat/anulat) funcționează în lista de comenzi

🤖 Generated with [Claude Code](https://claude.com/claude-code)