### PR TITLE
[FIX] repară testele roșii pe 19.0 (search picking_status O19 + MockRequest cost_price)

### DIFF
--- a/deltatech_purchase_picking_status/__manifest__.py
+++ b/deltatech_purchase_picking_status/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase picking status",
     "summary": "Get purchase status from pickings",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Purchase",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",

--- a/deltatech_purchase_picking_status/models/purchase_order.py
+++ b/deltatech_purchase_picking_status/models/purchase_order.py
@@ -36,7 +36,17 @@ class PurchaseOrder(models.Model):
                 order.picking_status = state
 
     def _search_picking_status(self, operator, value):
+        # În Odoo 19 ORM-ul normalizează `("picking_status", "=", "x")` la
+        # operatorul `in` cu o colecție de valori, deci trebuie tratate atât
+        # `in`/`not in` (value = listă/set) cât și `=`/`!=` (value = scalar).
+        if operator in ("in", "not in"):
+            values = set(value)
+        elif operator in ("=", "!="):
+            values = {value}
+        else:
+            raise NotImplementedError(self.env._("Operator %s not supported", operator))
         orders = self.search([("state", "!=", "cancel")])
-        f_orders = orders.filtered(lambda x: x.picking_status == value)
-        res = [("id", "in", [x.id for x in f_orders] if f_orders else False)]
-        return res
+        f_orders = orders.filtered(lambda x: x.picking_status in values)
+        if operator in ("not in", "!="):
+            f_orders = orders - f_orders
+        return [("id", "in", f_orders.ids)]

--- a/deltatech_website_sale_cost_price/__manifest__.py
+++ b/deltatech_website_sale_cost_price/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Website Sale Cost Price",
     "summary": "Prevent adding to cart if price is lower than cost price",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Terrabit, Voicu Stefan",
     "website": "https://www.terrabit.ro",
     "category": "Website/Website",

--- a/deltatech_website_sale_cost_price/tests/test_sale_cost_price.py
+++ b/deltatech_website_sale_cost_price/tests/test_sale_cost_price.py
@@ -4,7 +4,7 @@
 
 from odoo.tests import tagged
 
-from odoo.addons.website_sale.tests.common import WebsiteSaleCommon
+from odoo.addons.website_sale.tests.common import MockRequest, WebsiteSaleCommon
 
 
 @tagged("post_install", "-at_install")
@@ -29,27 +29,29 @@ class TestWebsiteSaleCostPrice(WebsiteSaleCommon):
         self.test_product.list_price = 100.0
         self.test_product.standard_price = 80.0
 
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        self.assertFalse(info["prevent_zero_price_sale"], "Sale should NOT be prevented when price > cost")
-        self.assertTrue(self.test_product._website_show_quick_add(), "Quick add should be allowed")
-        self.assertTrue(self.test_product._is_add_to_cart_allowed(), "Add to cart should be allowed")
+        with MockRequest(self.env, website=self.website):
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            self.assertFalse(info["prevent_zero_price_sale"], "Sale should NOT be prevented when price > cost")
+            self.assertTrue(self.test_product._website_show_quick_add(), "Quick add should be allowed")
+            self.assertTrue(self.test_product._is_add_to_cart_allowed(), "Add to cart should be allowed")
 
     def test_02_price_lower_than_cost(self):
         """Test that product is NOT allowed when price is lower than cost"""
         self.test_product.list_price = 70.0
         self.test_product.standard_price = 80.0
 
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        self.assertTrue(info["prevent_zero_price_sale"], "Sale SHOULD be prevented when price < cost")
-        self.assertFalse(self.test_product._website_show_quick_add(), "Quick add should NOT be allowed")
-        # _is_add_to_cart_allowed returns True for system user, so we check without system user or just check logic
-        # For simplicity, we know we are running as admin in tests usually, so we might need to check with a different user
+        with MockRequest(self.env, website=self.website):
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            self.assertTrue(info["prevent_zero_price_sale"], "Sale SHOULD be prevented when price < cost")
+            self.assertFalse(self.test_product._website_show_quick_add(), "Quick add should NOT be allowed")
+            # _is_add_to_cart_allowed returns True for system user, so we check without system user or just check logic
+            # For simplicity, we know we are running as admin in tests usually, so we might need to check with a different user
 
-        public_user = self.env.ref("base.public_user")
-        self.assertFalse(
-            self.test_product.with_user(public_user)._is_add_to_cart_allowed(),
-            "Add to cart should NOT be allowed for public user",
-        )
+            public_user = self.env.ref("base.public_user")
+            self.assertFalse(
+                self.test_product.with_user(public_user)._is_add_to_cart_allowed(),
+                "Add to cart should NOT be allowed for public user",
+            )
 
     def test_03_price_with_margin(self):
         """Test that margin is correctly applied"""
