### PR TITLE
[18.0][FIX] deltatech_product_code: unicitate cod intern corectă (company NULL)

### DIFF
--- a/deltatech_product_code/__manifest__.py
+++ b/deltatech_product_code/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Products Code",
     "summary": "Product codification internal",
-    "version": "18.0.1.0.7",
+    "version": "18.0.1.0.8",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_product_code/models/product.py
+++ b/deltatech_product_code/models/product.py
@@ -5,7 +5,8 @@
 
 import random
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class ProductCategory(models.Model):
@@ -17,16 +18,29 @@ class ProductCategory(models.Model):
     barcode_random = fields.Boolean(default=True)
 
 
+def _conflicting_company(company_a, company_b):
+    """Doua coduri intra in conflict daca apartin aceleiasi companii sau daca
+    cel putin unul e partajat (company_id = False) — in PostgreSQL NULL != NULL,
+    deci o constrangere SQL unique(default_code, active, company_id) NU prinde
+    duplicatele cu company_id NULL. De aceea verificam in Python."""
+    return not company_a or not company_b or company_a == company_b
+
+
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
-    _sql_constraints = [
-        (
-            "name_code",
-            "unique (default_code,active,company_id)",
-            "Internal Reference already exists !",
-        ),
-    ]
+    @api.constrains("default_code", "active", "company_id")
+    def _check_default_code_unique(self):
+        for product in self:
+            if not product.default_code or not product.active:
+                continue
+            others = self.search([("default_code", "=", product.default_code), ("id", "!=", product.id)])
+            for other in others:
+                if _conflicting_company(product.company_id, other.company_id):
+                    raise ValidationError(
+                        _("Referința internă '%(code)s' există deja la produsul '%(name)s'!")
+                        % {"code": product.default_code, "name": other.display_name}
+                    )
 
     @api.model
     def get_new_code(self, categ, default_code, barcode):
@@ -115,6 +129,20 @@ class ProductTemplate(models.Model):
 class ProductProduct(models.Model):
     _inherit = "product.product"
 
+    @api.constrains("default_code", "active")
+    def _check_default_code_unique(self):
+        for product in self:
+            if not product.default_code or not product.active:
+                continue
+            company = product.product_tmpl_id.company_id
+            others = self.search([("default_code", "=", product.default_code), ("id", "!=", product.id)])
+            for other in others:
+                if _conflicting_company(company, other.product_tmpl_id.company_id):
+                    raise ValidationError(
+                        _("Referința internă '%(code)s' există deja la produsul '%(name)s'!")
+                        % {"code": product.default_code, "name": other.display_name}
+                    )
+
     # la crearea unei variante nu se codifica automat si produsul
     # codificare automata  la creare
     @api.model_create_multi
@@ -163,11 +191,13 @@ class ProductProduct(models.Model):
 
     @api.model
     def show_not_unique(self):
+        # product_product nu are coloana company_id (compania vine din template)
         sql = """
              SELECT id FROM
               (SELECT *, count(*)
-                   OVER   (PARTITION BY  default_code, active, company_id) AS count
-                    FROM product_product)
+                   OVER   (PARTITION BY  default_code, active) AS count
+                    FROM product_product
+                    WHERE default_code IS NOT NULL AND default_code <> '')
                tableWithCount
               WHERE tableWithCount.count > 1;
         """

--- a/deltatech_product_code/models/product.py
+++ b/deltatech_product_code/models/product.py
@@ -4,6 +4,7 @@
 
 
 import random
+from collections import defaultdict
 
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
@@ -26,21 +27,38 @@ def _conflicting_company(company_a, company_b):
     return not company_a or not company_b or company_a == company_b
 
 
+def _check_unique_default_code(records, company_of):
+    """Verifica unicitatea default_code pe un recordset, cu O SINGURA interogare
+    (nu una per inregistrare), ca sa scaleze la import/scriere in lot pe baze mari.
+    `company_of(rec)` intoarce compania inregistrarii."""
+    to_check = records.filtered(lambda p: p.default_code and p.active)
+    if not to_check:
+        return
+    codes = list({p.default_code for p in to_check})
+    # un singur search indexat (default_code IN [...]); active_test filtreaza activele
+    by_code = defaultdict(list)
+    for rec in records.search([("default_code", "in", codes)]):
+        by_code[rec.default_code].append(rec)
+    for product in to_check:
+        company = company_of(product)
+        for other in by_code[product.default_code]:
+            if other.id != product.id and _conflicting_company(company, company_of(other)):
+                raise ValidationError(
+                    _("Referința internă '%(code)s' există deja la produsul '%(name)s'!")
+                    % {"code": product.default_code, "name": other.display_name}
+                )
+
+
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    # index pe default_code (campul standard e stored dar neindexat) — necesar
+    # ca search-ul din constrangere sa fie rapid pe baze mari
+    default_code = fields.Char(index=True)
+
     @api.constrains("default_code", "active", "company_id")
     def _check_default_code_unique(self):
-        for product in self:
-            if not product.default_code or not product.active:
-                continue
-            others = self.search([("default_code", "=", product.default_code), ("id", "!=", product.id)])
-            for other in others:
-                if _conflicting_company(product.company_id, other.company_id):
-                    raise ValidationError(
-                        _("Referința internă '%(code)s' există deja la produsul '%(name)s'!")
-                        % {"code": product.default_code, "name": other.display_name}
-                    )
+        _check_unique_default_code(self, lambda p: p.company_id)
 
     @api.model
     def get_new_code(self, categ, default_code, barcode):
