### PR TITLE
fix(deltatech_business_process): allow file:// git transport in TestLibraryGitSync

### DIFF
--- a/deltatech_business_process/tests/test_library_git_sync.py
+++ b/deltatech_business_process/tests/test_library_git_sync.py
@@ -100,6 +100,23 @@ class TestLibraryGitSync(TransactionCase):
         patcher = patch.object(type(self.library), "_git_repos_cache_dir", lambda lib, cache=self.cache_dir: cache)
         patcher.start()
         self.addCleanup(patcher.stop)
+        # Certain hardened environments (e.g. CI build sandboxes) set
+        # ``protocol.file.allow=never`` system-wide, which would break the
+        # ``file://`` transport this fixture relies on to simulate a real repo
+        # without network access. Force it back on for the git calls made by
+        # the code under test — this only affects the test's own subprocess
+        # invocations, never production traffic (which is https/ssh).
+        original_auth_args = type(self.library)._git_auth_args
+
+        def _patched_auth_args(lib, url, _orig=original_auth_args):
+            args = _orig(lib, url)
+            if url.startswith("file://"):
+                args = ["-c", "protocol.file.allow=always", *args]
+            return args
+
+        auth_patcher = patch.object(type(self.library), "_git_auth_args", _patched_auth_args)
+        auth_patcher.start()
+        self.addCleanup(auth_patcher.stop)
 
     def _configure_repo(self):
         self.icp.set_param(PARAM_REPOS, self.repo_url)


### PR DESCRIPTION
## Summary
- `TestLibraryGitSync` clones a local `file://` fixture repo to simulate a real git sync without network access.
- Hardened CI/build sandboxes (e.g. odoo.sh) often set `protocol.file.allow=never` system-wide (post-CVE-2022-39253 hardening), which makes `git clone file://...` fail with `fatal: transport 'file' not allowed`.
- That makes `_sync_git_repo` return `None`, cascading into empty `available_processes()` / import lines, and failing several tests in the class (matches the CI failure: `AssertionError: business.process.library.import.line() is not true`).
- Fix: in `setUp`, patch `_git_auth_args` to inject `-c protocol.file.allow=always` only for `file://` URLs, leaving production behavior (https/ssh) untouched.

## Test plan
- [x] Reproduced the exact CI failure locally by simulating `protocol.file.allow=never` (`GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` env vars).
- [x] Confirmed the fix resolves it: full `deltatech_business_process` suite (127 tests) passes with `protocol.file.allow=never` forced.
- [x] Confirmed the suite still passes in a normal (unrestricted) git environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)