### PR TITLE
[FIX] deltatech_queue_job: build jobs directly in dedup tests

### DIFF
--- a/deltatech_queue_job/tests/test_identity_key_dedup.py
+++ b/deltatech_queue_job/tests/test_identity_key_dedup.py
@@ -3,25 +3,33 @@
 # See README.rst file on addons root folder for license details
 from odoo.tests import TransactionCase, tagged
 
+from odoo.addons.queue_job.job import Job
+
 
 @tagged("post_install", "-at_install")
 class TestQueueJobIdentityKeyDedup(TransactionCase):
-    def _enqueue(self, identity_key=None):
-        """Enqueue a real job (with a valid uuid and records) and return it."""
-        return self.env["queue.job"].with_delay(identity_key=identity_key)._test_job()
+    def _store_job(self, identity_key=None, state=None):
+        """Persist a real queue.job record (with a valid uuid) and return it.
+
+        Built directly through ``Job`` so it is stored regardless of the
+        ``QUEUE_JOB__NO_DELAY`` test mode (where ``with_delay`` would run
+        inline and never create a record).
+        """
+        job = Job(self.env["queue.job"]._test_job, identity_key=identity_key)
+        if state == "failed":
+            job.set_failed(exc_info="boom")
+        job.store()
+        return job
 
     def test_failed_duplicate_cancelled_on_new_job(self):
         """A new job cancels older failed jobs sharing the same identity_key."""
         identity = "deltatech_qj_dedup_test"
 
-        failed = self._enqueue(identity_key=identity)
+        failed = self._store_job(identity_key=identity, state="failed")
         failed_record = failed.db_record()
-        failed.set_failed(exc_info="boom")
-        failed.store()
-        failed_record.invalidate_recordset(["state"])
         self.assertEqual(failed_record.state, "failed")
 
-        new_job = self._enqueue(identity_key=identity)
+        new_job = self._store_job(identity_key=identity)
         new_record = new_job.db_record()
 
         failed_record.invalidate_recordset(["state"])
@@ -31,12 +39,10 @@ class TestQueueJobIdentityKeyDedup(TransactionCase):
 
     def test_failed_without_identity_key_is_kept(self):
         """A new job without identity_key must not touch existing failed jobs."""
-        failed = self._enqueue()
+        failed = self._store_job(state="failed")
         failed_record = failed.db_record()
-        failed.set_failed(exc_info="boom")
-        failed.store()
 
-        self._enqueue()
+        self._store_job()
 
         failed_record.invalidate_recordset(["state"])
         self.assertEqual(failed_record.state, "failed")


### PR DESCRIPTION
Aligns the 19.0 dedup tests with the 18.0 fix (#2547).

## Context

The tests added in #2545 used `with_delay()._test_job()` to create jobs. Under `QUEUE_JOB__NO_DELAY` (the mode `oca_run_tests` uses in CI) that call runs the job inline and returns `None`, so no `queue.job` record is stored. It happened to pass on the 19.0 CI image, but it is fragile.

## Change

Build the `queue.job` records directly through `Job(...).store()`, so the tests work regardless of the no-delay test mode.

Verified locally on Odoo 19 with `QUEUE_JOB__NO_DELAY=1`: `0 failed, 0 error(s) of 2 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
