### PR TITLE
[FIX] deltatech_website_sale_status: restaurează filtrele de portal pierdute la migrarea 18->19

### DIFF
--- a/deltatech_website_sale_status/controllers/portal.py
+++ b/deltatech_website_sale_status/controllers/portal.py
@@ -13,8 +13,17 @@ class CustomerPortal(portal.CustomerPortal):
         values = super()._prepare_portal_layout_values()
         if "show_order_fiter" in request.env.context:
             searchbar_filters = {
-                "open_order": {"label": _("Open Orders"), "domain": [("stage", "not in", ["delivered", "cancel"])]},
                 "all": {"label": _("All"), "domain": []},
+                "open_order": {"label": _("Open Orders"), "domain": [("stage", "not in", ["delivered", "cancel"])]},
+                "closed_order": {"label": _("Closed Orders"), "domain": [("stage", "in", ["delivered", "cancel"])]},
+                "placed": {"label": _("Placed"), "domain": [("stage", "=", "placed")]},
+                "in_process": {"label": _("In Process"), "domain": [("stage", "=", "in_process")]},
+                "waiting": {"label": _("Waiting availability"), "domain": [("stage", "=", "waiting")]},
+                "postponed": {"label": _("Postponed"), "domain": [("stage", "=", "postponed")]},
+                "to_be_delivery": {"label": _("To Be Delivery"), "domain": [("stage", "=", "to_be_delivery")]},
+                "in_delivery": {"label": _("In Delivery"), "domain": [("stage", "=", "in_delivery")]},
+                "delivered": {"label": _("Delivered"), "domain": [("stage", "=", "delivered")]},
+                "cancel": {"label": _("Canceled"), "domain": [("stage", "=", "cancel")]},
             }
             values.update(
                 {
@@ -36,16 +45,72 @@ class CustomerPortal(portal.CustomerPortal):
 
     def _prepare_orders_domain(self, partner):
         domain = super()._prepare_orders_domain(partner)
-        if request.params.get("filterby", "") == "open_order":
-            domain += [("stage", "not in", ["delivered", "cancel"])]
+
+        filterby = request.params.get("filterby", "")
+        match filterby:
+            case "open_order":
+                domain += [("stage", "not in", ["delivered", "cancel"])]
+            case "closed_order":
+                domain += [("stage", "in", ["delivered", "cancel"])]
+            case "placed":
+                domain += [("stage", "=", "placed")]
+            case "in_process":
+                domain += [("stage", "=", "in_process")]
+            case "waiting":
+                domain += [("stage", "=", "waiting")]
+            case "postponed":
+                domain += [("stage", "=", "postponed")]
+            case "to_be_delivery":
+                domain += [("stage", "=", "to_be_delivery")]
+            case "in_delivery":
+                domain += [("stage", "=", "in_delivery")]
+            case "delivered":
+                domain += [("stage", "=", "delivered")]
+            case "cancel":
+                domain += [("stage", "=", "cancel")]
+            case _:
+                # Default case, no additional filter
+                pass
+
         return domain
 
     @http.route()
     def portal_my_orders(self, page=1, date_begin=None, date_end=None, sortby=None, filterby=None, **kw):
         request.update_context(show_order_fiter=True)
+        if not filterby:
+            filterby = "all"
         result = super().portal_my_orders(
             page=page, date_begin=date_begin, date_end=date_end, sortby=sortby, filterby=filterby, **kw
         )
 
         result.qcontext["filterby"] = request.params.get("filterby", "all")
         return result
+
+    def _prepare_sale_portal_rendering_values(
+        self, page=1, date_begin=None, date_end=None, sortby=None, quotation_page=False, **kwargs
+    ):
+        filterby = kwargs.get("filterby", "all")
+        if not filterby:
+            filterby = "all"
+            kwargs["filterby"] = filterby
+
+        values = super()._prepare_sale_portal_rendering_values(
+            page=page, date_begin=date_begin, date_end=date_end, sortby=sortby, quotation_page=quotation_page, **kwargs
+        )
+
+        values["filterby"] = filterby
+        values["pager"] = self.fix_pager_filer(values["pager"], filterby)
+
+        return values
+
+    def fix_pager_filer(self, pager, filterby):
+        pager["page"]["url"] = pager["page"]["url"] + "&filterby=" + filterby
+        pager["page_first"]["url"] = pager["page_first"]["url"] + "&filterby=" + filterby
+        pager["page_start"]["url"] = pager["page_start"]["url"] + "&filterby=" + filterby
+        pager["page_previous"]["url"] = pager["page_previous"]["url"] + "&filterby=" + filterby
+        pager["page_next"]["url"] = pager["page_next"]["url"] + "&filterby=" + filterby
+        pager["page_end"]["url"] = pager["page_end"]["url"] + "&filterby=" + filterby
+        pager["page_last"]["url"] = pager["page_last"]["url"] + "&filterby=" + filterby
+        for page in pager["pages"]:
+            page["url"] = page["url"] + "&filterby=" + filterby
+        return pager


### PR DESCRIPTION
## Context
La migrarea 18→19 (#2227), controllerul de portal `deltatech_website_sale_status` a fost adus doar în varianta simplificată (doar filtrele `open_order` și `all`). Varianta completă din 18.0 **nu a existat niciodată pe 19.0** (`git log -S "placed"` pe `origin/19.0` nu găsește nimic) — deci e funcționalitate pierdută la replay, nu un redesign intenționat.

Descoperit în timpul verificării migrării proiectului **Ridacon**, care depinde de acest modul.

## Ce restaurează
- Cele **11 filtre de stadiu** din portalul clientului: `closed_order`, `placed`, `in_process`, `waiting`, `postponed`, `to_be_delivery`, `in_delivery`, `delivered`, `cancel` (pe lângă `open_order` + `all`)
- Logica `match-case` din `_prepare_orders_domain`
- `_prepare_sale_portal_rendering_values` + `fix_pager_filer` — păstrarea parametrului `filterby` la navigarea între pagini

## Adaptare O19
Se păstrează `request.env.context` (corect O19) introdus la migrare. Toate cele 3 metode super (`_prepare_orders_domain`, `_get_sale_searchbar_sortings`, `_prepare_sale_portal_rendering_values`) există nemodificate în `sale/controllers/portal.py` pe O19, cu semnături potrivite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)