### PR TITLE
[FIX] deltatech_invoice_report: refresh_invoice_history on product.product

### DIFF
--- a/deltatech_invoice_report/__manifest__.py
+++ b/deltatech_invoice_report/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Invoice Report",
     "summary": "Invoice Report",
-    "version": "18.0.1.0.7",
+    "version": "18.0.1.0.8",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_invoice_report/models/product.py
+++ b/deltatech_invoice_report/models/product.py
@@ -133,6 +133,9 @@ class ProductTemplate(models.Model):
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
+    def refresh_invoice_history(self):
+        return self.product_tmpl_id.refresh_invoice_history()
+
     def action_view_invoice(self):
         action = self.env["ir.actions.actions"]._for_xml_id("account.action_account_invoice_report_all")
         action["context"] = {

--- a/deltatech_invoice_report/readme/HISTORY.md
+++ b/deltatech_invoice_report/readme/HISTORY.md
@@ -1,0 +1,3 @@
+## 18.0.1.0.8
+
+- [FIX] add `refresh_invoice_history` on `product.product` (delegates to template); the button is inherited into `product.product_normal_form_view` and validation failed when only the template defined the method


### PR DESCRIPTION
## Summary
- The Refresh button (`refresh_invoice_history`) is added on `product.product_template_form_view`, but the core primary view `product.product_normal_form_view` (model `product.product`) inherits it and validation failed because the method existed only on `product.template`.
- Added `refresh_invoice_history` on `product.product` that delegates to `product_tmpl_id`.

## Test plan
- [ ] Install/update `deltatech_invoice_report` on a DB that also installs `deltatech_nap` (or any module reaching the `product.product` form view) — registry loads without `ParseError`.
- [ ] Open a product variant form, click Refresh on the History tab, confirm `product.invoice.history` is refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)