### PR TITLE
[ADD] deltatech_rpc_audit: log XML-RPC/JSON-RPC calls with real client IP

### DIFF
--- a/deltatech_rpc_audit/README.rst
+++ b/deltatech_rpc_audit/README.rst
@@ -1,0 +1,52 @@
+==============
+RPC Audit Log
+==============
+
+.. |badge1| image:: https://img.shields.io/badge/maturity-Beta-yellow.png
+    :target: https://odoo-community.org/page/development-status
+    :alt: Beta
+.. |badge2| image:: https://img.shields.io/badge/github-dhongu%2Fdeltatech-lightgray.png?logo=github
+    :target: https://github.com/dhongu/deltatech/tree/18.0/deltatech_rpc_audit
+    :alt: dhongu/deltatech
+
+|badge1| |badge2|
+
+This module logs external **XML-RPC** (``/xmlrpc``, ``/xmlrpc/2``) and
+**JSON-RPC** (``/jsonrpc``) calls, so you can audit which integration calls
+which model and method, and from where.
+
+For each call to the ``object`` service it logs the client IP, database, user
+id, model, method and a trimmed representation of the arguments, under the
+logger ``odoo.rpc.audit``. Credentials are never logged.
+
+The real client IP is read from the ``X-Forwarded-For`` header, so calls behind
+a reverse proxy (nginx, the Odoo.sh edge) are not all attributed to the proxy
+IP (e.g. ``10.0.0.2``), independently of the ``proxy_mode`` server option.
+
+Configuration
+=============
+
+Noisy IPs (health checks, monitoring) can be skipped via:
+
+- the config-file key ``rpc_audit_ignore_ips`` (self-hosted), or
+- the System Parameter ``rpc_audit.ignore_ips`` (works on Odoo.sh),
+
+both comma separated and merged together.
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues <https://github.com/dhongu/deltatech/issues>`_.
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* Terrabit
+
+Maintainers
+~~~~~~~~~~~
+
+* Dorin Hongu <dhongu>

--- a/deltatech_rpc_audit/__init__.py
+++ b/deltatech_rpc_audit/__init__.py
@@ -1,0 +1,1 @@
+from . import controllers

--- a/deltatech_rpc_audit/__manifest__.py
+++ b/deltatech_rpc_audit/__manifest__.py
@@ -1,0 +1,17 @@
+# ©  2024-2026 Terrabit
+# See README.rst file on addons root folder for license details
+
+{
+    "name": "RPC Audit Log",
+    "summary": "Log XML-RPC / JSON-RPC calls with the real client IP",
+    "version": "18.0.1.0.0",
+    "author": "Terrabit, Dorin Hongu",
+    "website": "https://www.terrabit.ro",
+    "category": "Technical",
+    "depends": ["base"],
+    "license": "OPL-1",
+    "data": [],
+    "installable": True,
+    "development_status": "Beta",
+    "maintainers": ["dhongu"],
+}

--- a/deltatech_rpc_audit/controllers/__init__.py
+++ b/deltatech_rpc_audit/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import rpc

