### PR TITLE
[19.0][FIX] deltatech_purchase_xls: teste fără date demo + citire xlsx cu openpyxl

### DIFF
--- a/deltatech_purchase_xls/tests/test_import_xlsx.py
+++ b/deltatech_purchase_xls/tests/test_import_xlsx.py
@@ -44,9 +44,10 @@ class TestImportXLS(TransactionCase):
         )
 
         # Create a purchase order
+        self.partner = self.env["res.partner"].create({"name": "vendor"})
         self.purchase_order = self.env["purchase.order"].create(
             {
-                "partner_id": self.env.ref("base.res_partner_1").id,
+                "partner_id": self.partner.id,
                 "date_order": fields.Date.today(),
                 "order_line": [
                     (

--- a/deltatech_purchase_xls/wizard/import_purchase_line.py
+++ b/deltatech_purchase_xls/wizard/import_purchase_line.py
@@ -1,4 +1,5 @@
 import base64
+import io
 import logging
 
 from odoo import api, fields, models
@@ -8,15 +9,11 @@ _logger = logging.getLogger(__name__)
 
 # todo: de folosit
 # from odoo.tools.misc import xlsxwriter
+# xlrd >= 2.0 nu mai citește fișiere .xlsx, deci folosim openpyxl (inclus în Odoo)
 try:
-    import xlrd
-
-    try:
-        from xlrd import xlsx
-    except ImportError:
-        xlsx = None
+    import openpyxl
 except ImportError:
-    xlrd = xlsx = None
+    openpyxl = None
 
 
 class ImportPurchaseLine(models.TransientModel):
@@ -48,18 +45,24 @@ class ImportPurchaseLine(models.TransientModel):
         return defaults
 
     def get_rows(self):
+        if openpyxl is None:
+            raise UserError(self.env._("The 'openpyxl' Python library is required to read .xlsx files."))
         decoded_data = base64.b64decode(self.data_file)
-        book = xlrd.open_workbook(file_contents=decoded_data)
-        sheet = book.sheet_by_index(0)
+        book = openpyxl.load_workbook(io.BytesIO(decoded_data), data_only=True)
+        sheet = book.worksheets[0]
         table_values = []
-        for row in list(map(sheet.row, range(sheet.nrows))):
+        for row in sheet.iter_rows(values_only=True):
             values = []
-            for cell in row:
-                if cell.ctype is xlrd.XL_CELL_NUMBER:
-                    is_float = cell.value % 1 != 0.0
-                    values.append(str(cell.value) if is_float else str(int(cell.value)))
+            for value in row:
+                if value is None:
+                    values.append("")
+                elif isinstance(value, bool):
+                    values.append(value)
+                elif isinstance(value, (int, float)):
+                    is_float = value % 1 != 0.0
+                    values.append(str(value) if is_float else str(int(value)))
                 else:
-                    values.append(cell.value)
+                    values.append(value)
             table_values.append(values)
 
         if not table_values:


### PR DESCRIPTION
## Problemă
Pe `19.0`, jobul CI „test with Odoo" pică la `deltatech_purchase_xls`:
- `test_xlsx_file_export` → `ValueError: External ID not found: base.res_partner_1` — testul referă un record de **date demo**, indisponibil la instalarea fără demo (cum rulează CI-ul).
- `test_xlsx_file_import` → `xlrd.biffh.XLRDError: Excel xlsx file; not supported` — `xlrd >= 2.0` nu mai citește fișiere `.xlsx`.

## Soluție
- **test_xlsx_file_export**: înlocuiește `self.env.ref("base.res_partner_1")` cu un partener creat în test (ca în `test_xlsx_file_import`).
- **import wizard** (`get_rows`): trece citirea de la `xlrd` la `openpyxl` (inclus în Odoo), cu gardă dacă lipsește. Exportul rămâne pe `xlsxwriter`.

## Testare
Pe bază curată, fără demo (condiții ca de CI):
```
deltatech_purchase_xls: 4 tests, 0 failed, 0 error(s) of 2 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)