### PR TITLE
[FIX] deltatech_business_process_handover_document: store handover_process_ids

### DIFF
--- a/deltatech_business_process_handover_document/models/business_project.py
+++ b/deltatech_business_process_handover_document/models/business_project.py
@@ -14,6 +14,7 @@ class BusinessProject(models.Model):
         "business.process",
         string="Handover Processes",
         compute="_compute_handover_process_ids",
+        store=True,
         help="Processes included in the handover document, after applying the stage filter.",
     )
 


### PR DESCRIPTION
## Summary
- `handover_process_ids` era computed dar nestocat, ceea ce împiedica Odoo să determine ce înregistrări `business.project` să recalculeze la modificarea `business.development` prin `handover_process_ids.development_ids`, generând un `UserWarning` la pornire/instalare.
- Adaugă `store=True` pe câmp, făcându-l searchable.

## Test plan
- [ ] `-u deltatech_business_process_handover_document --stop-after-init` fără warning-ul respectiv

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>