### PR TITLE
[IMP] deltatech_rpc_audit: on/off switch + isEnabledFor guard

### DIFF
--- a/deltatech_rpc_audit/README.rst
+++ b/deltatech_rpc_audit/README.rst
@@ -26,6 +26,14 @@ IP (e.g. ``10.0.0.2``), independently of the ``proxy_mode`` server option.
 Configuration
 =============
 
+The module can be turned on/off without uninstalling it:
+
+- the config-file key ``rpc_audit_enabled`` (self-hosted), or
+- the System Parameter ``rpc_audit.enabled`` (works on Odoo.sh, no rebuild).
+
+Default is enabled; either source can disable. On a self-hosted server you can
+also mute it through the logger level, e.g. ``--log-handler=odoo.rpc.audit:WARNING``.
+
 Noisy IPs (health checks, monitoring) can be skipped via:
 
 - the config-file key ``rpc_audit_ignore_ips`` (self-hosted), or

--- a/deltatech_rpc_audit/__manifest__.py
+++ b/deltatech_rpc_audit/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "RPC Audit Log",
     "summary": "Log XML-RPC / JSON-RPC calls with the real client IP",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Technical",

--- a/deltatech_rpc_audit/controllers/rpc.py
+++ b/deltatech_rpc_audit/controllers/rpc.py
@@ -17,14 +17,25 @@ _logger = logging.getLogger("odoo.rpc.audit")
 # Maximum length of the serialized arguments written to the log line.
 _MAX_ARGS_REPR = 500
 
-# System Parameter holding the comma separated IPs to skip (works on Odoo.sh,
-# where the config file is not editable). On a self-hosted server the config
-# file key ``rpc_audit_ignore_ips`` is used as well.
+# System Parameters (work on Odoo.sh, where the config file is not editable).
+# On a self-hosted server the config-file keys ``rpc_audit_enabled`` and
+# ``rpc_audit_ignore_ips`` are honored as well; either source can disable.
+_ENABLED_PARAM = "rpc_audit.enabled"
 _IGNORE_PARAM = "rpc_audit.ignore_ips"
 
 # Short cache so we do not open a cursor on every single RPC call.
-_IGNORE_TTL = 60  # seconds
-_ignore_cache = {}  # db -> (expiry_ts, frozenset of ips)
+_SETTINGS_TTL = 60  # seconds
+_settings_cache = {}  # db -> (expiry_ts, {"enabled": bool, "ignore_ips": set})
+
+_FALSY = {"0", "false", "no", "off", ""}
+
+
+def _as_bool(value, default):
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() not in _FALSY
 
 
 def _client_ip():
@@ -42,38 +53,46 @@ def _client_ip():
     return httprequest.remote_addr or "?"
 
 
-def _ips_from_config():
-    raw = config.get("rpc_audit_ignore_ips") or ""
-    return {ip.strip() for ip in raw.split(",") if ip.strip()}
+def _settings_from_config():
+    enabled = _as_bool(config.get("rpc_audit_enabled"), True)
+    raw_ips = config.get("rpc_audit_ignore_ips") or ""
+    ignore_ips = {ip.strip() for ip in raw_ips.split(",") if ip.strip()}
+    return enabled, ignore_ips
 
 
-def _ips_from_param(db):
-    """Read the ignore list from ir.config_parameter, with a small TTL cache."""
-    if not db:
-        return set()
+def _settings_from_param(db):
+    """Read enabled flag + ignore list from ir.config_parameter (cached)."""
     now = time.time()
-    cached = _ignore_cache.get(db)
+    cached = _settings_cache.get(db)
     if cached and cached[0] > now:
         return cached[1]
-    value = ""
+    enabled = True
+    ignore_ips = set()
     try:
         with Registry(db).cursor() as cr:
             cr.execute(
-                "SELECT value FROM ir_config_parameter WHERE key = %s",
-                (_IGNORE_PARAM,),
+                "SELECT key, value FROM ir_config_parameter WHERE key IN %s",
+                ((_ENABLED_PARAM, _IGNORE_PARAM),),
             )
-            row = cr.fetchone()
-            if row and row[0]:
-                value = row[0]
+            rows = dict(cr.fetchall())
+        enabled = _as_bool(rows.get(_ENABLED_PARAM), True)
+        raw_ips = rows.get(_IGNORE_PARAM) or ""
+        ignore_ips = {ip.strip() for ip in raw_ips.split(",") if ip.strip()}
     except Exception:  # never let auditing break a real RPC call
