### PR TITLE
[FIX] Apps Store: lizibilitate descriere (CSS)

### DIFF
--- a/deltatech/static/description/index.html
+++ b/deltatech/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_account/static/description/index.html
+++ b/deltatech_account/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-account"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-account"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_actions/static/description/index.html
+++ b/deltatech_actions/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-actions"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-actions"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_agreement_management/static/description/index.html
+++ b/deltatech_agreement_management/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="agreement-management"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="agreement-management"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_alternative/static/description/index.html
+++ b/deltatech_alternative/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="products-alternative"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="products-alternative"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_alternative_website/static/description/index.html
+++ b/deltatech_alternative_website/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="website-alternative-code"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="website-alternative-code"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_analytic_distribution/static/description/index.html
+++ b/deltatech_analytic_distribution/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-analytic-distribution-enforcer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-analytic-distribution-enforcer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_auto_reorder_rule/static/description/index.html
+++ b/deltatech_auto_reorder_rule/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-auto-reorder-rule"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-auto-reorder-rule"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_average_payment_period/static/description/index.html
+++ b/deltatech_average_payment_period/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-average-payment-period"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-average-payment-period"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_backup_attachment/static/description/index.html
+++ b/deltatech_backup_attachment/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="backup-attachments"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="backup-attachments"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_batch_transfer/static/description/index.html
+++ b/deltatech_batch_transfer/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-batch-transfer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-batch-transfer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_business_process_handover_document/static/description/index.html
+++ b/deltatech_business_process_handover_document/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="business-process-handover-document"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="business-process-handover-document"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_cash_statement/static/description/index.html
+++ b/deltatech_cash_statement/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-cash-statement-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-cash-statement-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_category_group/static/description/index.html
+++ b/deltatech_category_group/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-category-group"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-category-group"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_contact/static/description/index.html
+++ b/deltatech_contact/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-contacts"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-contacts"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_credentials/static/description/index.html
+++ b/deltatech_credentials/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="credentials"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="credentials"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_data_sheet/static/description/index.html
+++ b/deltatech_data_sheet/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-data-sheet"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-data-sheet"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_data_sheet_website/static/description/index.html
+++ b/deltatech_data_sheet_website/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-data-sheet-website"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-data-sheet-website"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_dc/static/description/index.html
+++ b/deltatech_dc/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="declaration-of-conformity"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="declaration-of-conformity"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_delivery_status/static/description/index.html
+++ b/deltatech_delivery_status/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-delivery-status"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-delivery-status"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_download/static/description/index.html
+++ b/deltatech_download/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="download-file"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="download-file"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_dropshipping/static/description/index.html
+++ b/deltatech_dropshipping/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-drop-shipping"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-drop-shipping"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_expenses/static/description/index.html
+++ b/deltatech_expenses/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="expenses-deduction"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="expenses-deduction"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_fast_purchase/static/description/index.html
+++ b/deltatech_fast_purchase/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="fast-purchase"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="fast-purchase"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_fast_sale/static/description/index.html
+++ b/deltatech_fast_sale/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="fast-sale"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="fast-sale"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_followup/static/description/index.html
+++ b/deltatech_followup/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="invoice-followup"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="invoice-followup"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_gln/static/description/index.html
+++ b/deltatech_gln/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-partner-gln"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-partner-gln"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_invoice_picking/static/description/index.html
+++ b/deltatech_invoice_picking/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="invoice-pickings"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="invoice-pickings"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_invoice_picking_automatically/static/description/index.html
+++ b/deltatech_invoice_picking_automatically/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="invoice-pickings-automatically"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="invoice-pickings-automatically"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_invoice_product_filter/static/description/index.html
+++ b/deltatech_invoice_product_filter/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="invoice-product-filter"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="invoice-product-filter"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_invoice_receipt/static/description/index.html
+++ b/deltatech_invoice_receipt/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-invoice-receipt"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-invoice-receipt"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_invoice_weight/static/description/index.html
+++ b/deltatech_invoice_weight/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="invoice-weight"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="invoice-weight"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_ledger/static/description/index.html
+++ b/deltatech_ledger/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-ledger"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-ledger"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_list_view/static/description/index.html
+++ b/deltatech_list_view/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="list-view-select-text"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="list-view-select-text"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_logistic_docs/static/description/index.html
+++ b/deltatech_logistic_docs/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="logistic-documents"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="logistic-documents"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_mail/static/description/index.html
+++ b/deltatech_mail/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="mail-substitution"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="mail-substitution"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_mrp/static/description/index.html
+++ b/deltatech_mrp/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="mrp-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="mrp-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_mrp_concentration/static/description/index.html
+++ b/deltatech_mrp_concentration/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="mrp-concentration"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="mrp-concentration"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_mrp_cost/static/description/index.html
+++ b/deltatech_mrp_cost/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="mrp-cost"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="mrp-cost"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_mrp_simple/static/description/index.html
+++ b/deltatech_mrp_simple/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="simple-mrp"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="simple-mrp"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_no_quick_create/static/description/index.html
+++ b/deltatech_no_quick_create/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="no-quick-create"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="no-quick-create"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_notification_sound/static/description/index.html
+++ b/deltatech_notification_sound/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="notification-sound"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="notification-sound"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_partner_generic/static/description/index.html
+++ b/deltatech_partner_generic/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-generic-partner"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-generic-partner"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_payment_term/static/description/index.html
+++ b/deltatech_payment_term/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="payment-term-rate-wizard"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="payment-term-rate-wizard"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_picking_transit/static/description/index.html
+++ b/deltatech_picking_transit/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="stock-auto-transfer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="stock-auto-transfer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_price_categ/static/description/index.html
+++ b/deltatech_price_categ/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="price-category"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="price-category"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_pricelist_line_viewer/static/description/index.html
+++ b/deltatech_pricelist_line_viewer/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="price-list-line-viewer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="price-list-line-viewer"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_code/static/description/index.html
+++ b/deltatech_product_code/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="products-code"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="products-code"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_dimension/static/description/index.html
+++ b/deltatech_product_dimension/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="products-dimension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="products-dimension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_extension/static/description/index.html
+++ b/deltatech_product_extension/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-products-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-products-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_labels/static/description/index.html
+++ b/deltatech_product_labels/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-labels"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-labels"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_list/static/description/index.html
+++ b/deltatech_product_list/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-list"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-list"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_mpn/static/description/index.html
+++ b/deltatech_product_mpn/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-mpn"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-mpn"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_product_trade_markup/static/description/index.html
+++ b/deltatech_product_trade_markup/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="product-trade-markup"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="product-trade-markup"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_project_price_list/static/description/index.html
+++ b/deltatech_project_price_list/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-project-pricelist"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-project-pricelist"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_promissory_note/static/description/index.html
+++ b/deltatech_promissory_note/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-promissory-note"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-promissory-note"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_purchase_add_extra_line/static/description/index.html
+++ b/deltatech_purchase_add_extra_line/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="purchase-add-extra-line"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="purchase-add-extra-line"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_purchase_mail/static/description/index.html
+++ b/deltatech_purchase_mail/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="purchase-send-multi-orders-by-email-with-xlsx"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="purchase-send-multi-orders-by-email-with-xlsx"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_purchase_price/static/description/index.html
+++ b/deltatech_purchase_price/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="purchase-price"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="purchase-price"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_purchase_ubl/static/description/index.html
+++ b/deltatech_purchase_ubl/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-purchase-ubl"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-purchase-ubl"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_putaway_strategy/static/description/index.html
+++ b/deltatech_putaway_strategy/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-putaway-strategy"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-putaway-strategy"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_queue_job/static/description/index.html
+++ b/deltatech_queue_job/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-queue-job-enhancements"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-queue-job-enhancements"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_ral/static/description/index.html
+++ b/deltatech_ral/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ral"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ral"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_reception_note/static/description/index.html
+++ b/deltatech_reception_note/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-reception-note"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-reception-note"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_record_type/static/description/index.html
+++ b/deltatech_record_type/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="terrabit-record-type"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="terrabit-record-type"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_replenishment_explain/static/description/index.html
+++ b/deltatech_replenishment_explain/static/description/index.html
@@ -360,7 +360,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-replenishment-explain"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-replenishment-explain"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_add_extra_line/static/description/index.html
+++ b/deltatech_sale_add_extra_line/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-add-extra-line"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-add-extra-line"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_commission/static/description/index.html
+++ b/deltatech_sale_commission/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-commission"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-commission"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_contact/static/description/index.html
+++ b/deltatech_sale_contact/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-contact"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-contact"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_cost_product/static/description/index.html
+++ b/deltatech_sale_cost_product/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-sale-cost-on-order"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-sale-cost-on-order"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_currency/static/description/index.html
+++ b/deltatech_sale_currency/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-sale-currency"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-sale-currency"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_feedback/static/description/index.html
+++ b/deltatech_sale_feedback/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-feedback"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-feedback"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_margin/static/description/index.html
+++ b/deltatech_sale_margin/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-margin"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-margin"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_multiple/static/description/index.html
+++ b/deltatech_sale_multiple/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-qty-multiple"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-qty-multiple"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_pallet/static/description/index.html
+++ b/deltatech_sale_pallet/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-pallet"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-pallet"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_payment/static/description/index.html
+++ b/deltatech_sale_payment/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-payment"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-payment"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_phone/static/description/index.html
+++ b/deltatech_sale_phone/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-phone"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-phone"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_purchase_requisition/static/description/index.html
+++ b/deltatech_sale_purchase_requisition/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-purchase-rfq-alternative-purchase-orders"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-purchase-rfq-alternative-purchase-orders"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_qty_available/static/description/index.html
+++ b/deltatech_sale_qty_available/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-qty-available"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-qty-available"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_return_cause/static/description/index.html
+++ b/deltatech_sale_return_cause/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-return-cause"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-return-cause"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_stage/static/description/index.html
+++ b/deltatech_sale_stage/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-sale-order-stage"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-sale-order-stage"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sale_team/static/description/index.html
+++ b/deltatech_sale_team/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="sale-team-access"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="sale-team-access"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_saleorder_pickup_list/static/description/index.html
+++ b/deltatech_saleorder_pickup_list/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-sale-order-pickup-list"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-sale-order-pickup-list"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sms/static/description/index.html
+++ b/deltatech_sms/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-sms"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-sms"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_sms_sale/static/description/index.html
+++ b/deltatech_sms_sale/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-sms-sale"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-sms-sale"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_account/static/description/index.html
+++ b/deltatech_stock_account/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="stock-account-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="stock-account-extension"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_count_zero/static/description/index.html
+++ b/deltatech_stock_count_zero/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-stock-count-zero"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-stock-count-zero"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_delivery/static/description/index.html
+++ b/deltatech_stock_delivery/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="invoice-delivery-reception"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="invoice-delivery-reception"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_inventory/static/description/index.html
+++ b/deltatech_stock_inventory/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="stock-inventory"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="stock-inventory"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_inventory_product_display/static/description/index.html
+++ b/deltatech_stock_inventory_product_display/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="stock-inventory-product-display"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="stock-inventory-product-display"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_negative/static/description/index.html
+++ b/deltatech_stock_negative/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="no-negative-stock"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="no-negative-stock"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_report/static/description/index.html
+++ b/deltatech_stock_report/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="stock-reports"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="stock-reports"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_stock_reseller/static/description/index.html
+++ b/deltatech_stock_reseller/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="stock-report-reseller"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="stock-report-reseller"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_team_logo/static/description/index.html
+++ b/deltatech_team_logo/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-team-logo"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-team-logo"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_test_system/static/description/index.html
+++ b/deltatech_test_system/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-test-system"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-test-system"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_transport_change/static/description/index.html
+++ b/deltatech_transport_change/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-transport-change"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-transport-change"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_vendor_stock/static/description/index.html
+++ b/deltatech_vendor_stock/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="vendor-stock"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="vendor-stock"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_warehouse_arrangement/static/description/index.html
+++ b/deltatech_warehouse_arrangement/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-warehouse-arrangement"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-warehouse-arrangement"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_warehouse_map/static/description/index.html
+++ b/deltatech_warehouse_map/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="deltatech-warehouse-map"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="deltatech-warehouse-map"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_watermark/static/description/index.html
+++ b/deltatech_watermark/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="watermark"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="watermark"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_breadcrumb/static/description/index.html
+++ b/deltatech_website_breadcrumb/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-category-breadcrumb"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-category-breadcrumb"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_checkout_confirm/static/description/index.html
+++ b/deltatech_website_checkout_confirm/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-checkout-confirm-order"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-checkout-confirm-order"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_city/static/description/index.html
+++ b/deltatech_website_city/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="website-city"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="website-city"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_delivery_and_payment/static/description/index.html
+++ b/deltatech_website_delivery_and_payment/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="delivery-and-payment"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="delivery-and-payment"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_disable_fuzzy_search/static/description/index.html
+++ b/deltatech_website_disable_fuzzy_search/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="website-disable-fuzzy-search"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="website-disable-fuzzy-search"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_fixed_price/static/description/index.html
+++ b/deltatech_website_fixed_price/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-display-fixed-price-as-discount"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-display-fixed-price-as-discount"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_phone_validation/static/description/index.html
+++ b/deltatech_website_phone_validation/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="website-phone-validation"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="website-phone-validation"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_price_without_tax/static/description/index.html
+++ b/deltatech_website_price_without_tax/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-product-price-without-tax"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-product-price-without-tax"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_product_code/static/description/index.html
+++ b/deltatech_website_product_code/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-product-code"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-product-code"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_product_url_image/static/description/index.html
+++ b/deltatech_website_product_url_image/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-product-image-url-link"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-product-image-url-link"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_sale_attributes/static/description/index.html
+++ b/deltatech_website_sale_attributes/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-attribute-values"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-attribute-values"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_sale_sort/static/description/index.html
+++ b/deltatech_website_sale_sort/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-product-sort"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-product-sort"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_sale_status/static/description/index.html
+++ b/deltatech_website_sale_status/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-sale-order-status"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-sale-order-status"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_short_description/static/description/index.html
+++ b/deltatech_website_short_description/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-sale-short-description"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-sale-short-description"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_stock_availability/static/description/index.html
+++ b/deltatech_website_stock_availability/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-stock-availability"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-stock-availability"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_vat_validation/static/description/index.html
+++ b/deltatech_website_vat_validation/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="website-vat-validation"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="website-vat-validation"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_website_warehouse_stock/static/description/index.html
+++ b/deltatech_website_warehouse_stock/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="ecommerce-warehouse-stock"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="ecommerce-warehouse-stock"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_widget_fontawesome/static/description/index.html
+++ b/deltatech_widget_fontawesome/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="fontawesome-widget"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="fontawesome-widget"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/deltatech_widget_many2one_badge/static/description/index.html
+++ b/deltatech_widget_many2one_badge/static/description/index.html
@@ -359,7 +359,7 @@ ul.auto-toc {
 </style>
 </head>
 <body>
-<div class="document" id="many2one-badge-widget"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;"><!-- tb-skin v4 -->
+<div class="document" id="many2one-badge-widget"><div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#1f2d27;"><!-- tb-skin v4 -->
 <div style="background-color:#006F42;color:#ffffff;border-radius:20px;
   padding:54px 40px;text-align:center;margin:8px 0 22px;box-shadow:0 18px 40px rgba(0,67,42,0.28);">
   <div style="display:inline-block;background-color:#00432a;color:#9be8b6;font-weight:700;

--- a/scripts/tb_skin_index.py
+++ b/scripts/tb_skin_index.py
@@ -76,7 +76,7 @@ FONT = "'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif"
 # NB: gradient/`background` shorthand sunt tăiate de store → doar `background-color`.
 # ----------------------------------------------------------------------------- #
 
-WRAP_OPEN = f'<div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:{FONT};">'
+WRAP_OPEN = f'<div style="max-width:1100px;margin:0 auto;padding:0 16px;font-family:{FONT};color:#1f2d27;">'
 
 HERO = """%(marker)s
 <div style="background-color:%(primary)s;color:#ffffff;border-radius:20px;


### PR DESCRIPTION
Odoo Apps Store taie tag-ul `<style>` din `index.html`. Skin-ul se baza pe culoare moștenită pentru corpul textului → pe store textul ieșea gri, ilizibil pe fundal alb (vezi Sale Margin).

**Fix:**
- Culoare ink explicită inline (`color:#1f2d27`) pe wrapperul de conținut (`WRAP_OPEN`), de unde tot corpul o moștenește.
- Re-skin la **v4** pentru modulele rămase pe v2 (aveau corpul nestilizat + shields vizibile pe store).

Template-ul `scripts/tb_skin_index.py` e actualizat pentru regenerări viitoare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)