### PR TITLE
[19.0][FIX] Repară testul activity-report blocat de restricția picking

### DIFF
--- a/deltatech_stock_picking_activity_report/tests/test_stock_picking_activity_report.py
+++ b/deltatech_stock_picking_activity_report/tests/test_stock_picking_activity_report.py
@@ -38,6 +38,18 @@ class TestStockPickingActivityReport(TransactionCase):
             }
         )
 
+        # Dacă în aceeași bază e instalat și deltatech_picking_restrict_entry_exit
+        # (cazul CI pe tot repo-ul), userul de test trebuie scutit de restricția
+        # care cere linie de vânzare/achiziție la validare — aceste teste verifică
+        # doar logarea activității, pe picking-uri de sine stătătoare. Nu adăugăm
+        # dependență în manifest; referința e opțională.
+        restrict_group = cls.env.ref(
+            "deltatech_picking_restrict_entry_exit.group_picking_restrict_entry_exit",
+            raise_if_not_found=False,
+        )
+        if restrict_group:
+            cls.stock_user.group_ids = [(4, restrict_group.id)]
+
         cls.warehouse = cls.env["stock.warehouse"].search([("company_id", "=", cls.env.company.id)], limit=1)
         cls.stock_location = cls.warehouse.lot_stock_id
         cls.customer_location = cls.env.ref("stock.stock_location_customers")


### PR DESCRIPTION
## Context
Pe CI (job *test with Odoo*) cădea 1 test din 598:
`TestStockPickingActivityReport.test_button_validate_outgoing_sets_exit_number`.

Cauza: modulul nou `deltatech_picking_restrict_entry_exit` (adăugat recent pe `19.0`) suprascrie `button_validate` și, pentru userii din afara grupului `group_picking_restrict_entry_exit`, aruncă `UserError` dacă un picking outgoing/incoming nu are linie de vânzare/achiziție. Cum în CI pe tot repo-ul ambele module sunt instalate, testul din `deltatech_stock_picking_activity_report` (care validează un picking standalone) pica.

## Fix
Adaug userul de test în `group_picking_restrict_entry_exit`, dar **doar dacă modulul restrict e instalat** (`env.ref(..., raise_if_not_found=False)`). Astfel:
- nu introduc o dependență în `__manifest__` între cele două module;
- testele rulează corect și izolat (modul singur), și în full-repo CI.

Testele vizează strict logarea activității, nu interacțiunea cu modulul de restricție.

## Verificare locală
Instalare ambele module + `--test-tags=/deltatech_stock_picking_activity_report`:
`0 failed, 0 error(s) of 9 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)