### PR TITLE
[FIX] deltatech_dc: page-break-after removes for declaration of conformity

### DIFF
--- a/deltatech_dc/views/report_dc.xml
+++ b/deltatech_dc/views/report_dc.xml
@@ -7,7 +7,7 @@
             <t t-call="web.external_layout">
                 <div class="page">
                     <t t-foreach="docs" t-as="o">
-                        <div id="declaration" style="page-break-after: always; page-break-inside: avoid;">
+                        <div id="declaration" style="page-break-inside: avoid;">
                             <h3>
                                 <span>Declaration of Conformity:</span>
                                 <span t-field="o.name" />


### PR DESCRIPTION
## Summary

- În Odoo 19 randorul QWeb respectă `page-break-after: always`, spre deosebire de v18 care îl ignora
- Rezultat: fiecare declarație de conformitate forța o pagină nouă → ~1 declarație/pagină
- Fix: scos `page-break-after: always`, păstrat `page-break-inside: avoid`

## Test plan

- [ ] Printează declarație de conformitate cu ≥3 produse și verifică că apar ~3 declarații/pagină
- [ ] Verifică că o declarație nu e tăiată la mijloc de un page break

Tichet: #8887 (migrare Romchim v19)

🤖 Generated with [Claude Code](https://claude.com/claude-code)