### PR TITLE
[FIX] deltatech_purchase_price: ultimul preț de achiziție pe șablon multi-variantă (tichet 8403)

### DIFF
--- a/deltatech_purchase_price/__manifest__.py
+++ b/deltatech_purchase_price/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Purchase Price",
     "summary": "Update vendor price after reception",
-    "version": "19.0.1.2.6",
+    "version": "19.0.1.2.7",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_purchase_price/models/product.py
+++ b/deltatech_purchase_price/models/product.py
@@ -32,9 +32,37 @@ class ProductTemplate(models.Model):
         company_dependent=True,
     )
 
+    @api.depends("product_variant_ids.last_purchase_price", "seller_ids.price", "seller_ids.product_id")
     @api.depends_context("company")
     def _compute_last_purchase_price(self):
-        self._compute_template_field_from_variant_field("last_purchase_price")
+        # Single-variant (and variant-less) templates keep the native behaviour:
+        # the template value mirrors its only variant. For multi-variant
+        # templates the native helper would fall back to 0 (variants may hold
+        # different costs), which leaves the template price at 0 and breaks the
+        # markup-based sale price. Instead we surface the most recently updated
+        # supplier price, regardless of variant (ticket 8403).
+        single = self.filtered(lambda t: len(t.product_variant_ids) <= 1)
+        single._compute_template_field_from_variant_field("last_purchase_price")
+        for template in self - single:
+            template.last_purchase_price = template._get_last_purchase_price_from_sellers()
+
+    def _get_last_purchase_price_from_sellers(self):
+        """Last purchase price to show on a multi-variant template.
+
+        Picks the purchase price of the variant tied to the most recently
+        updated vendor line (``product.supplierinfo``); a template-level vendor
+        line falls back to the first variant. When no vendor line yields a
+        price, falls back to the highest known purchase price across variants,
+        so the template never collapses to 0 while any variant has a cost.
+        """
+        self.ensure_one()
+        sellers = self.seller_ids.sorted(key=lambda s: s.write_date or s.create_date, reverse=True)
+        for seller in sellers:
+            variant = seller.product_id or self.product_variant_ids[:1]
+            if variant.last_purchase_price:
+                return variant.last_purchase_price
+        prices = [p for p in self.product_variant_ids.mapped("last_purchase_price") if p]
+        return max(prices) if prices else 0.0
 
     def _inverse_last_purchase_price(self):
         self._set_product_variant_field("last_purchase_price")

--- a/deltatech_purchase_price/tests/test_purchase.py
+++ b/deltatech_purchase_price/tests/test_purchase.py
@@ -87,6 +87,50 @@ class TestPurchase(TransactionCase):
         # se verifica ultimul pret de achizitie
         self.assertEqual(self.product_a.last_purchase_price, 10.0)
 
+    def test_multi_variant_last_purchase_price(self):
+        # produs cu mai multe variante: pe sablon ultimul pret de achizitie nu
+        # mai trebuie sa fie 0, ci pretul de la furnizor (tichet 8403)
+        attribute = self.env["product.attribute"].create(
+            {
+                "name": "Test Size",
+                "create_variant": "always",
+                "value_ids": [(0, 0, {"name": "S"}), (0, 0, {"name": "L"})],
+            }
+        )
+        template = self.env["product.template"].create(
+            {
+                "name": "Variant template",
+                "is_storable": True,
+                "trade_markup": 10,
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": attribute.id,
+                            "value_ids": [(6, 0, attribute.value_ids.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        self.assertEqual(len(template.product_variant_ids), 2)
+        # nativ, sablonul multi-varianta ar avea 0
+        self.assertEqual(template.last_purchase_price, 0.0)
+
+        variant_l = template.product_variant_ids[-1]
+        self.env["product.supplierinfo"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "product_tmpl_id": template.id,
+                "product_id": variant_l.id,
+                "price": 20,
+            }
+        )
+        # furnizorul actualizeaza pretul variantei, iar sablonul il preia
+        self.assertEqual(variant_l.last_purchase_price, 20.0)
+        self.assertEqual(template.last_purchase_price, 20.0)
+
     def test_wizard_trade_markup(self):
         wizard = Form(self.env["product.markup.wizard"])
         wizard.trade_markup = 10


### PR DESCRIPTION
## Context (tichet helpdesk #8403 — REPER V TRANS)

La produsele **cu mai multe variante**, prețul de vânzare ieșea **0**. Cauza: câmpul `last_purchase_price` de pe `product.template` se calcula prin helper-ul nativ `_compute_template_field_from_variant_field`, care populează valoarea pe șablon **doar la o singură variantă** (variantele pot avea costuri diferite, deci la multi-variantă pune 0). Listele de preț calculate ca adaos față de prețul furnizorului / cost rezultau astfel 0. La produsele fără variante totul funcționa corect.

## Soluție (agreată cu clientul)

Pe șablon se trece **ultimul preț actualizat de la furnizor, indiferent de variantă**:

- la multi-variantă, `_compute_last_purchase_price` ia prețul variantei legate de cel mai recent `product.supplierinfo` (după `write_date`);
- fallback: maximul prețurilor non-zero ale variantelor (șablonul nu mai colapsează la 0 câtă vreme o variantă are cost);
- single-variantă rămâne pe comportamentul nativ.

S-a adăugat `@api.depends` pe `product_variant_ids.last_purchase_price` și pe `seller_ids`, astfel încât șablonul se recalculează când se schimbă prețul de la furnizor (fără asta, valoarea computată rămânea în cache).

## Test

- test nou `test_multi_variant_last_purchase_price` (produs cu 2 variante → șablonul preia prețul furnizorului, nu 0);
- toate cele 6 teste din modul trec pe bază curată.

## Note

- Componenta de **sincronizare OpenCart** (preț pe șablon vs. per variantă) rămâne o decizie separată, în afara acestui PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)