### PR TITLE
[19.0][FIX] deltatech_website_stock_availability: free_qty + product_template scoping

### DIFF
--- a/deltatech_website_stock_availability/__manifest__.py
+++ b/deltatech_website_stock_availability/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Stock Availability",
     "category": "Website",
     "summary": "eCommerce Stock Availability and lead time",
-    "version": "19.0.1.0.6",
+    "version": "19.0.1.0.7",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "depends": ["website", "website_sale_stock", "purchase", "deltatech_vendor_stock"],

--- a/deltatech_website_stock_availability/models/product.py
+++ b/deltatech_website_stock_availability/models/product.py
@@ -29,6 +29,11 @@ class ProductTemplate(models.Model):
         if not self.env.context.get("website_sale_stock_get_quantity"):
             return combination_info
 
+        if "free_qty" not in combination_info and combination_info.get("product_id"):
+            product = self.env["product.product"].sudo().browse(combination_info["product_id"])
+            website = self.env["website"].get_current_website()
+            combination_info["free_qty"] = website._get_product_available_qty(product)
+
         combination_info["lead_time"] = 0
         if combination_info["product_id"]:
             product = self.env["product.product"].sudo().browse(combination_info["product_id"])
@@ -40,6 +45,7 @@ class ProductTemplate(models.Model):
             combination_info["sale_delay_safety"] = product.sale_delay_safety
             combination_info["purchase_lead_time"] = company_lead_time + supplier_lead_time
             combination_info["availability_vendor"] = availability_vendor
+            combination_info["product_template"] = self.id
             if (
                 product.seller_ids
                 and product.seller_ids[0].date_start

--- a/deltatech_website_stock_availability/static/src/scss/lead_time_availability.scss
+++ b/deltatech_website_stock_availability/static/src/scss/lead_time_availability.scss
@@ -1,11 +1,23 @@
 .o_immediate_delivery {
     font-size: large;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 .o_subsequent_delivery {
     font-size: large;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }
 
 .o_stock_available {
     font-size: large;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.o_stock_unavailable {
+    font-size: large;
+    margin-top: 5px;
+    margin-bottom: 5px;
 }

--- a/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml
+++ b/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml
@@ -6,8 +6,7 @@
 
 
             <div
-                id="in_of_stock_message"
-                t-if="free_qty gt 0"
+                t-if="free_qty &gt; 0"
                 style="font-size: medium;"
                 t-attf-class="availability_message_#{product_template} text-success mt16 fw-bold"
             >
@@ -15,16 +14,14 @@
                 In stock
             </div>
 
-<!--
             <div
                 id="in_of_stock_message"
                 t-if="free_qty lte 0 and availability_vendor == 0"
-
-                t-attf-class="availability_message_#{product_template}  text-danger fw-bold">
-                <i class="fa fa-times me-1"/>
+                t-attf-class="availability_message_#{product_template}  text-danger fw-bold"
+            >
+                <i class="fa fa-times me-1" />
                 Out of stock
             </div>
--->
 
             <div
                 id="in_of_stock_message"
@@ -96,23 +93,22 @@
     <t t-name="deltatech_website_stock_availability.lead_time_availability">
         <div t-attf-class="lead_time_availability_#{product_template}">
             <div
-                id="in_of_stock_message"
-                t-if="free_qty gt 0"
+                t-if="free_qty &gt; 0"
                 style="font-size: medium;"
-                t-attf-class="availability_message_#{product_template} text-success mt16 fw-bold"
+                t-attf-class="deltatech_availability_message_#{product_template} text-success mt-3 fw-bold d-block"
             >
                 In stock
             </div>
             <!-- keep out of stock block commented as in main template -->
-            <!--
+
             <div
-                id="in_of_stock_message"
-                t-if="free_qty lte 0 and availability_vendor == 0"
-                t-attf-class="availability_message_#{product_template}  text-danger fw-bold">
-                <i class="fa fa-times me-1"/>
+                t-if="free_qty &lt;= 0 and availability_vendor == 0"
+                t-attf-class="availability_message_#{product_template}  text-danger fw-bold"
+            >
+                <i class="fa fa-times me-1" />
                 Out of stock
             </div>
-            -->
+
             <div
                 id="in_of_stock_message"
                 t-if="free_qty lte 0 and availability_vendor gt 0"

--- a/deltatech_website_stock_availability/tests/test_product.py
+++ b/deltatech_website_stock_availability/tests/test_product.py
@@ -80,3 +80,37 @@ class TestProduct(TransactionCase):
         with MockRequest(self.env, website=website):
             product = self.product_b.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)
             product._get_combination_info(product_id=self.product_b.id)
+
+    def test_combination_info_includes_free_qty(self):
+        # garda defensivă asigură free_qty în combination_info pentru template-urile QWeb
+        website = self.env["website"].create({"name": "Test Website"})
+        with MockRequest(self.env, website=website):
+            tmpl = self.product_a.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)
+            info = tmpl._get_combination_info(product_id=self.product_a.id)
+            self.assertIn("free_qty", info)
+            self.assertGreater(info["free_qty"], 0, "Produsul A are 1000 în stoc")
+
+    def test_combination_info_free_qty_zero_when_no_stock(self):
+        # produsul C nu are stoc -> free_qty == 0 (nu lipsă/undefined)
+        website = self.env["website"].create({"name": "Test Website"})
+        with MockRequest(self.env, website=website):
+            tmpl = self.product_c.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)
+            info = tmpl._get_combination_info(product_id=self.product_c.id)
+            self.assertIn("free_qty", info)
+            self.assertEqual(info["free_qty"], 0)
+
+    def test_combination_info_sets_product_template(self):
+        # product_template = id-ul template-ului, folosit de JS pentru scoping clase wrapper
+        website = self.env["website"].create({"name": "Test Website"})
+        with MockRequest(self.env, website=website):
+            tmpl = self.product_a.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)
+            info = tmpl._get_combination_info(product_id=self.product_a.id)
+            self.assertEqual(info.get("product_template"), self.product_a.product_tmpl_id.id)
+
+    def test_combination_info_untouched_without_context(self):
+        # fără contextul de stoc, modulul nu intervine (nu adaugă product_template)
+        website = self.env["website"].create({"name": "Test Website"})
+        with MockRequest(self.env, website=website):
+            tmpl = self.product_a.product_tmpl_id
+            info = tmpl._get_combination_info(product_id=self.product_a.id)
+            self.assertNotIn("product_template", info)

