### PR TITLE
[IMP] deltatech_queue_job: cancel failed duplicates with same identity_key (port 18.0)

### DIFF
--- a/deltatech_queue_job/__manifest__.py
+++ b/deltatech_queue_job/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech  Queue Job Enhancements",
     "summary": "Deltatech Queue Job",
     "author": "Terrabit, Dorin Hongu",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.2.0",
     "license": "AGPL-3",
     "website": "https://www.terrabit.ro",
     "category": "Others",

--- a/deltatech_queue_job/models/queue_job.py
+++ b/deltatech_queue_job/models/queue_job.py
@@ -14,6 +14,44 @@ _logger = logging.getLogger(__name__)
 class QueueJob(models.Model):
     _inherit = "queue.job"
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        records = super().create(vals_list)
+        records._remove_failed_duplicates()
+        return records
+
+    def _remove_failed_duplicates(self):
+        """Cancel older jobs left in 'failed' state that share the same
+        identity_key as a freshly created job.
+
+        The standard deduplication (job_record_with_same_identity_key) only
+        considers active states (pending/enqueued/wait_dependencies), so a
+        failed job never blocks a new enqueue and dead duplicates pile up.
+        When a new job with the same identity_key is created we move the
+        previous failed ones to 'cancelled': the record (and its traceback) is
+        kept for diagnostics and the standard autovacuum cron will remove it
+        later based on the channel removal_interval.
+        """
+        keys = {record.identity_key for record in self if record.identity_key}
+        if not keys:
+            return
+        old_failed = self.sudo().search(
+            [
+                ("identity_key", "in", list(keys)),
+                ("state", "=", "failed"),
+                ("id", "not in", self.ids),
+            ]
+        )
+        if old_failed:
+            _logger.info(
+                "Cancelling %d failed job(s) superseded by a new job with the same identity_key",
+                len(old_failed),
+            )
+            old_failed._change_job_state(
+                "cancelled",
+                result=self.env._("Superseded by a new job with the same identity_key"),
+            )
+
     @api.model
     def _api_job_runner(self, batch_size=20, max_seconds=50):
         """Runner dedicated to External API calls (e.g. cron-job.org)"""

--- a/deltatech_queue_job/readme/HISTORY.md
+++ b/deltatech_queue_job/readme/HISTORY.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 19.0.1.2.0
+
+- When a new job is created, automatically move older jobs left in the
+  `failed` state that share the same `identity_key` to `cancelled`. The
+  standard deduplication only checks active states
+  (pending/enqueued/wait_dependencies), so failed duplicates used to pile up.
+  The record and its traceback are kept for diagnostics and the standard
+  `autovacuum` cron removes cancelled jobs later based on the channel
+  `removal_interval`.

--- a/deltatech_queue_job/tests/__init__.py
+++ b/deltatech_queue_job/tests/__init__.py
@@ -1,4 +1,4 @@
 # ©  2024 Deltatech
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
-from . import test_queue_job
+from . import test_identity_key_dedup, test_queue_job

--- a/deltatech_queue_job/tests/test_identity_key_dedup.py
+++ b/deltatech_queue_job/tests/test_identity_key_dedup.py
@@ -1,0 +1,42 @@
+# ©  2024 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestQueueJobIdentityKeyDedup(TransactionCase):
+    def _enqueue(self, identity_key=None):
+        """Enqueue a real job (with a valid uuid and records) and return it."""
+        return self.env["queue.job"].with_delay(identity_key=identity_key)._test_job()
+
+    def test_failed_duplicate_cancelled_on_new_job(self):
+        """A new job cancels older failed jobs sharing the same identity_key."""
+        identity = "deltatech_qj_dedup_test"
+
+        failed = self._enqueue(identity_key=identity)
+        failed_record = failed.db_record()
+        failed.set_failed(exc_info="boom")
+        failed.store()
+        failed_record.invalidate_recordset(["state"])
+        self.assertEqual(failed_record.state, "failed")
+
+        new_job = self._enqueue(identity_key=identity)
+        new_record = new_job.db_record()
+
+        failed_record.invalidate_recordset(["state"])
+        self.assertEqual(failed_record.state, "cancelled")
+        self.assertEqual(new_record.state, "pending")
+        self.assertNotEqual(failed_record.id, new_record.id)
+
+    def test_failed_without_identity_key_is_kept(self):
+        """A new job without identity_key must not touch existing failed jobs."""
+        failed = self._enqueue()
+        failed_record = failed.db_record()
+        failed.set_failed(exc_info="boom")
+        failed.store()
+
+        self._enqueue()
+
+        failed_record.invalidate_recordset(["state"])
+        self.assertEqual(failed_record.state, "failed")


### PR DESCRIPTION
Port of #2544 to 19.0.

## Context

`identity_key` deduplicates jobs at **enqueue time**, but `job_record_with_same_identity_key()` only checks active states (`pending`, `enqueued`, `wait_dependencies`). A job left in `failed` never blocks a new enqueue, so dead duplicates with the same `identity_key` accumulate.

## Change

Override `create()`: when a new job with an `identity_key` is created, older `failed` jobs sharing that key are moved to `cancelled` via the standard `_change_job_state(CANCELLED)`. The record/traceback is kept for diagnostics and `autovacuum` removes cancelled jobs later based on the channel `removal_interval`.

Adapted for 19.0: uses `self.env._()` for the translated result message (no imported `_`). Version bumped to `19.0.1.2.0`, `readme/HISTORY.md` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
