### PR TITLE
[IMP] deltatech_queue_job: cancel failed duplicates with same identity_key

### DIFF
--- a/deltatech_queue_job/__manifest__.py
+++ b/deltatech_queue_job/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech  Queue Job Enhancements",
     "summary": "Deltatech Queue Job",
     "author": "Terrabit, Dorin Hongu",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "license": "AGPL-3",
     "website": "https://www.terrabit.ro",
     "category": "Others",

--- a/deltatech_queue_job/models/queue_job.py
+++ b/deltatech_queue_job/models/queue_job.py
@@ -14,6 +14,44 @@ _logger = logging.getLogger(__name__)
 class QueueJob(models.Model):
     _inherit = "queue.job"
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._remove_failed_duplicates()
+        return records
+
+    def _remove_failed_duplicates(self):
+        """Cancel older jobs left in 'failed' state that share the same
+        identity_key as a freshly created job.
+
+        The standard deduplication (job_record_with_same_identity_key) only
+        considers active states (pending/enqueued/wait_dependencies), so a
+        failed job never blocks a new enqueue and dead duplicates pile up.
+        When a new job with the same identity_key is created we move the
+        previous failed ones to 'cancelled': the record (and its traceback) is
+        kept for diagnostics and the standard autovacuum cron will remove it
+        later based on the channel removal_interval.
+        """
+        keys = {record.identity_key for record in self if record.identity_key}
+        if not keys:
+            return
+        old_failed = self.sudo().search(
+            [
+                ("identity_key", "in", list(keys)),
+                ("state", "=", "failed"),
+                ("id", "not in", self.ids),
+            ]
+        )
+        if old_failed:
+            _logger.info(
+                "Cancelling %d failed job(s) superseded by a new job with the same identity_key",
+                len(old_failed),
+            )
+            old_failed._change_job_state(
+                "cancelled",
+                result=_("Superseded by a new job with the same identity_key"),
+            )
+
     @api.model
     def _api_job_runner(self, batch_size=20, max_seconds=50):
         """Runner dedicated to External API calls (e.g. cron-job.org)"""

--- a/deltatech_queue_job/readme/HISTORY.md
+++ b/deltatech_queue_job/readme/HISTORY.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 18.0.1.2.0
+
+- When a new job is created, automatically move older jobs left in the
+  `failed` state that share the same `identity_key` to `cancelled`. The
+  standard deduplication only checks active states
+  (pending/enqueued/wait_dependencies), so failed duplicates used to pile up.
+  The record and its traceback are kept for diagnostics and the standard
+  `autovacuum` cron removes cancelled jobs later based on the channel
+  `removal_interval`.


### PR DESCRIPTION
## Context

`identity_key` deduplicates jobs at **enqueue time**, but `job_record_with_same_identity_key()` only checks active states (`pending`, `enqueued`, `wait_dependencies`). A job left in `failed` therefore never blocks a new enqueue, so dead duplicates with the same `identity_key` accumulate over time.

## Change

Override `create()` in `deltatech_queue_job`: when a new job with an `identity_key` is created, older jobs in the `failed` state sharing that key are moved to `cancelled` via the standard `_change_job_state(CANCELLED)`.

Why `cancelled` instead of `unlink`:
- the record and its traceback are kept for diagnostics;
- it uses the official state-transition method, which also cancels dependent jobs (no orphans in the graph);
- the standard `autovacuum` cron later removes `cancelled` jobs based on the channel `removal_interval`.

Failed jobs are not locked by any running worker, so no `SKIP LOCKED` is needed.

## Notes

- Only the `failed` state is touched; `done`/`cancelled` stay with `autovacuum`, `started` orphans are out of scope.
- Version bumped to `18.0.1.2.0`, `readme/HISTORY.md` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
