### PR TITLE
[FIX] deltatech_tc: administratorii primesc automat rolul de Manager

### DIFF
--- a/deltatech_tc/security/deltatech_tc_security.xml
+++ b/deltatech_tc/security/deltatech_tc_security.xml
@@ -15,7 +15,11 @@
         <field name="name">Manager</field>
         <field name="privilege_id" ref="groups_privilege_deltatech_tc"/>
         <field name="implied_ids" eval="[(4, ref('group_deltatech_tc_user'))]"/>
-        <field name="user_ids" eval="[(4, ref('base.user_admin'))]"/>
+    </record>
+
+    <!-- Administratorii de sistem primesc automat rolul de Manager Terrabit Connect. -->
+    <record id="base.group_system" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('group_deltatech_tc_manager'))]"/>
     </record>
 
     <record id="rule_deltatech_tc_station_company" model="ir.rule">


### PR DESCRIPTION
Grupul **Manager** din `deltatech_tc` adăuga explicit doar `base.user_admin` (un singur user), deci alți administratori de sistem nu vedeau meniurile/config-ul Terrabit Connect după instalare.

Acum **`base.group_system` implică `group_deltatech_tc_manager`** → toți administratorii de sistem primesc automat rolul de Manager TC, la instalare și la upgrade (Odoo propagă implicația și utilizatorilor existenți).

Verificat pe test19: userul `admin` primește grupul automat. 7 teste verzi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
