### PR TITLE
[FIX] deltatech_account_edi_ubl_advice: referință aviz în e-Factura (ubl_bis3)

### DIFF
--- a/deltatech_account_edi_ubl_advice/__manifest__.py
+++ b/deltatech_account_edi_ubl_advice/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech UBL despatch advice",
     "summary": "Deltatech Account UBL despatch advice",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_account_edi_ubl_advice/models/account_edi_ubl.py
+++ b/deltatech_account_edi_ubl_advice/models/account_edi_ubl.py
@@ -6,16 +6,21 @@
 from odoo import models
 
 
-class AccountEdiXmlUBL20(models.AbstractModel):
-    _inherit = "account.edi.xml.ubl_20"
+class AccountEdiXmlUBLBis3(models.AbstractModel):
+    # Extindem la nivelul ubl_bis3, nu ubl_20: în Odoo 19 metoda
+    # _add_invoice_header_nodes din ubl_bis3 este un OVERRIDE care NU apelează
+    # super(), deci un patch pe ubl_20 nu mai este niciodată executat pentru
+    # e-Factura RO (account.edi.xml.ubl_ro -> ubl_bis3). Ne agățăm de ubl_bis3,
+    # care este baza folosită la exportul CIUS-RO.
+    _inherit = "account.edi.xml.ubl_bis3"
 
     def _add_invoice_header_nodes(self, document_node, vals):
-        res = super()._add_invoice_header_nodes(document_node, vals)
+        super()._add_invoice_header_nodes(document_node, vals)
         invoice = vals["invoice"]
         if invoice.move_type != "out_invoice":
-            return res
+            return
         if "sale_line_ids" not in invoice.invoice_line_ids._fields:
-            return res
+            return
         pickings = self.env["stock.picking"]
         for line in invoice.invoice_line_ids:
             for sale_line in line.sale_line_ids:
@@ -25,5 +30,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         if pickings:
             names = pickings.mapped("name")
             vals["despatch_advice"] = ", ".join(names)
+            # Nodul este definit în template-ul Invoice (cac:DespatchDocumentReference,
+            # între BillingReference și Delivery), deci ordinea în XML este corectă
+            # indiferent de momentul inserării în dict.
             document_node["cac:DespatchDocumentReference"] = {"cbc:ID": {"_text": ", ".join(names)}}
-        return res


### PR DESCRIPTION
## Problemă (tichet 8931, regresie față de 8198)

Referința avizului de expediție (`cac:DespatchDocumentReference`) nu mai apărea în XML-ul e-Factura RO al clientului Romchim.

## Cauză

Modulul suprascria `_add_invoice_header_nodes` pe `account.edi.xml.ubl_20`. În Odoo 19, `account.edi.xml.ubl_bis3._add_invoice_header_nodes` este un **OVERRIDE fără `super()`**, care reconstruiește tot antetul. Cum e-Factura RO folosește `account.edi.xml.ubl_ro → ubl_bis3`, lanțul se oprea la `bis3` și nu ajungea niciodată la patch-ul din `ubl_20` → cod mort.

## Fix

Hook-ul mutat pe `account.edi.xml.ubl_bis3`, cu `super()` păstrat. Nodul e adăugat după `super()`; fiind definit în template-ul `Invoice` (între `BillingReference` și `Delivery`), ordinea în XML rămâne corectă. Logica de identificare a avizelor (picking-uri `done` din liniile SO) este neschimbată.

🤖 Generated with [Claude Code](https://claude.com/claude-code)