### PR TITLE
[FIX] deltatech_ral, deltatech_mrp: fix O19 alignment

### DIFF
--- a/deltatech_mrp/__manifest__.py
+++ b/deltatech_mrp/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "MRP Extension",
     "summary": "MRP Extension",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_mrp/report/deltatech_mrp_report.py
+++ b/deltatech_mrp/report/deltatech_mrp_report.py
@@ -55,7 +55,6 @@ class DeltatechMrpReport(models.Model):
     company_id = fields.Many2one("res.company", "Company", readonly=True)
     #        origin = fields.char('Source Document', size=64)
     nbr = fields.Integer("# of Orders", readonly=True)
-    lot_producing_id = fields.Many2one("stock.lot", "Lot", readonly=True)
 
     state = fields.Selection(
         [
@@ -87,7 +86,6 @@ SELECT s.id, s.id as production_id,
     to_date(to_char(s.date_start, 'MM-dd-YYYY'::text), 'MM-dd-YYYY'::text) AS date,
 
     s.product_id,
-    null as lot_producing_id,
     pt.uom_id AS product_uom,
     sum((s.product_qty / u.factor)) AS product_qty,
     sum(sub_prod_ef.product_qty_ef) AS product_qty_ef,

--- a/deltatech_mrp/report/deltatech_mrp_report.xml
+++ b/deltatech_mrp/report/deltatech_mrp_report.xml
@@ -9,7 +9,6 @@
                 <list>
                     <field name="date" optional="hide" />
                     <field name="product_id" invisible="0" />
-                    <field name="lot_producing_id" optional="hide" />
                     <field name="categ_id" optional="show" />
                     <field name="production_id" optional="hide" />
                     <field name="product_qty" sum='Qty Plan' />
@@ -55,7 +54,6 @@
                 <pivot string="Production Analysis">
                     <field name="product_id" type="row" />
                     <field name="date" interval="month" type="row" />
-                    <field name="lot_producing_id" type="row" />
                     <field name="consumed_val" type="measure" />
                     <field name="consumed_raw_val" type="measure" />
                     <field name="consumed_pak_val" type="measure" />
@@ -76,7 +74,6 @@
                     <filter name="filter_date" date="date" default_period="month-1" />
 
                     <field name="product_id" />
-                    <field name="lot_producing_id" />
                     <separator />
                     <filter string="Current" name='current' domain="[('state','in',('open','draft'))]" />
                     <filter string="In Production" name="in_production" domain="[('state','=','in_production')]" />

--- a/deltatech_mrp/tests/test_mrp_production.py
+++ b/deltatech_mrp/tests/test_mrp_production.py
@@ -44,7 +44,7 @@ class TestMrpProduction(TransactionCase):
         production._compute_cost_detail()
         self.assertEqual(len(production.cost_detail_ids), 0)
 
-        # Notă: Deoarece deltatech.cost.detail este un view SQL care depinde de stock_move și stock_valuation_layer
-        # în starea 'done', un test complet ar necesita simularea fluxului de stoc.
+        # Notă: Deoarece deltatech.cost.detail este un view SQL care depinde de valoarea (stock_move.value)
+        # mișcărilor în starea 'done', un test complet ar necesita simularea fluxului de stoc.
         # Pentru acest test, verificăm măcar dacă metoda de calcul poate fi apelată fără erori.
         production.recompute_cost_detail()

--- a/deltatech_ral/__manifest__.py
+++ b/deltatech_ral/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "RAL",
     "summary": "RAL",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.0.4",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_ral/models/mrp.py
+++ b/deltatech_ral/models/mrp.py
@@ -33,6 +33,7 @@ class MrpProduction(models.Model):
                     self.ral_id = ral
         return res
 
+    @api.model_create_multi
     def create(self, vals_list):
         res = super().create(vals_list)
         for mrp in res:
@@ -40,11 +41,10 @@ class MrpProduction(models.Model):
             mrp.onchange_ral_id()
         return res
 
-    def action_generate_serial(self):
-        res = super().action_generate_serial()
+    def action_generate_serial(self, workorder=False):
+        res = super().action_generate_serial(workorder=workorder)
         if self.ral_id:
-            for lot in self.lot_producing_ids:
-                lot.write({"ral_id": self.ral_id.id})
+            self.lot_producing_ids.write({"ral_id": self.ral_id.id})
         return res
 
     @api.onchange("ral_id")
@@ -54,7 +54,11 @@ class MrpProduction(models.Model):
                 if move.bom_line_id.product_id.default_code == "RAL 0000":
                     move.product_id = self.ral_id
 
-    def _generate_moves(self):
-        res = super()._generate_moves()
-        self.onchange_ral_id()
-        return res
+    def _get_move_raw_values(self, product, product_uom_qty, product_uom, operation_id=False, bom_line=False):
+        # În O19 move_raw_ids este câmp calculat (_compute_move_raw_ids), iar la fiecare
+        # recalculare componentele sunt regenerate din valorile liniei de BoM. Înlocuim aici
+        # componenta generică RAL 0000 cu produsul RAL ales, astfel încât substituția să reziste
+        # recalculării (vechiul hook _generate_moves nu mai există în 19.0).
+        if self.ral_id and product.default_code == "RAL 0000":
+            product = self.ral_id
+        return super()._get_move_raw_values(product, product_uom_qty, product_uom, operation_id, bom_line)

--- a/deltatech_ral/tests/test_ral.py
+++ b/deltatech_ral/tests/test_ral.py
@@ -88,6 +88,28 @@ class TestRal(TransactionCase):
                     move.product_id.id, self.product_ral_red.id, "Componenta RAL ar fi trebuit înlocuită la creare"
                 )
 
+    def test_05_substitution_survives_recompute(self):
+        """RAL substituit trebuie să reziste recalculării componentelor (O19: move_raw_ids calculat)"""
+        production = self.env["mrp.production"].create(
+            {
+                "product_id": self.product_finished_variant.id,
+                "bom_id": self.bom.id,
+                "product_qty": 1.0,
+            }
+        )
+        production.ral_id = self.product_ral_red
+        production.onchange_ral_id()
+        # Modificarea cantității retrigăruiește _compute_move_raw_ids și regenerează componentele
+        production.product_qty = 5.0
+        ral_moves = production.move_raw_ids.filtered(lambda m: m.bom_line_id.product_id == self.product_ral_0000)
+        self.assertTrue(ral_moves, "Ar fi trebuit să existe o mișcare pentru componenta RAL")
+        for move in ral_moves:
+            self.assertEqual(
+                move.product_id.id,
+                self.product_ral_red.id,
+                "Substituția RAL trebuie păstrată după recalcularea componentelor",
+            )
+
     def test_04_action_generate_serial(self):
         """Test propagarea RAL către lot"""
         production = self.env["mrp.production"].create(


### PR DESCRIPTION
## Context
Verificare de pregătire pentru migrarea proiectului **romchim** pe Odoo 19. Ambele module erau deja migrate pe `19.0` și instalau curat, dar reviewul a scos la iveală o regresie funcțională reală (necacoperită de teste) plus cod mort/convenții.

## `deltatech_ral`
- **Regresie restaurată:** override-ul `_generate_moves` era cod mort — metoda a fost eliminată din core 19.0. Pe 18 reaplica substituția „RAL 0000 → RAL ales" după regenerarea componentelor. În O19 `move_raw_ids` este câmp **calculat** (`_compute_move_raw_ids`), iar la fiecare recalculare (ex. schimbare cantitate) substituția se pierdea și revenea la RAL 0000. Mutat hook-ul pe `_get_move_raw_values` (punctul corect în O19), deci substituția rezistă recalculării.
- `action_generate_serial` — semnătură aliniată cu core (`workorder=False`).
- `create` — adăugat `@api.model_create_multi` (obligatoriu în O19).
- Test nou de regresie: substituția rezistă recalculării componentelor.

## `deltatech_mrp`
- Eliminat dimensiunea moartă `lot_producing_id` din raportul de analiză cost (mereu `NULL` în O19 multi-lot) — din model, view SQL și view-urile listă/pivot/căutare.
- Actualizat comentariul învechit din test care referea `stock_valuation_layer` (eliminat în O19).

## Testare
Pe `test19`: `deltatech_ral` 7/7, `deltatech_mrp` 3/3 — `0 failed, 0 error(s)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)