-        value = ""
-    ips = {ip.strip() for ip in value.split(",") if ip.strip()}
-    _ignore_cache[db] = (now + _IGNORE_TTL, ips)
-    return ips
+        enabled, ignore_ips = True, set()
+    result = {"enabled": enabled, "ignore_ips": ignore_ips}
+    _settings_cache[db] = (now + _SETTINGS_TTL, result)
+    return result
 
 
-def _ignored_ips(db):
-    return _ips_from_config() | _ips_from_param(db)
+def _settings(db):
+    """Effective settings, merging the config file and System Parameters."""
+    enabled, ignore_ips = _settings_from_config()
+    if db:
+        param = _settings_from_param(db)
+        enabled = enabled and param["enabled"]
+        ignore_ips = ignore_ips | param["ignore_ips"]
+    return enabled, ignore_ips
 
 
 def _trim(value):
@@ -84,9 +103,18 @@ def _trim(value):
 
 
 def _log_rpc_call(service, rpc_method, params):
-    ip = _client_ip()
+    # Cheapest guard first: if the logger is muted (e.g. raised above INFO via
+    # log_handler), do no work at all -- not even repr() of the arguments.
+    if not _logger.isEnabledFor(logging.INFO):
+        return
+
     db = params[0] if service == "object" and params else None
-    if ip in _ignored_ips(db):
+    enabled, ignore_ips = _settings(db)
+    if not enabled:
+        return
+
+    ip = _client_ip()
+    if ip in ignore_ips:
         return
 
     # The "object" service carries the ORM call we usually care about:

--- a/deltatech_rpc_audit/readme/DESCRIPTION.md
+++ b/deltatech_rpc_audit/readme/DESCRIPTION.md
@@ -10,6 +10,11 @@ The real client IP is read from the `X-Forwarded-For` header, so calls behind a
 reverse proxy (nginx, the Odoo.sh edge) are not all attributed to the proxy IP
 (e.g. `10.0.0.2`), independently of the `proxy_mode` server option.
 
+The module can be turned on/off without uninstalling it, via the config-file
+key `rpc_audit_enabled` (self-hosted) or the System Parameter
+`rpc_audit.enabled` (works on Odoo.sh, no rebuild). When the `odoo.rpc.audit`
+logger is muted above INFO, the module does no work at all.
+
 Noisy IPs (health checks, monitoring) can be skipped via:
 
 - the config-file key `rpc_audit_ignore_ips` (self-hosted), or

--- a/deltatech_rpc_audit/readme/HISTORY.md
+++ b/deltatech_rpc_audit/readme/HISTORY.md
@@ -1,5 +1,15 @@
 # History
 
+## 18.0.1.1.0 (2026-06-29)
+
+- Add an on/off switch, so the module can stay installed but idle:
+  - config-file key `rpc_audit_enabled` (self-hosted);
+  - System Parameter `rpc_audit.enabled` (works on Odoo.sh, no rebuild),
+    cached 60s alongside the ignore list.
+  Either source can disable; default is enabled.
+- Skip all work (including `repr()` of the arguments) when the `odoo.rpc.audit`
+  logger is muted above INFO, via an `isEnabledFor` guard.
+
 ## 18.0.1.0.0 (2026-06-29)
 
 - Initial release.


### PR DESCRIPTION
Follow-up la [#2575](https://github.com/dhongu/deltatech/pull/2575).

## Ce adaugă

1. **Comutator on/off fără dezinstalare** — fie din fișierul de config (`rpc_audit_enabled`, self-hosted), fie din **System Parameter** `rpc_audit.enabled` (funcționează pe **Odoo.sh**, fără rebuild). Citit în același cache de 60s, împreună cu lista de IP-uri. Oricare sursă poate dezactiva; default = activat.

2. **Guard `isEnabledFor(INFO)`** — dacă loggerul `odoo.rpc.audit` e ridicat peste INFO (ex. `--log-handler=odoo.rpc.audit:WARNING`), modulul nu mai face **niciun** calcul, nici măcar `repr()` pe argumente → cost ~0 pe producție când e mut.

## De ce

Răspuns la întrebarea de performanță: cele două singure ineficiențe reale (repr necondiționat + lipsă de pârghie de oprire pe Odoo.sh) sunt acum eliminate. Pe Odoo.sh, unde nu poți edita `.conf`/log level, ai on/off din UI (Settings → Technical → System Parameters).

## Cum se folosește

- Oprire pe Odoo.sh: System Parameter `rpc_audit.enabled` = `0`.
- Oprire self-hosted: `rpc_audit_enabled = False` în `.conf`, sau `--log-handler=odoo.rpc.audit:WARNING`.

Doar controller, fără modele/date noi. Versiune bump-uită la `18.0.1.1.0`, HISTORY actualizat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)