@@ -60,13 +62,14 @@ class TestWebsiteSaleCostPrice(WebsiteSaleCommon):
         self.test_product.list_price = 85.0
         self.test_product.standard_price = 80.0
 
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        self.assertTrue(info["prevent_zero_price_sale"], "Sale SHOULD be prevented when price < cost + margin")
+        with MockRequest(self.env, website=self.website):
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            self.assertTrue(info["prevent_zero_price_sale"], "Sale SHOULD be prevented when price < cost + margin")
 
-        # Price 90 should be accepted.
-        self.test_product.list_price = 90.0
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        self.assertFalse(info["prevent_zero_price_sale"], "Sale should NOT be prevented when price > cost + margin")
+            # Price 90 should be accepted.
+            self.test_product.list_price = 90.0
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            self.assertFalse(info["prevent_zero_price_sale"], "Sale should NOT be prevented when price > cost + margin")
 
     def test_04_tax_adjustment(self):
         """Test tax adjustment logic"""
@@ -93,18 +96,19 @@ class TestWebsiteSaleCostPrice(WebsiteSaleCommon):
         # Standard Odoo: list_price is tax excluded.
         # _get_combination_info applies taxes to the price obtained from pricelist.
 
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        # price should be 110 * 1.2 = 132.0
-        # cost_price for comparison should be 100 * 1.2 = 120.0 (since website is tax_included and cost is tax_excluded)
-        # 132 > 120 -> allowed.
-        self.assertFalse(info["prevent_zero_price_sale"], "Should be allowed: 132 > 120")
+        with MockRequest(self.env, website=self.website):
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            # price should be 110 * 1.2 = 132.0
+            # cost_price for comparison should be 100 * 1.2 = 120.0 (since website is tax_included and cost is tax_excluded)
+            # 132 > 120 -> allowed.
+            self.assertFalse(info["prevent_zero_price_sale"], "Should be allowed: 132 > 120")
 
-        self.test_product.list_price = 90.0
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        # price = 90 * 1.2 = 108.0
-        # cost = 120.0
-        # 108 < 120 -> prevented.
-        self.assertTrue(info["prevent_zero_price_sale"], "Should be prevented: 108 < 120")
+            self.test_product.list_price = 90.0
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            # price = 90 * 1.2 = 108.0
+            # cost = 120.0
+            # 108 < 120 -> prevented.
+            self.assertTrue(info["prevent_zero_price_sale"], "Should be prevented: 108 < 120")
 
     def test_05_prevent_zero_price_sale_disabled(self):
         """Test that if the main setting is disabled, our check is also skipped"""
@@ -112,5 +116,6 @@ class TestWebsiteSaleCostPrice(WebsiteSaleCommon):
         self.test_product.list_price = 10.0
         self.test_product.standard_price = 100.0
 
-        info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
-        self.assertFalse(info["prevent_zero_price_sale"], "Should NOT be prevented because main toggle is OFF")
+        with MockRequest(self.env, website=self.website):
+            info = self.test_product.product_tmpl_id._get_combination_info(product_id=self.test_product.id)
+            self.assertFalse(info["prevent_zero_price_sale"], "Should NOT be prevented because main toggle is OFF")


### PR DESCRIPTION
Repară cele două eșecuri **preexistente** care țin CI-ul roșu pe `19.0` (introduse de migrări recente, nu de vreun PR de funcționalitate).

## 1. `deltatech_purchase_picking_status` — `test_search_picking_status`
În Odoo 19, ORM-ul normalizează `("picking_status", "=", "in_progress")` și apelează metoda `search` cu `operator="in"` și `value=OrderedSet(['in_progress'])`. `_search_picking_status` compara `x.picking_status == value` (un set) → mereu fals → `[("id", "in", False)]` → 0 rezultate.

**Fix:** metoda tratează acum `in`/`not in`/`=`/`!=`, filtrează pe apartenență și întoarce `[("id", "in", ids)]`.

## 2. `deltatech_website_sale_cost_price` — 5 teste `RuntimeError: object unbound`
Testele apelau `_get_combination_info`, care în O19 accesează `request.website`, fără context de request.

**Fix:** apelurile sunt învelite în `MockRequest(self.env, website=self.website)`, ca în `deltatech_website_stock_availability`.

## Verificare locală
- `deltatech_website_sale_cost_price`: **5/5** teste OK
- `deltatech_purchase_picking_status`: logica `search` validată în shell (in_progress găsit, done absent). Testul complet e blocat local doar de o coloană orfană `publish_date` din baza de test locală — irelevant pentru CI (bază curată).

Ambele module: bump versiune.

🤖 Generated with [Claude Code](https://claude.com/claude-code)