--- a/deltatech_website_stock_availability/tests/test_product.py
+++ b/deltatech_website_stock_availability/tests/test_product.py
@@ -90,6 +90,19 @@ class TestProduct(TransactionCase):
             self.assertIn("free_qty", info)
             self.assertGreater(info["free_qty"], 0, "Produsul A are 1000 în stoc")
 
+    def test_combination_info_free_qty_guard_for_non_storable(self):
+        # pentru produse non-storable core-ul O19 NU pune free_qty -> garda din modul
+        # îl injectează prin website._get_product_available_qty (acoperă blocul defensiv)
+        consu = self.env["product.product"].create(
+            {"name": "Test Consu", "type": "consu", "is_storable": False, "list_price": 10}
+        )
+        website = self.env["website"].create({"name": "Test Website"})
+        with MockRequest(self.env, website=website):
+            tmpl = consu.product_tmpl_id.with_context(website_sale_stock_get_quantity=True)
+            info = tmpl._get_combination_info(product_id=consu.id)
+            self.assertIn("free_qty", info)
+            self.assertEqual(info["free_qty"], 0)
+
     def test_combination_info_free_qty_zero_when_no_stock(self):
         # produsul C nu are stoc -> free_qty == 0 (nu lipsă/undefined)
         website = self.env["website"].create({"name": "Test Website"})


### PR DESCRIPTION
## Drift 18→19 adus în 19.0

Analiza de drift a găsit un commit de fix din 18.0 (`dbd9c295d`, 5 mai 2026) apărut **după** migrarea modulului în 19.0, deci niciodată propagat. Restul „diferențelor" din raportul inițial (`parent_combination→uom_id`, `company_lead_time`, glob assets) erau false pozitive — deja corect adaptate la API-ul O19.

### Modificări
1. **Gardă defensivă `free_qty`** — core-ul O19 pune `free_qty` în `combination_info` doar pentru produse `is_storable`+variantă cu context special. Pentru restul, modulul îl injectează acum prin `website._get_product_available_qty(product)`, altfel template-urile QWeb primeau `undefined` → mesaje de disponibilitate greșite.
2. **`combination_info["product_template"] = self.id`** — clasele wrapper QWeb (`lead_time_availability_<id>` / `lead_time_interval_<id>`) sunt folosite de JS (`variant_mixin.esm.js`) pentru curățare prin `querySelectorAll`. Fără el deveneau `..._undefined` → elementele se **acumulau** la schimbarea variantei.
3. Decomentează blocul **„Out of stock"** în ambele template-uri + clasa SCSS `o_stock_unavailable`.

### Verificat în browser (Preview MCP) pe shop
Produs storable publicat, ambele stări:
- **In stock** (`free_qty=25`) → afișează „In stock", wrapper `lead_time_availability_357` (id real, nu `undefined`)
- **Out of stock** (`free_qty=0`) → afișează „Out of stock", **un singur wrapper** (fără acumulare)
- **zero erori în consolă** în ambele cazuri

Adaptat manual la O19 (nu cherry-pick brut). Bump versiune `19.0.1.0.6` → `19.0.1.0.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)