### PR TITLE
[FIX] sale_pallet & sale_margin: Odoo 19 compatibility cleanups

### DIFF
--- a/deltatech_sale_margin/models/sale.py
+++ b/deltatech_sale_margin/models/sale.py
@@ -18,6 +18,7 @@ class SaleOrder(models.Model):
     def _compute_can_change_price(self):
         self.can_change_price = not self.env.user.has_group("deltatech_sale_margin.group_sale_no_change_price")
 
+    @api.depends("state", "order_line.price_reduce_taxexcl", "order_line.purchase_price")
     def _compute_price_warning_message(self):
         self.price_warning_message = False
         for order in self.filtered(lambda o: o.state in ["draft", "sent"]):
@@ -159,7 +160,7 @@ class SaleOrderLine(models.Model):
                 if price_unit < line.purchase_price:
                     if not self.env.user.has_group("deltatech_sale_margin.group_sale_below_purchase_price"):
                         raise UserError(
-                            self.env._(f"You can not sell below the purchase price: {self[0].product_id.name}.")
+                            self.env._("You can not sell below the purchase price: %s.", line.product_id.name)
                         )
                     else:
                         message = self.env._("Sale %s under the purchase price.") % line.product_id.name

--- a/deltatech_sale_pallet/models/sale.py
+++ b/deltatech_sale_pallet/models/sale.py
@@ -21,7 +21,10 @@ class SaleOrder(models.Model):
         for product_id in pallets:
             if pallets and pallets[product_id]["product_uom_qty"]:
                 order_line = self.order_line.new(pallets[product_id])
-                order_line._onchange_product_id_warning()
+                # `_onchange_product_id_warning` nu există în O19 nativ; e adus
+                # doar de deltatech_sale_margin. Apelăm doar dacă e disponibil.
+                if hasattr(order_line, "_onchange_product_id_warning"):
+                    order_line._onchange_product_id_warning()
                 # order_line.product_uom_change()
 
     def recompute_pallet_lines(self, delete_if_under=False):

--- a/deltatech_sale_pallet/models/sale_report.py
+++ b/deltatech_sale_pallet/models/sale_report.py
@@ -3,7 +3,7 @@
 # See README.rst file on addons root folder for license details
 
 
-from odoo import fields, models
+from odoo import models
 from odoo.tools import SQL
 from odoo.tools.safe_eval import safe_eval
 
@@ -11,22 +11,10 @@ from odoo.tools.safe_eval import safe_eval
 class SaleReport(models.Model):
     _inherit = "sale.report"
 
-    price_unit = fields.Float(string="Price Unit", digits="Product Price", aggregator="avg")
-
-    def _select_additional_fields(self):
-        additional_fields_info = super()._select_additional_fields()
-        additional_fields_info["price_unit"] = """
-            CASE WHEN l.product_id IS NOT NULL
-                THEN sum(l.untaxed_amount_invoiced / CASE COALESCE(s.currency_rate, 0) WHEN 0
-                THEN 1.0 ELSE s.currency_rate END) / CASE COALESCE(sum(l.qty_invoiced / u.factor * u2.factor), 0)
-                     WHEN 0
-                     THEN 1.0
-                     ELSE sum(l.qty_invoiced / u.factor * u2.factor)
-                     END
-                ELSE 0
-            END
-        """
-        return additional_fields_info
+    # `price_unit` (cu aggregator="avg") e declarat nativ în O19 și inclus în
+    # select-ul de bază al raportului. Nu mai redefinim câmpul și nici nu mai
+    # adăugăm o coloană prin `_select_additional_fields` (redundant cu nativul);
+    # calculul cu `sale_pallet.price_coef` se face la citire în `_read_group_select`.
 
     def _read_group_select(self, aggregate_spec, query):
         if aggregate_spec == "price_unit:avg":


### PR DESCRIPTION
## Context
Verificare de compatibilitate Odoo 19 pe `deltatech_sale_pallet` și `deltatech_sale_margin`. Modulele erau funcționale, dar aveau câteva probleme latente / de calitate confirmate la analiză și testare pe `test19`.

## Modificări

### deltatech_sale_pallet
- **`models/sale.py`** — apelul `order_line._onchange_product_id_warning()` din `onchange_order_line` e protejat cu `hasattr`. Metoda **nu mai există în Odoo 19 nativ**; e furnizată doar de `deltatech_sale_margin`, care nu e dependență declarată (manifestul depinde de `sale_margin` nativ). Fără guard → `AttributeError` la adăugarea unui produs cu palet în SO, pe o instalare fără `deltatech_sale_margin`.
- **`models/sale_report.py`** — eliminat redefinirea câmpului `price_unit` și override-ul `_select_additional_fields` (redundante). Odoo 19 oferă nativ `price_unit` (`aggregator="avg"`) deja inclus în select-ul de bază al raportului; coeficientul de palet se calculează la citire în `_read_group_select`.

### deltatech_sale_margin
- **`models/sale.py`** — `UserError` care interpola printr-un f-string în interiorul `self.env._()` (netraductibil) și raporta `self[0]` în loc de `line` → înlocuit cu `%s` + `line.product_id.name`.
- **`models/sale.py`** — adăugat `@api.depends` pe `_compute_price_warning_message` ca alerta de marjă negativă să se reîmprospăteze reactiv în UI.

## Testare
- `deltatech_sale_pallet`: instalare curată, rebuild raport fără erori SQL; testele proprii trec.
- `deltatech_sale_margin`: `-u deltatech_sale_margin --test-tags=/deltatech_sale_margin` → **0 failed, 0 error(s) of 4 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)