### PR TITLE
[IMP] deltatech_image_optimize: step 2 - recompress resized variants

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.0.1",
+    "version": "18.0.1.1.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -31,4 +31,22 @@
         <field name="value">image_1920,image_variant_1920</field>
     </record>
 
+    <!-- Resized variant fields to recompress in place (step 2). -->
+    <record id="cp_variant_fields" model="ir.config_parameter">
+        <field name="key">deltatech_image_optimize.variant_fields</field>
+        <field name="value">image_1024,image_512,image_256,image_128</field>
+    </record>
+
+    <!-- Quality for re-encoding the variants. -->
+    <record id="cp_variant_quality" model="ir.config_parameter">
+        <field name="key">deltatech_image_optimize.variant_quality</field>
+        <field name="value">85</field>
+    </record>
+
+    <!-- Only recompress variants larger than this many bytes (20 KB). -->
+    <record id="cp_variant_min_size" model="ir.config_parameter">
+        <field name="key">deltatech_image_optimize.variant_min_size</field>
+        <field name="value">20480</field>
+    </record>
+
 </odoo>

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -12,6 +12,7 @@ except ImportError:  # pragma: no cover
     Image = None
 
 DEFAULT_TARGET_FIELDS = "image_1920,image_variant_1920"
+DEFAULT_VARIANT_FIELDS = "image_1024,image_512,image_256,image_128"
 
 
 class IrAttachment(models.Model):
@@ -166,6 +167,68 @@ class IrAttachment(models.Model):
         return {"scanned": len(attachments), "optimized": optimized, "freed": freed}
 
     @api.model
+    def _dt_image_optimize_variants_run(self, limit=None):
+        """Recompress the stored resized variants (image_1024/512/256/128).
+
+        Variants are ``related='image_1920'`` fields, so they must NOT be
+        written through the record (that would propagate back and downscale the
+        original). Instead we recompress the variant's own attachment in place
+        (``att.write({'raw': ...})``): no resize (already sized), just a lower
+        quality re-encode. No propagation, original untouched.
+
+        :return: dict with ``scanned``, ``optimized`` and ``freed`` (bytes).
+        """
+        if Image is None:
+            return {"scanned": 0, "optimized": 0, "freed": 0}
+        get = self.env["ir.config_parameter"].sudo().get_param
+        quality = max(1, min(95, int(get("deltatech_image_optimize.variant_quality", 85))))
+        min_size = int(get("deltatech_image_optimize.variant_min_size", 20480))
+        vfields = [
+            name.strip()
+            for name in get("deltatech_image_optimize.variant_fields", DEFAULT_VARIANT_FIELDS).split(",")
+            if name.strip()
+        ]
+        limit = limit or int(get("deltatech_image_optimize.batch", 200))
+        domain = [
+            ("res_field", "in", vfields),
+            ("deltatech_image_optimized", "=", False),
+        ]
+        if min_size:
+            domain.append(("file_size", ">", min_size))
+        attachments = self.sudo().search(domain, order="file_size desc", limit=limit)
+
+        now = fields.Datetime.now()
+        optimized = 0
+        freed = 0
+        for index, att in enumerate(attachments, start=1):
+            raw = att.raw
+            # max_dim=0 -> no resize, only a lower quality re-encode.
+            data = self._dt_image_recompress(raw, quality, 0)
+            vals = {"deltatech_image_optimized": now}
+            if data:
+                vals["raw"] = data
+            try:
+                att.write(vals)
+            except Exception as exc:  # noqa: BLE001
+                _logger.warning("Variant optimize failed for att %s: %s", att.id, exc)
+                continue
+            if data:
+                freed += len(raw) - len(data)
+                optimized += 1
+            if index % 20 == 0:
+                self.env.flush_all()
+                self.env.invalidate_all()
+
+        _logger.info(
+            "Image optimizer (variants): scanned=%s optimized=%s freed=%.1f MB",
+            len(attachments),
+            optimized,
+            freed / 1048576.0,
+        )
+        return {"scanned": len(attachments), "optimized": optimized, "freed": freed}
+
+    @api.model
     def _dt_image_optimize_cron(self):
-        """Entry point for the scheduled action."""
+        """Entry point for the scheduled action: originals then variants."""
         self._dt_image_optimize_run()
+        self._dt_image_optimize_variants_run()

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 18.0.1.1.0 (2025)
+
+- Step 2 — recompress the stored resized variants (image_1024/512/256/128)
+  in place (`att.write({'raw': ...})`), at a configurable `variant_quality`,
+  without resizing and without touching the original (no related write-back).
+- New parameters: `variant_fields`, `variant_quality`, `variant_min_size`.
+- The scheduled action now optimizes originals **and** variants.
+
 ## 18.0.1.0.1 (2025)
 
 - Keep memory flat over large batches: flush and invalidate the ORM cache

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -75,3 +75,42 @@ class TestImageOptimize(TransactionCase):
         # Everything processed is flagged, so a second run finds nothing new.
         stats = self.env["ir.attachment"]._dt_image_optimize_run(limit=50)
         self.assertEqual(stats["optimized"], 0)
+
+    def test_variant_optimize_keeps_original(self):
+        if Image is None:
+            self.skipTest("Pillow not available")
+
+        ICP = self.env["ir.config_parameter"].sudo()
+        ICP.set_param("deltatech_image_optimize.variant_min_size", "1")
+        ICP.set_param("deltatech_image_optimize.variant_quality", "60")
+
+        partner = self.env["res.partner"].create(
+            {"name": "Variant Test", "image_1920": self._make_big_jpeg()}
+        )
+        orig_att = self._image_attachment(partner)
+        orig_1920 = orig_att.raw  # keep the master bytes to prove they don't change
+
+        # Variants are stored lazily: read image_1024 to materialize its attachment.
+        _ = partner.image_1024
+        self.env.flush_all()
+
+        var = (
+            self.env["ir.attachment"]
+            .sudo()
+            .search(
+                [("res_model", "=", "res.partner"), ("res_id", "=", partner.id), ("res_field", "=", "image_1024")],
+                limit=1,
+            )
+        )
+        self.assertTrue(var, "image_1024 variant attachment should exist")
+        before = var.file_size
+
+        stats = self.env["ir.attachment"]._dt_image_optimize_variants_run(limit=50)
+        self.assertGreaterEqual(stats["optimized"], 1)
+
+        var.invalidate_recordset()
+        self.assertLess(var.file_size, before)  # variant shrank
+        self.assertTrue(var.deltatech_image_optimized)
+        # the master image_1920 must be byte-for-byte unchanged (no propagation)
+        self._image_attachment(partner).invalidate_recordset()
+        self.assertEqual(self._image_attachment(partner).raw, orig_1920)


### PR DESCRIPTION
Pas-2: recomprimă în loc variantele redimensionate (`image_1024/512/256/128`).

- Variantele sunt câmpuri `related='image_1920'` → se recomprimă pe **atașamentul propriu** (`att.write({'raw': ...})`), la `variant_quality`, fără resize și **fără propagare** în original.
- Cron-ul optimizează acum originale **și** variante.
- Parametri noi: `variant_fields`, `variant_quality`, `variant_min_size`.
- Test nou dovedește că `image_1920` rămâne byte-identic după optimizarea variantelor.

Ținta pe agroamat: variantele ~38 GB → estimat ~10-15 GB recuperabili.

🤖 Generated with [Claude Code](https://claude.com/claude-code)