### PR TITLE
[IMP] deltatech_stock_close: use check_access instead of deprecated check_access_rights

### DIFF
--- a/deltatech_stock_close/__manifest__.py
+++ b/deltatech_stock_close/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech Stock Close",
     "summary": "Close stock operations at date",
-    "version": "18.0.1.0.3",
+    "version": "18.0.1.0.4",
     "author": "Terrabit, Dorin Hongu, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "support": "support@terrabit.ro",

--- a/deltatech_stock_close/models/stock_report.py
+++ b/deltatech_stock_close/models/stock_report.py
@@ -33,7 +33,7 @@ class StorageSheet(models.TransientModel):
                     product_list = [-1]  # dummy list
                     all_products = True
 
-            self.env["account.move.line"].check_access_rights("read")
+            self.env["account.move.line"].check_access("read")
 
             lines = self.env["l10n.ro.stock.storage.sheet.line"].search([("report_id", "=", self.id)])
             lines.unlink()

--- a/deltatech_stock_close/readme/HISTORY.md
+++ b/deltatech_stock_close/readme/HISTORY.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 18.0.1.0.4
+
+- Replace deprecated `check_access_rights("read")` with `check_access("read")`
+  on `account.move.line` (the two ACL methods were merged in Odoo 18.0).


### PR DESCRIPTION
## Context
`check_access_rights()` is deprecated since Odoo 18.0 — it was merged with `check_access_rule()` into a single `check_access()` method. The XMLRPC layer logs a `DeprecationWarning` whenever it is used.

## Change
- `deltatech_stock_close/models/stock_report.py`: `account.move.line.check_access_rights("read")` → `check_access("read")`
- bump version `18.0.1.0.3` → `18.0.1.0.4`
- add `readme/HISTORY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)