### PR TITLE
FIX: deltatech_dc — rapoarte conformitate cu produse fără trasabilitate

### DIFF
--- a/deltatech_dc/__manifest__.py
+++ b/deltatech_dc/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Declaration of Conformity",
     "summary": "Print Declaration of Conformity",
-    "version": "19.0.1.0.10",
+    "version": "19.0.1.0.11",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_dc/report/report_dc.py
+++ b/deltatech_dc/report/report_dc.py
@@ -91,7 +91,7 @@ class ReportDCInvoicePrint(models.AbstractModel):
             ):
                 if line.product_id in product_with_lots:
                     continue
-                if line.product_id.type != "product":
+                if line.product_id.type == "service":
                     continue
                 domain = [
                     ("product_id", "=", line.product_id.id),
@@ -130,20 +130,39 @@ class ReportDCPickingPrint(models.AbstractModel):
             for move in picking.move_ids:
                 for move_line in move.move_line_ids:
                     lot = move_line.lot_id
-                    if not lot:
-                        continue
-                    domain = [("lot_id", "=", lot.id)]
-                    dc = self.env["deltatech.dc"].search(domain)
-                    if not dc:
-                        dc = self.env["deltatech.dc"].create(
-                            {
-                                "product_id": lot.product_id.id,
-                                "date": lot.production_date or fields.Date.today(),
-                                "lot_id": lot.id,
-                            }
-                        )
-                    product_with_lots |= lot.product_id
-                    declarations |= dc
+                    if lot:
+                        domain = [("lot_id", "=", lot.id)]
+                        dc = self.env["deltatech.dc"].search(domain)
+                        if not dc:
+                            dc = self.env["deltatech.dc"].create(
+                                {
+                                    "product_id": lot.product_id.id,
+                                    "date": lot.production_date or fields.Date.today(),
+                                    "lot_id": lot.id,
+                                }
+                            )
+                        product_with_lots |= lot.product_id
+                        declarations |= dc
+                    else:
+                        if move_line.product_id in product_with_lots:
+                            continue
+                        if move_line.product_id.type == "service":
+                            continue
+                        domain = [
+                            ("product_id", "=", move_line.product_id.id),
+                            ("date", "=", picking.date_done or fields.Date.today()),
+                            ("lot_id", "=", False),
+                        ]
+                        dc = self.env["deltatech.dc"].search(domain)
+                        if not dc:
+                            dc = self.env["deltatech.dc"].create(
+                                {
+                                    "product_id": move_line.product_id.id,
+                                    "date": picking.date_done or fields.Date.today(),
+                                }
+                            )
+                        product_with_lots |= move_line.product_id
+                        declarations |= dc
 
         return {
             "doc_ids": declarations.ids,

--- a/deltatech_dc/tests/test_dc.py
+++ b/deltatech_dc/tests/test_dc.py
@@ -9,10 +9,24 @@ from odoo.tests.common import TransactionCase
 class TestDC(TransactionCase):
     def setUp(self):
         super().setUp()
-        self.partner_a = self.env["res.partner"].create({"name": "Test"})
-        self.product_a = self.env["product.product"].create(
+        self.partner_a = self.env["res.partner"].create({"name": "Test Partner"})
+        self.product_storable = self.env["product.product"].create(
             {
-                "name": "Test A",
+                "name": "Storable Product",
+                "type": "consu",
+                "is_storable": True,
+            }
+        )
+        self.product_service = self.env["product.product"].create(
+            {
+                "name": "Service Product",
+                "type": "service",
+            }
+        )
+        self.product_with_lot = self.env["product.product"].create(
+            {
+                "name": "Product with Lot",
+                "type": "consu",
                 "is_storable": True,
             }
         )
@@ -21,13 +35,137 @@ class TestDC(TransactionCase):
         form_dc = Form(self.env["deltatech.dc"])
         form_dc.name = "Test"
         form_dc.date = "2021-01-01"
-        form_dc.product_id = self.product_a
+        form_dc.product_id = self.product_storable
         form_dc.save()
 
     def test_lot(self):
         form_lot = Form(self.env["stock.lot"])
         form_lot.name = "Test"
-        form_lot.product_id = self.product_a
+        form_lot.product_id = self.product_storable
         lot = form_lot.save()
         lot.production_date = "2021-01-01"
-        lot._get_dates(product_id=self.product_a.id)
+        lot._get_dates(product_id=self.product_storable.id)
+
+    def test_invoice_report_dc_with_storable_products(self):
+        """Test raport DC factură include produse stocabile (consu) și exclude servicii."""
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_storable.id,
+                            "quantity": 2,
+                            "price_unit": 100,
+                        },
+                    ),
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_service.id,
+                            "quantity": 1,
+                            "price_unit": 50,
+                        },
+                    ),
+                ],
+            }
+        )
+        invoice.action_post()
+
+        report = self.env["report.deltatech_dc.report_dc_invoice"]
+        values = report._get_report_values(invoice.ids)
+
+        dc_products = set(dc.product_id.id for dc in values["docs"])
+        self.assertIn(
+            self.product_storable.id,
+            dc_products,
+            "DC raport trebuie să includă produse stocabile",
+        )
+        self.assertNotIn(
+            self.product_service.id,
+            dc_products,
+            "DC raport nu trebuie să includă servicii",
+        )
+
+    def test_invoice_report_dc_with_lot(self):
+        """Test raport DC factură cu produse cu trasabilitate (lot)."""
+        self.env["stock.lot"].create(
+            {
+                "name": "LOT001",
+                "product_id": self.product_with_lot.id,
+                "production_date": "2021-01-01",
+            }
+        )
+
+        invoice = self.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": self.partner_a.id,
+                "invoice_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_with_lot.id,
+                            "quantity": 1,
+                            "price_unit": 100,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        self.env["account.move.line"].search(
+            [("move_id", "=", invoice.id), ("product_id", "=", self.product_with_lot.id)]
+        ).quantity = 1
+
+        invoice.action_post()
+
+        report = self.env["report.deltatech_dc.report_dc_invoice"]
+        values = report._get_report_values(invoice.ids)
+
+        self.assertGreater(len(values["docs"]), 0, "DC raport trebuie să conțină declarații")
+
+    def test_picking_report_dc_without_lot(self):
+        """Test raport DC picking include produse fără lot (consum)."""
+        warehouse = self.env["stock.warehouse"].search([], limit=1)
+        if not warehouse:
+            warehouse = self.env["stock.warehouse"].create(
+                {
+                    "name": "Test Warehouse",
+                    "code": "TEST",
+                }
+            )
+
+        picking = self.env["stock.picking"].create(
+            {
+                "picking_type_id": warehouse.out_type_id.id,
+                "partner_id": self.partner_a.id,
+                "move_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product_storable.id,
+                            "product_uom_qty": 1,
+                            "product_uom": self.product_storable.uom_id.id,
+                        },
+                    ),
+                ],
+            }
+        )
+
+        picking.button_validate()
+
+        report = self.env["report.deltatech_dc.report_dc_picking"]
+        values = report._get_report_values(picking.ids)
+
+        self.assertGreater(
+            len(values["docs"]),
+            0,
+            "DC raport picking trebuie să includă produse fără lot",
+        )


### PR DESCRIPTION
## Sumar

Porta fix-ul din commit 81dab1563 (18.0) → 19.0:
- **Raport factură**: condiția de excludere schimbată din `type != "product"` în `type == "service"` pentru a include corect produsele stocabile consumabile
- **Raport picking**: adaugă DC-uri și pentru produsele fără lot, pe baza produsului și datei picking-ului
- **Version bump**: 19.0.1.0.10 → 19.0.1.0.11

## Context

Drift-ul 18.0 → 19.0 arăta că commit-ul `81dab1563` (2026-02-24) cu fix-ul pentru readucerea produselor fără trasabilitate nu ajunsese în 19.0. Condiția veche `type != "product"` excludea și consumabilele stocabile în raportul facturilor.

## Testare

Schimbări validate:
- Sintaxa Python: ✓
- Pre-commit checks: ✓

🤖 Generated with Claude Code