### PR TITLE
[FIX] deltatech_image_optimize: keep memory flat on large batches

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -22,7 +22,7 @@
     <!-- How many images to process per cron run. -->
     <record id="cp_batch" model="ir.config_parameter">
         <field name="key">deltatech_image_optimize.batch</field>
-        <field name="value">1000</field>
+        <field name="value">200</field>
     </record>
 
     <!-- Original image fields to optimize (comma separated res_field values). -->

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -113,42 +113,49 @@ class IrAttachment(models.Model):
         now = fields.Datetime.now()
         optimized = 0
         freed = 0
-        for att in attachments:
+        # Decoded images and their raw bytes are heavy; flush and drop the ORM
+        # cache regularly so memory stays flat over large batches (otherwise a
+        # single batch can exhaust the worker/shell memory and get killed).
+        flush_every = 20
+        for index, att in enumerate(attachments, start=1):
             raw = att.raw
             data = self._dt_image_recompress(raw, params["quality"], params["max_dim"])
             if not data:
                 att.deltatech_image_optimized = now
-                continue
-            record = self.env[att.res_model].sudo().browse(att.res_id)
-            if not record.exists() or att.res_field not in record._fields:
-                att.deltatech_image_optimized = now
-                continue
-            try:
-                record.write({att.res_field: base64.b64encode(data)})
-            except Exception as exc:  # noqa: BLE001
-                _logger.warning(
-                    "Image optimize failed for %s(%s).%s: %s",
-                    att.res_model,
-                    att.res_id,
-                    att.res_field,
-                    exc,
-                )
-                att.deltatech_image_optimized = now
-                continue
-            # Writing the image field recreates the attachment: flag the new one
-            # so it is not reprocessed on the next run.
-            new_att = self.sudo().search(
-                [
-                    ("res_model", "=", att.res_model),
-                    ("res_id", "=", att.res_id),
-                    ("res_field", "=", att.res_field),
-                ],
-                limit=1,
-            )
-            if new_att:
-                new_att.deltatech_image_optimized = now
-            freed += len(raw) - len(data)
-            optimized += 1
+            else:
+                record = self.env[att.res_model].sudo().browse(att.res_id)
+                if not record.exists() or att.res_field not in record._fields:
+                    att.deltatech_image_optimized = now
+                else:
+                    try:
+                        record.write({att.res_field: base64.b64encode(data)})
+                    except Exception as exc:  # noqa: BLE001
+                        _logger.warning(
+                            "Image optimize failed for %s(%s).%s: %s",
+                            att.res_model,
+                            att.res_id,
+                            att.res_field,
+                            exc,
+                        )
+                        att.deltatech_image_optimized = now
+                    else:
+                        # Writing the image field recreates the attachment:
+                        # flag the new one so it is not reprocessed next run.
+                        new_att = self.sudo().search(
+                            [
+                                ("res_model", "=", att.res_model),
+                                ("res_id", "=", att.res_id),
+                                ("res_field", "=", att.res_field),
+                            ],
+                            limit=1,
+                        )
+                        if new_att:
+                            new_att.deltatech_image_optimized = now
+                        freed += len(raw) - len(data)
+                        optimized += 1
+            if index % flush_every == 0:
+                self.env.flush_all()
+                self.env.invalidate_all()
 
         _logger.info(
             "Image optimizer: scanned=%s optimized=%s freed=%.1f MB",

--- a/deltatech_image_optimize/readme/DESCRIPTION.md
+++ b/deltatech_image_optimize/readme/DESCRIPTION.md
@@ -41,6 +41,6 @@ enable it.
 For a large one-time backlog you can loop the batch method from the shell:
 
 ```python
-while env["ir.attachment"]._dt_image_optimize_run(limit=2000)["scanned"]:
+while env["ir.attachment"]._dt_image_optimize_run(limit=200)["scanned"]:
     env.cr.commit()
 ```

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 18.0.1.0.1 (2025)
+
+- Keep memory flat over large batches: flush and invalidate the ORM cache
+  every 20 images (avoids the worker/shell being killed on big batches).
+- Lower the default batch size to 200.
+
 ## 18.0.1.0.0 (2025)
 
 - Initial release.


### PR DESCRIPTION
Rularea backlog-ului pe staging (128k poze) a fost omorâtă de OOM: un lot de 1000 acumula în cache-ul ORM raw-ul + imaginile decodate ale celor mai mari 1000 poze (câțiva GB).

Fix:
- `flush_all()` + `invalidate_all()` la fiecare 20 de imagini → memoria rămâne plată indiferent de mărimea lotului.
- Batch implicit coborât la 200.

Teste: 2/2 trec local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)