### PR TITLE
[IMP] Apps Store: ascunde Changelog/History din descriere

### DIFF
--- a/deltatech_business_process/static/description/index.html
+++ b/deltatech_business_process/static/description/index.html
@@ -537,43 +537,6 @@ blocked by design.</li>
 </li>
 </ul>
 </div>
-<div class="section" id="changelog">
-<h1><a class="toc-backref" href="#toc-entry-1">Changelog</a></h1>
-<div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-2">19.0.1.8.0</a></h2>
-<ul class="simple">
-<li><strong>Reset to Draft</strong> button on the business process form is now shown in
-every state except <tt class="docutils literal">draft</tt> (previously hidden in <tt class="docutils literal">production</tt> and
-<tt class="docutils literal">draft</tt>), so a process can be reset from any active stage.</li>
-<li>Passing the <strong>implementor (internal) test</strong> no longer advances the
-process state to <tt class="docutils literal">ready</tt>. Marking an internal test <em>Done</em> still
-records <tt class="docutils literal">status_internal_test = done</tt> but leaves the process state
-unchanged; integration and user-acceptance tests continue to advance
-the process as before.</li>
-</ul>
-</div>
-<div class="section" id="section-2">
-<h2><a class="toc-backref" href="#toc-entry-3">19.0.1.7.0</a></h2>
-<ul class="simple">
-<li>Process Library: support for <strong>private HTTPS git repositories</strong>. A
-token/password is sent as an HTTP Basic <tt class="docutils literal">Authorization</tt> header on
-each git command (never written into the cloned repo’s on-disk
-config), with a configurable username (default <tt class="docutils literal"><span class="pre">x-access-token</span></tt> for
-GitHub, <tt class="docutils literal">oauth2</tt> for GitLab). Git now runs non-interactively, so a
-missing or wrong credential fails fast instead of blocking until the
-timeout. SSH (<tt class="docutils literal">git&#64;…</tt>) URLs and URLs that already embed credentials
-are used as-is.</li>
-<li>Library import now maps the <strong>full process metadata</strong> from
-<tt class="docutils literal">process.json</tt> — process group, module type, implementation stage
-(including legacy stage keys), state — and imports the <strong>configuration
-/ instructing / testing / data-migration durations</strong> that were
-previously dropped.</li>
-<li>New <strong>“Include durations”</strong> toggle on the library import dialog:
-import every selected process with or without its exported effort
-estimates (all-or-nothing).</li>
-</ul>
-</div>
-</div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-4">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.

--- a/deltatech_purchase_ubl/static/description/index.html
+++ b/deltatech_purchase_ubl/static/description/index.html
@@ -407,47 +407,6 @@ purchase order when an order is resolved.</div></li><li style="background-color:
 using data from the UBL file.</div></li></ul>
 <p>The module supports standard UBL Invoice namespaces and common unit code
 mappings (C62, KGM, LTR, etc.).</p>
-<div class="section" id="changelog">
-<h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
-</div>
-<div class="section" id="changelog-1">
-<h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
-<div class="section" id="section-1">
-<h2 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:24px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">[18.0.1.1.0] - 2026-05-26</h2>
-<div class="section" id="added">
-<h3 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:19px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Added</h3>
-<ul class="simple">
-<li><strong>Discount support from e-Factura SPV XML</strong>: Line-level
-<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">AllowanceCharge</code> elements with <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ChargeIndicator=false</code> are now
-extracted and applied as percentage discounts on purchase order lines.<ul>
-<li>Discount percent is calculated as
-<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">allowance_amount / (price * qty) * 100</code>.</li>
-<li>Applied on both newly created order lines and existing order lines
-during update.</li>
-<li>The gross price (<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">PriceAmount</code>) is preserved as <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">price_unit</code>;
-the discount is stored separately in the <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">discount</code> field.</li>
-</ul>
-</li>
-<li><strong>Test coverage</strong>: Added automated test
-<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">test_allowance_charge_discount_applied_on_order_line</code> verifying
-correct discount extraction and application (based on real e-Factura
-SPV invoice data: <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">PriceAmount=372.20</code>,
-<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">AllowanceCharge/Amount=93.05</code>, <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">qty=1</code> → <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">discount=25%</code>).</li>
-</ul>
-</div>
-</div>
-<div class="section" id="section-2">
-<h2 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:24px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">[18.0.1.0.0] - 2025-01-01</h2>
-<div class="section" id="added-1">
-<h3 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:19px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Added</h3>
-<ul style="list-style:none;padding:0;margin:14px 0 30px;display:grid;grid-template-columns:repeat(2,1fr);gap:14px;"><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Initial release: import UBL XML vendor invoices to automate purchase
-order management.</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Automatic product matching by barcode (GS1/EAN), supplier code,
-internal reference, or name.</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Purchase order line creation and update (quantities and prices) from
-XML data.</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Supplier price update in vendor pricelist (Supplier Info).</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Stock receipt (picking) validation with quantities from XML.</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Vendor bill creation linked to the purchase order.</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Option to automatically create missing products from UBL data.</li><li style="background-color:transparent;border:1px solid rgba(127,160,140,0.40);border-radius:14px;list-style:none;margin:0;line-height:1.5;padding:16px 18px 16px 50px;position:relative;"><span style="position:absolute;left:16px;top:17px;width:22px;height:22px;border-radius:7px;background-color:#57B952;color:#04331f;font-weight:800;font-size:13px;text-align:center;line-height:22px;display:inline-block;">&#10003;</span>Support for standard UBL Invoice namespaces and common unit code
-mappings (C62, KGM, LTR, etc.).</li></ul>
-</div>
-</div>
-</div>
 <div class="section" id="bug-tracker">
 <h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Bug Tracker</h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.

--- a/deltatech_queue_job/static/description/index.html
+++ b/deltatech_queue_job/static/description/index.html
@@ -525,24 +525,6 @@ Queue Job list view using the <strong>Process</strong> button (internal cron tri
 or <strong>Process (Thread)</strong> (API-style runner in a new thread), or trigger a
 background execution using <strong>Cron Trigger</strong>.</p>
 </div>
-<div class="section" id="changelog">
-<h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
-</div>
-<div class="section" id="changelog-1">
-<h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
-<div class="section" id="section-1">
-<h2 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:24px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">19.0.1.2.0</h2>
-<ul class="simple">
-<li>When a new job is created, automatically move older jobs left in the
-<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">failed</code> state that share the same <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">identity_key</code> to
-<code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">cancelled</code>. The standard deduplication only checks active states
-(pending/enqueued/wait_dependencies), so failed duplicates used to
-pile up. The record and its traceback are kept for diagnostics and the
-standard <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">autovacuum</code> cron removes cancelled jobs later based on the
-channel <code style="border:1px solid rgba(127,160,140,0.40);padding:1px 7px;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">removal_interval</code>.</li>
-</ul>
-</div>
-</div>
 <div class="section" id="bug-tracker">
 <h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Bug Tracker</h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.

--- a/deltatech_replenishment_explain/static/description/index.html
+++ b/deltatech_replenishment_explain/static/description/index.html
@@ -400,19 +400,6 @@ timeline</strong> (today → lead time → lead-horizon date).</p>
 horizon</strong> (invisible to the forecast), <strong>no vendor found</strong> (silent +365
 days), a <strong>potential stockout</strong> even when nothing is ordered (deadline
 set), rounding inflation, manual overrides and snoozes.</p>
-<div class="section" id="changelog">
-<h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
-<p><strong>19.0.1.1.0</strong></p>
-<ul class="simple">
-<li>Add a visual summary to the “Why this replenishment?” dialog: an SVG
-quantity bar (forecast vs Min / Max, with the to-order gap) and a
-lead-horizon timeline (today -&gt; lead time -&gt; lead horizon date).</li>
-</ul>
-<p><strong>19.0.1.0.0</strong></p>
-<ul class="simple">
-<li>Initial release.</li>
-</ul>
-</div>
 <div class="section" id="bug-tracker">
 <h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Bug Tracker</h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.

--- a/deltatech_report_prn/static/description/index.html
+++ b/deltatech_report_prn/static/description/index.html
@@ -390,22 +390,6 @@ files that have syntax for Zebra label printers.</li>
 </li>
 </ul>
 </div>
-<div class="section" id="changelog">
-<h1><a class="toc-backref" href="#toc-entry-1">Changelog</a></h1>
-<div class="section" id="section-1">
-<h2><a class="toc-backref" href="#toc-entry-2">19.0.1.1.0</a></h2>
-<ul class="simple">
-<li>Refactor the <tt class="docutils literal"><span class="pre">qweb-prn</span></tt> report handler and export <tt class="docutils literal">buildPrnUrl</tt> so
-a companion module can intercept the report (with a lower handler
-sequence) and print through <strong>Zebra Browser Print</strong>, falling back to
-the legacy <tt class="docutils literal">.prn</tt> download handled here. No functional change to the
-legacy flow.</li>
-<li>The whole Zebra Browser Print feature (the SDK, the enable switch and
-the print logic) lives in a separate companion module; this module
-stays free of any proprietary code and any Browser Print dependency.</li>
-</ul>
-</div>
-</div>
 <div class="section" id="bug-tracker">
 <h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.

--- a/deltatech_stock_close/static/description/index.html
+++ b/deltatech_stock_close/static/description/index.html
@@ -399,20 +399,6 @@ according to your business needs.</li>
 <p><strong>Table of contents</strong></p>
 </div>
 </div>
-<div class="section" id="changelog">
-<h1>Changelog</h1>
-</div>
-<div class="section" id="changelog-1">
-<h1>Changelog</h1>
-<div class="section" id="section-1">
-<h2>19.0.1.0.0</h2>
-<ul class="simple">
-<li>Port to Odoo 19.0 from 18.0.</li>
-<li>Uses <tt class="docutils literal"><span class="pre">check_access(&quot;read&quot;)</span></tt> (the deprecated <tt class="docutils literal">check_access_rights</tt>
-was removed in favor of the merged <tt class="docutils literal">check_access</tt> method).</li>
-</ul>
-</div>
-</div>
 <div class="section" id="bug-tracker">
 <h1>Bug Tracker</h1>
 <p>Bugs are tracked on <a class="reference external" href="https://github.com/dhongu/deltatech/issues">GitHub Issues</a>.

--- a/scripts/tb_skin_index.py
+++ b/scripts/tb_skin_index.py
@@ -238,6 +238,21 @@ def remove_secondary_language(html):
     return html
 
 
+def remove_changelog(html):
+    """Elimină secțiunea Changelog (din HISTORY.md) + subsecțiunile de versiune.
+    Taie de la <div class="section" id="changelog"> până la secțiunea Bug Tracker
+    (pe care o păstrăm). Pe Apps Store istoricul lung nu-și are locul în descriere."""
+    start = re.search(r'<div class="section" id="changelog', html)
+    if not start:
+        return html
+    bug = re.search(r'<div class="section" id="bug-tracker"', html[start.start():])
+    if bug:
+        end = start.start() + bug.start()
+    else:
+        end = _section_end(html, start.start()) or len(html)
+    return html[: start.start()] + html[end:]
+
+
 # --- heading-uri docutils: bară-accent verde + ink închis ---------------------- #
 def style_headings(html):
     """Stilează heading-urile de secțiune (h1/h2/h3 docutils, fără style) cu o bară-accent
@@ -397,6 +412,7 @@ def skin_html(html, manifest):
     html = remove_duplicate_name_heading(html, name)
     html = remove_secondary_language(html)
     html = strip_toc(html)
+    html = remove_changelog(html)
     # 2) stilizează conținutul docutils
     html = style_headings(html)
     html = style_code(html)


### PR DESCRIPTION
Secțiunea Changelog (din HISTORY.md) + subsecțiunile de versiune erau zgomot în descrierea de pe Apps Store. Skin-ul le taie acum (`remove_changelog`), de la secțiunea `changelog` până la `Bug Tracker` (păstrat). Aplicat și pe index.html existente + în template pentru regenerări viitoare.

🤖 Generated with [Claude Code](https://claude.com/claude-code)