### PR TITLE
[FIX] deltatech_purchase_price: compute_sudo pe last_purchase_price (tichet 8921)

### DIFF
--- a/deltatech_purchase_price/__manifest__.py
+++ b/deltatech_purchase_price/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Purchase Price",
     "summary": "Update vendor price after reception",
-    "version": "19.0.1.2.7",
+    "version": "19.0.1.2.8",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_purchase_price/models/product.py
+++ b/deltatech_purchase_price/models/product.py
@@ -30,6 +30,12 @@ class ProductTemplate(models.Model):
         search="_search_last_purchase_price",
         tracking=True,
         company_dependent=True,
+        # Compute-ul citește seller_ids (product.supplierinfo) pentru template-urile
+        # multi-variantă (fix tichet 8403). Câmpul e afișat indirect pe website prin
+        # deltatech_price_categ (list_price_base = "last_purchase_price"), deci
+        # recalcularea trebuie să ruleze ca sudo, altfel userul Public — care nu are
+        # drept pe product.supplierinfo — primește 403 la /shop (tichet 8921).
+        compute_sudo=True,
     )
 
     @api.depends("product_variant_ids.last_purchase_price", "seller_ids.price", "seller_ids.product_id")

--- a/deltatech_purchase_price/tests/test_purchase.py
+++ b/deltatech_purchase_price/tests/test_purchase.py
@@ -131,6 +131,49 @@ class TestPurchase(TransactionCase):
         self.assertEqual(variant_l.last_purchase_price, 20.0)
         self.assertEqual(template.last_purchase_price, 20.0)
 
+    def test_last_purchase_price_readable_as_public(self):
+        # tichet 8921: last_purchase_price este afisat indirect pe website
+        # (deltatech_price_categ). Pentru sabloanele multi-varianta compute-ul
+        # citeste seller_ids (product.supplierinfo), la care userul Public nu are
+        # drept. Fara compute_sudo, citirea crapa cu 403 la /shop. Verificam ca
+        # un user public poate citi campul fara AccessError.
+        attribute = self.env["product.attribute"].create(
+            {
+                "name": "Public Size",
+                "create_variant": "always",
+                "value_ids": [(0, 0, {"name": "S"}), (0, 0, {"name": "L"})],
+            }
+        )
+        template = self.env["product.template"].create(
+            {
+                "name": "Public variant template",
+                "is_storable": True,
+                "attribute_line_ids": [
+                    (
+                        0,
+                        0,
+                        {
+                            "attribute_id": attribute.id,
+                            "value_ids": [(6, 0, attribute.value_ids.ids)],
+                        },
+                    )
+                ],
+            }
+        )
+        self.env["product.supplierinfo"].create(
+            {
+                "partner_id": self.partner_a.id,
+                "product_tmpl_id": template.id,
+                "product_id": template.product_variant_ids[-1].id,
+                "price": 20,
+            }
+        )
+        public_user = self.env.ref("base.public_user")
+        template.invalidate_recordset(["last_purchase_price"])
+        # nu trebuie sa ridice AccessError pe product.supplierinfo
+        price = template.with_user(public_user).last_purchase_price
+        self.assertEqual(price, 20.0)
+
     def test_wizard_trade_markup(self):
         wizard = Form(self.env["product.markup.wizard"])
         wizard.trade_markup = 10

--- a/scripts/tb_skin_index.py
+++ b/scripts/tb_skin_index.py
@@ -245,7 +245,7 @@ def remove_changelog(html):
     start = re.search(r'<div class="section" id="changelog', html)
     if not start:
         return html
-    bug = re.search(r'<div class="section" id="bug-tracker"', html[start.start():])
+    bug = re.search(r'<div class="section" id="bug-tracker"', html[start.start() :])
     if bug:
         end = start.start() + bug.start()
     else:


### PR DESCRIPTION
## Problemă (tichet #8921 — REPER V TRANS SRL)

Vizitatorii **nelogați** pe `/shop` primeau **403 Forbidden**:
> `Failed to read field product.template.seller_ids` — *Nu aveți permisiunea de a accesa 'Lista de prețuri Furnizor' (product.supplierinfo)*

## Cauză

Regresie a fix-ului tichetului **8403** (deltatech#2558). `last_purchase_price` pe `product.template` este un câmp **computed non-stocat**, fără `compute_sudo`. Pentru șabloanele **multi-variantă**, `_compute_last_purchase_price` → `_get_last_purchase_price_from_sellers()` citește `self.seller_ids` (`product.supplierinfo`).

Câmpul e folosit indirect pe website prin `deltatech_price_categ` (`list_price_base` default `"last_purchase_price"`), deci recalcularea se declanșează și la randarea `/shop` pentru userul **Public**, care nu are drept pe `product.supplierinfo` → 403.

## Fix

`compute_sudo=True` pe câmp → recalcularea rulează mereu ca sudo. Lista de furnizori **nu** e expusă: se folosește doar prețul agregat, intern, pentru calculul prețului de vânzare.

## Test

Adăugat `test_last_purchase_price_readable_as_public`: citirea `last_purchase_price` ca user Public pe un șablon multi-variantă cu furnizor nu mai ridică `AccessError`. Rulat local — trece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)