### PR TITLE
[18.0][FIX] deltatech_product_code: unicitate cod intern doar între produse active

### DIFF
--- a/deltatech_product_code/__manifest__.py
+++ b/deltatech_product_code/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Products Code",
     "summary": "Product codification internal",
-    "version": "18.0.1.0.8",
+    "version": "18.0.1.0.9",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_product_code/models/product.py
+++ b/deltatech_product_code/models/product.py
@@ -35,9 +35,12 @@ def _check_unique_default_code(records, company_of):
     if not to_check:
         return
     codes = list({p.default_code for p in to_check})
-    # un singur search indexat (default_code IN [...]); active_test filtreaza activele
+    # Uniqueness is over (default_code, active, company_id): an active and an
+    # archived product may share a code (see show_not_unique). Force active_test
+    # so ambient active_test=False (e.g. during marketplace import) does not make
+    # archived records collide with active ones.
     by_code = defaultdict(list)
-    for rec in records.search([("default_code", "in", codes)]):
+    for rec in records.with_context(active_test=True).search([("default_code", "in", codes)]):
         by_code[rec.default_code].append(rec)
     for product in to_check:
         company = company_of(product)

--- a/deltatech_product_code/readme/HISTORY.md
+++ b/deltatech_product_code/readme/HISTORY.md
@@ -1,0 +1,17 @@
+## 18.0.1.0.9
+
+- Fix `default_code` uniqueness check: only active products conflict with each
+  other. The check now forces `active_test=True` in its lookup, so an ambient
+  `active_test=False` context (e.g. during a marketplace/Shopify import) no
+  longer makes an archived product collide with a newly created active one.
+  Uniqueness stays over `(default_code, active, company_id)`, matching
+  `show_not_unique`.
+
+## 18.0.1.0.8
+
+- Batch-safe uniqueness constraint (single indexed query) and index on
+  `default_code`.
+
+## 18.0.1.0.7
+
+- Correct internal-code uniqueness for shared products (NULL company).


### PR DESCRIPTION
## Problemă

Importul de produse din Shopify crapă cu `ValidationError: Referința internă 'X' există deja la produsul ...` când codul intern al produsului importat coincide cu al unui produs **arhivat**.

Cauză: constrângerea de unicitate `default_code` face `records.search(...)` cu `active_test` moștenit din context. La import contextul e `active_test=False` (setat în `marketplace.product.template.save_from_marketplace`), deci produsele arhivate sunt tratate ca duplicate și blochează scrierea pe produsul activ.

Unicitatea e definită pe `(default_code, active, company_id)` — vezi `show_not_unique` — deci un produs activ și unul arhivat **pot** împărți același cod.

## Fix

Se forțează `active_test=True` în căutarea din `_check_unique_default_code`, astfel doar produsele active intră în conflict între ele. Fix strict de relaxare (elimină un fals pozitiv).

## Impact

Pe baza PTC: ~21.700 template-uri arhivate cu `default_code` setat, din care 4.520 orfani generici „Tavite portbagaj …". Orice produs activ al cărui cod coincidea cu un arhivat era blocat la import — toate deblocate acum.

Verificat empiric pe `terrabit-ro-ptc-main` (produs 193296BSC: activ 2743 + arhivat 22468).

🤖 Generated with [Claude Code](https://claude.com/claude-code)