--- a/deltatech_rpc_audit/controllers/rpc.py
+++ b/deltatech_rpc_audit/controllers/rpc.py
@@ -1,0 +1,127 @@
+# ©  2024-2026 Terrabit
+# See README.rst file on addons root folder for license details
+
+import logging
+import time
+import xmlrpc.client
+
+from odoo.http import dispatch_rpc, request, route
+from odoo.modules.registry import Registry
+from odoo.tools import config
+
+# Reuse the helpers from core so this override stays a faithful copy.
+from odoo.addons.base.controllers.rpc import RPC, _check_request, dumps
+
+_logger = logging.getLogger("odoo.rpc.audit")
+
+# Maximum length of the serialized arguments written to the log line.
+_MAX_ARGS_REPR = 500
+
+# System Parameter holding the comma separated IPs to skip (works on Odoo.sh,
+# where the config file is not editable). On a self-hosted server the config
+# file key ``rpc_audit_ignore_ips`` is used as well.
+_IGNORE_PARAM = "rpc_audit.ignore_ips"
+
+# Short cache so we do not open a cursor on every single RPC call.
+_IGNORE_TTL = 60  # seconds
+_ignore_cache = {}  # db -> (expiry_ts, frozenset of ips)
+
+
+def _client_ip():
+    """Return the real client IP.
+
+    Behind a reverse proxy (nginx on a self-hosted box, the Odoo.sh edge) the
+    ``remote_addr`` is the proxy IP. The real client is the first entry of the
+    ``X-Forwarded-For`` header. We read the header directly so it works
+    regardless of the ``proxy_mode`` server option.
+    """
+    httprequest = request.httprequest
+    forwarded_for = httprequest.headers.get("X-Forwarded-For")
+    if forwarded_for:
+        return forwarded_for.split(",")[0].strip()
+    return httprequest.remote_addr or "?"
+
+
+def _ips_from_config():
+    raw = config.get("rpc_audit_ignore_ips") or ""
+    return {ip.strip() for ip in raw.split(",") if ip.strip()}
+
+
+def _ips_from_param(db):
+    """Read the ignore list from ir.config_parameter, with a small TTL cache."""
+    if not db:
+        return set()
+    now = time.time()
+    cached = _ignore_cache.get(db)
+    if cached and cached[0] > now:
+        return cached[1]
+    value = ""
+    try:
+        with Registry(db).cursor() as cr:
+            cr.execute(
+                "SELECT value FROM ir_config_parameter WHERE key = %s",
+                (_IGNORE_PARAM,),
+            )
+            row = cr.fetchone()
+            if row and row[0]:
+                value = row[0]
+    except Exception:  # never let auditing break a real RPC call
+        value = ""
+    ips = {ip.strip() for ip in value.split(",") if ip.strip()}
+    _ignore_cache[db] = (now + _IGNORE_TTL, ips)
+    return ips
+
+
+def _ignored_ips(db):
+    return _ips_from_config() | _ips_from_param(db)
+
+
+def _trim(value):
+    text = repr(value)
+    if len(text) > _MAX_ARGS_REPR:
+        return text[:_MAX_ARGS_REPR] + "...(truncated)"
+    return text
+
+
+def _log_rpc_call(service, rpc_method, params):
+    ip = _client_ip()
+    db = params[0] if service == "object" and params else None
+    if ip in _ignored_ips(db):
+        return
+
+    # The "object" service carries the ORM call we usually care about:
+    # params = [db, uid, password, model, method, args, kwargs]
+    if service == "object" and len(params) >= 5:
+        uid = params[1]
+        model, orm_method = params[3], params[4]
+        orm_args = params[5] if len(params) > 5 else []
+        _logger.info(
+            "RPC ip=%s db=%s uid=%s model=%s method=%s args=%s",
+            ip,
+            db,
+            uid,
+            model,
+            orm_method,
+            _trim(orm_args),
+        )
+    else:
+        # common / db services: never log credentials, only the RPC method.
+        _logger.info("RPC ip=%s service=%s method=%s", ip, service, rpc_method)
+
+
+class RPC(RPC):
+    """Audit layer over the core XML-RPC / JSON-RPC controller."""
+
+    def _xmlrpc(self, service):
+        _check_request()
+        data = request.httprequest.get_data()
+        params, method = xmlrpc.client.loads(data, use_datetime=True)
+        _log_rpc_call(service, method, params)
+        result = dispatch_rpc(service, method, params)
+        return dumps((result,))
+
+    @route("/jsonrpc", type="json", auth="none", save_session=False)
+    def jsonrpc(self, service, method, args):
+        _check_request()
+        _log_rpc_call(service, method, args)
+        return dispatch_rpc(service, method, args)

--- a/deltatech_rpc_audit/pyproject.toml
+++ b/deltatech_rpc_audit/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "whool",
+]
+build-backend = "whool.buildapi"
+
+[project]
+name = "odoo-addon-deltatech-rpc-audit"

