### PR TITLE
[FIX] deltatech_vendor_stock: cheie context location (drift 18.0→19.0)

### DIFF
--- a/deltatech_vendor_stock/__manifest__.py
+++ b/deltatech_vendor_stock/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Vendor Stock",
     "summary": "Vendor stock availability",
-    "version": "19.0.1.1.7",
+    "version": "19.0.1.1.8",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_vendor_stock/models/sale_order.py
+++ b/deltatech_vendor_stock/models/sale_order.py
@@ -64,7 +64,7 @@ class SaleOrderLine(models.Model):
                                 self.env.context.get("to_date"),
                             )
                         else:
-                            qty = product.with_context(location_id=warehouse.lot_stock_id.id)._compute_quantities_dict(
+                            qty = product.with_context(location=warehouse.lot_stock_id.id)._compute_quantities_dict(
                                 self.env.context.get("lot_id"),
                                 self.env.context.get("owner_id"),
                                 self.env.context.get("package_id"),


### PR DESCRIPTION
## Context

Reconciliere drift 18.0 → 19.0 pentru `deltatech_vendor_stock` (modulul era deja pe seria 19.0).

## Modificare
Backport al `814130ece` din 18.0: cheia de context transmisă lui `_compute_quantities_dict` în ramura `use_only_main_location` era `location_id`, dar kernel-ul stock din Odoo 19 citește `context.get('location')`. Rezultat: când `deltatech_vendor_stock.use_only_main_location = 1`, stocul afișat per depozit era cel total al produsului, nu cel din locația principală a depozitului.

`location_id` → `location` în `models/sale_order.py`. Bump versiune `19.0.1.1.7` → `19.0.1.1.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)