### PR TITLE
[19.0][FIX] Elimină blocul duplicat groups_id care rupea testele activity-report

### DIFF
--- a/deltatech_stock_picking_activity_report/tests/test_stock_picking_activity_report.py
+++ b/deltatech_stock_picking_activity_report/tests/test_stock_picking_activity_report.py
@@ -37,13 +37,6 @@ class TestStockPickingActivityReport(TransactionCase):
                 ],
             }
         )
-        restrict_group = cls.env.ref(
-            "deltatech_picking_restrict_entry_exit.group_picking_restrict_entry_exit",
-            raise_if_not_found=False,
-        )
-        if restrict_group:
-            cls.stock_user.groups_id |= restrict_group
-
         # Dacă în aceeași bază e instalat și deltatech_picking_restrict_entry_exit
         # (cazul CI pe tot repo-ul), userul de test trebuie scutit de restricția
         # care cere linie de vânzare/achiziție la validare — aceste teste verifică


### PR DESCRIPTION
## Context
La merge-ul PR #2581 peste fix-ul paralel `9c068f88e` (*Fix Odoo test with picking restriction addon*), cele două adăugiri în `setUpClass` din `test_stock_picking_activity_report.py` s-au combinat automat într-un **bloc duplicat**.

Primul bloc folosea `cls.stock_user.groups_id |= restrict_group` — `groups_id` e numele de câmp din 18.0, **inexistent pe `res.users` în 19.0** (acolo e `group_ids`). Rezultat: `AttributeError` în `setUpClass` → toată clasa `TestStockPickingActivityReport` cădea (`0 failed, 1 error of 0 tests`).

## Fix
Păstrez un singur bloc, cel corect pentru 19.0:
```python
cls.stock_user.group_ids = [(4, restrict_group.id)]
```

## Verificare locală
`-i deltatech_stock_picking_activity_report,deltatech_picking_restrict_entry_exit --test-tags=/deltatech_stock_picking_activity_report`
→ `0 failed, 0 error(s) of 9 tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)