--- a/deltatech_rpc_audit/readme/DESCRIPTION.md
+++ b/deltatech_rpc_audit/readme/DESCRIPTION.md
@@ -1,0 +1,21 @@
+This module logs external **XML-RPC** (`/xmlrpc`, `/xmlrpc/2`) and **JSON-RPC**
+(`/jsonrpc`) calls, so you can audit which integration calls which model and
+method, and from where.
+
+For each call to the `object` service it logs the client IP, database, user id,
+model, method and a trimmed representation of the arguments, under the logger
+`odoo.rpc.audit`. Credentials are never logged.
+
+The real client IP is read from the `X-Forwarded-For` header, so calls behind a
+reverse proxy (nginx, the Odoo.sh edge) are not all attributed to the proxy IP
+(e.g. `10.0.0.2`), independently of the `proxy_mode` server option.
+
+Noisy IPs (health checks, monitoring) can be skipped via:
+
+- the config-file key `rpc_audit_ignore_ips` (self-hosted), or
+- the System Parameter `rpc_audit.ignore_ips` (works on Odoo.sh),
+
+both comma separated and merged together.
+
+It is meant as a lightweight diagnostic / audit tool; the web client UI is not
+affected, since it uses a different endpoint.

--- a/deltatech_rpc_audit/readme/HISTORY.md
+++ b/deltatech_rpc_audit/readme/HISTORY.md
@@ -1,0 +1,16 @@
+# History
+
+## 18.0.1.0.0 (2026-06-29)
+
+- Initial release.
+- Logs XML-RPC (`/xmlrpc/<service>`, `/xmlrpc/2/<service>`) and JSON-RPC
+  (`/jsonrpc`) calls under the logger `odoo.rpc.audit`.
+- Resolves the real client IP from the `X-Forwarded-For` header so calls are
+  not all attributed to the reverse-proxy IP (e.g. `10.0.0.2`), independently
+  of the `proxy_mode` server option.
+- For the `object` service logs db / uid / model / method / trimmed args;
+  for `common` / `db` services logs only the RPC method (never credentials).
+- Optional ignore list (comma separated) to skip noisy IPs (e.g. health
+  checks), from two sources merged together:
+  - config-file key `rpc_audit_ignore_ips` (self-hosted);
+  - System Parameter `rpc_audit.ignore_ips` (works on Odoo.sh), cached 60s.


### PR DESCRIPTION
## Ce face

Modul nou `deltatech_rpc_audit` care loghează apelurile externe **XML-RPC** (`/xmlrpc`, `/xmlrpc/2`) și **JSON-RPC** (`/jsonrpc`) sub loggerul `odoo.rpc.audit`, ca să se vadă ce integrare apelează ce model/metodă și de unde.

Pentru serviciul `object` loghează: `ip / db / uid / model / method / args` (truncate la 500 caractere). Parolele nu sunt logate niciodată. UI-ul web nu e afectat (folosește alt endpoint, `/web/dataset/call_kw`).

## De ce

În spatele reverse-proxy-ului (nginx / edge-ul Odoo.sh) toate apelurile apăreau de pe IP-ul proxy-ului (ex. `10.0.0.2`). Modulul citește **`X-Forwarded-For`** direct, deci IP-ul real al clientului apare corect, indiferent de opțiunea `proxy_mode`.

## Filtrare IP-uri zgomotoase (health-check, monitorizare)

Listă combinată din două surse:
- cheia din fișierul de config `rpc_audit_ignore_ips` (self-hosted);
- System Parameter `rpc_audit.ignore_ips` (funcționează pe **Odoo.sh**, unde `.conf` nu e editabil), cu cache de 60s.

## Note implementare

- Override prin moștenire peste controllerul core `RPC` din `odoo.addons.base.controllers.rpc` — copie fidelă a `_xmlrpc`/`jsonrpc` cu o linie de log în plus.
- Doar controller, fără modele/date — după instalare e suficient restart/build, fără `-u`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)