### PR TITLE
[FIX] deltatech_record_type: re-add type column in list views (#2144)

### DIFF
--- a/deltatech_record_type/__manifest__.py
+++ b/deltatech_record_type/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Terrabit - Record Type",
     "summary": "Manage multiple record types",
-    "version": "19.0.1.1.11",
+    "version": "19.0.1.1.12",
     "author": "Terrabit, Voicu Stefan",
     "website": "https://www.terrabit.ro",
     "category": "Generic Modules/Other",

--- a/deltatech_record_type/views/account_move_view.xml
+++ b/deltatech_record_type/views/account_move_view.xml
@@ -18,6 +18,17 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="view_invoice_tree">
+        <field name="name">account.invoice.list</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree" />
+        <field name="arch" type="xml">
+            <field name="invoice_date" position="after">
+                <field name="invoice_type" optional="hide" />
+            </field>
+        </field>
+    </record>
+
     <record model="ir.actions.act_window" id="action_invoice_type">
         <field name="name">Invoice Types</field>
         <field name="res_model">record.type</field>

--- a/deltatech_record_type/views/purchase_view.xml
+++ b/deltatech_record_type/views/purchase_view.xml
@@ -21,6 +21,28 @@
         </field>
     </record>
 
+    <record model="ir.ui.view" id="purchase_order_view_tree">
+        <field name="name">purchase.order.view.list</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_view_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="po_type" optional="hide" />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="purchase_order_kpis_tree">
+        <field name="name">purchase.order.inherit.purchase.order.list</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_kpis_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="po_type" optional="hide" />
+            </field>
+        </field>
+    </record>
+
 
     <record model="ir.actions.act_window" id="action_purchase_order_type">
         <field name="name">Order Types</field>

--- a/deltatech_record_type/views/sale_view.xml
+++ b/deltatech_record_type/views/sale_view.xml
@@ -41,6 +41,17 @@
             </xpath>
         </field>
     </record>
+    <!--        Sale order tree view-->
+    <record model="ir.ui.view" id="sale_order_tree">
+        <field name="name">saleorder.type.saleorder.list</field>
+        <field name="model">sale.order</field>
+        <field name="inherit_id" ref="sale.sale_order_tree" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="so_type" optional="hide" />
+            </field>
+        </field>
+    </record>
 
 
     <record model="ir.actions.act_window" id="action_sale_order_type">


### PR DESCRIPTION
## Context
La migrarea 18.0 → 19.0 a modulului `deltatech_record_type` s-a pierdut funcționalitatea introdusă pe 18.0 prin #2144 (commit `a554d1fa0`, versiunea `18.0.1.1.12`): coloana opțională de **tip** în view-urile de listă. Versiunea 19.0 rămăsese la `19.0.1.1.11`, un patch în urmă.

Toate view-urile părinte vizate există în continuare în Odoo 19 core (`purchase.purchase_order_view_tree`, `purchase.purchase_order_kpis_tree`, `sale.sale_order_tree`, `account.view_invoice_tree`), deci eliminarea de la migrare a fost o regresie, nu o adaptare necesară.

## Modificări
- Re-adaugă coloana `po_type` (optional=hide) în listele `purchase.order` (form view tree + kpis tree)
- Re-adaugă coloana `so_type` (optional=hide) în lista `sale.order`
- Re-adaugă coloana `invoice_type` (optional=hide) în lista `account.move` (după `invoice_date`)
- Bump versiune `19.0.1.1.11` → `19.0.1.1.12` (paritate cu 18.0)

## Testare
- `-i deltatech_record_type` pe baza `test19` — instalare fără erori
- Cele 4 view-uri confirmate înregistrate în `ir_model_data` și aplicate
- pre-commit verde (ruff, pylint_odoo, prettier-xml, manifest, check-xml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)