@@ -131,17 +149,7 @@ class ProductProduct(models.Model):
 
     @api.constrains("default_code", "active")
     def _check_default_code_unique(self):
-        for product in self:
-            if not product.default_code or not product.active:
-                continue
-            company = product.product_tmpl_id.company_id
-            others = self.search([("default_code", "=", product.default_code), ("id", "!=", product.id)])
-            for other in others:
-                if _conflicting_company(company, other.product_tmpl_id.company_id):
-                    raise ValidationError(
-                        _("Referința internă '%(code)s' există deja la produsul '%(name)s'!")
-                        % {"code": product.default_code, "name": other.display_name}
-                    )
+        _check_unique_default_code(self, lambda p: p.product_tmpl_id.company_id)
 
     # la crearea unei variante nu se codifica automat si produsul
     # codificare automata  la creare

--- a/deltatech_product_code/tests/test_product_code.py
+++ b/deltatech_product_code/tests/test_product_code.py
@@ -2,6 +2,7 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+from odoo.exceptions import ValidationError
 from odoo.tests.common import TransactionCase
 
 
@@ -153,6 +154,37 @@ class TestProductCode(TransactionCase):
         # Based on product.py lines 60-91 (commented out) and 118-149
         for variant in product_template.product_variant_ids:
             self.assertTrue(variant.default_code.startswith("TEST/"))
+
+    def test_duplicate_code_blocked_template(self):
+        # produsele de test au company_id = False (NULL) — cazul pe care
+        # vechea constrangere SQL unique(default_code, active, company_id) il rata
+        self.env["product.template"].create(
+            {"name": "Prod A", "categ_id": self.product_category.id, "default_code": "DUP001"}
+        )
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].create(
+                {"name": "Prod B", "categ_id": self.product_category.id, "default_code": "DUP001"}
+            )
+
+    def test_duplicate_code_blocked_product(self):
+        self.env["product.product"].create(
+            {"name": "Var A", "categ_id": self.product_category.id, "default_code": "DUP002"}
+        )
+        with self.assertRaises(ValidationError):
+            self.env["product.product"].create(
+                {"name": "Var B", "categ_id": self.product_category.id, "default_code": "DUP002"}
+            )
+
+    def test_duplicate_code_archived_allowed(self):
+        # un produs arhivat nu trebuie sa blocheze refolosirea codului
+        product_a = self.env["product.template"].create(
+            {"name": "Prod A", "categ_id": self.product_category.id, "default_code": "DUP003"}
+        )
+        product_a.active = False
+        product_b = self.env["product.template"].create(
+            {"name": "Prod B", "categ_id": self.product_category.id, "default_code": "DUP003"}
+        )
+        self.assertEqual(product_b.default_code, "DUP003")
 
     def test_barcode_random(self):
         self.product_category.write({"generate_barcode": True, "barcode_random": True})

--- a/deltatech_product_code/tests/test_product_code.py
+++ b/deltatech_product_code/tests/test_product_code.py
@@ -175,6 +175,16 @@ class TestProductCode(TransactionCase):
                 {"name": "Var B", "categ_id": self.product_category.id, "default_code": "DUP002"}
             )
 
+    def test_duplicate_code_blocked_in_same_batch(self):
+        # doua coduri identice in acelasi create in lot trebuie blocate
+        with self.assertRaises(ValidationError):
+            self.env["product.template"].create(
+                [
+                    {"name": "Prod A", "categ_id": self.product_category.id, "default_code": "DUP010"},
+                    {"name": "Prod B", "categ_id": self.product_category.id, "default_code": "DUP010"},
+                ]
+            )
+
     def test_duplicate_code_archived_allowed(self):
         # un produs arhivat nu trebuie sa blocheze refolosirea codului
         product_a = self.env["product.template"].create(


### PR DESCRIPTION
## Problema
Tichet helpdesk **8894** (Ridacon): la creare/import produsele primesc același cod intern (`default_code`), ex. `CP086753` apărea pe 3 produse.

Cauza: constrângerea `_sql_constraints` `unique(default_code, active, company_id)` **nu prinde duplicatele când `company_id` este NULL**, fiindcă în PostgreSQL `NULL != NULL` într-un index unique. La instalările single-company (unde produsele au `company_id` gol) constrângerea era practic inactivă.

Investigația pe staging a confirmat că generarea codului din secvență funcționează corect în toate fluxurile (creare, duplicare, lot, variante) — problema era **lipsa unei constrângeri eficiente**, nu generarea.

## Modificări
- **Înlocuit** `_sql_constraints` cu `@api.constrains` în Python, pe `product.template` **și** `product.product` — corect pe companie și NULL-safe (un cod partajat, `company_id` gol, intră în conflict cu orice).
- **Reparat** `show_not_unique` pe `product.product` — interoga `company_id`, coloană care nu există pe tabela `product_product` (compania vine din template).
- **Teste noi**: blocarea duplicatelor (inclusiv cazul `company_id` NULL) și permiterea refolosirii codului după arhivare.

## Testare
`deltatech_product_code` — **11/11 teste trec**, 0 erori (rulat local pe o18_test).

## Note de rollout
Constrângerea în Python **nu blochează update-ul modulului** chiar dacă există deja duplicate (spre deosebire de un index SQL unique). Recomandare:
1. Deploy modulul.
2. Rulare script de corectare a duplicatelor existente (`force_new_code` per duplicat, păstrând primul).
3. De acum duplicatele sunt respinse cu mesaj clar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)