### PR TITLE
[FIX] deltatech_website_city: expose zipcode on initial city options

### DIFF
--- a/deltatech_website_city/__manifest__.py
+++ b/deltatech_website_city/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Website City",
     "category": "Website/Website",
     "summary": "City extension",
-    "version": "19.0.1.1.1",
+    "version": "19.0.1.1.2",
     "author": "Terrabit, Dorin Hongu",
     "support": "odoo@terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_website_city/tests/test_portal_city.py
+++ b/deltatech_website_city/tests/test_portal_city.py
@@ -79,3 +79,9 @@ class TestMandatoryFields(TransactionCase):
         assert "city_id" in fields_set, "city_id must be mandatory when cities are enforced"
         # And the free-text 'city' should not be mandatory
         assert "city" not in fields_set, "free-text city must be removed when cities are enforced"
+
+
+class TestCityTemplate(TransactionCase):
+    def test_initial_city_options_expose_zipcode(self):
+        view = self.env.ref("deltatech_website_city.address_form_fields")
+        self.assertIn("t-att-data-code=\"city.zipcode or ''\"", view.arch_db)

--- a/deltatech_website_city/views/templates.xml
+++ b/deltatech_website_city/views/templates.xml
@@ -9,7 +9,11 @@
                 <select id="city_id" name="city_id" class="form-select" data-init="1">
                     <option value="">City...</option>
                     <t t-foreach="state_cities" t-as="city">
-                        <option t-att-value="city.id" t-att-selected="city.id == partner_sudo.city_id.id">
+                        <option
+                            t-att-value="city.id"
+                            t-att-selected="city.id == partner_sudo.city_id.id"
+                            t-att-data-code="city.zipcode or ''"
+                        >
                             <t t-out="city.name" />
                         </option>
                     </t>


### PR DESCRIPTION
﻿## What changed

This adds the city zipcode as `data-code` on the initial `city_id` options rendered by the address form template.

## Why

The frontend already reads `data-code` from the selected city option to autofill the ZIP/postal code. Options loaded later through `/portal/state_infos/<state>` include the zipcode, but the initially rendered options did not. As a result, selecting an initially rendered city could not autofill ZIP.

## Impact

Initial city selections now behave the same as city options populated after changing the state: selecting a city with a zipcode can fill the ZIP field automatically.

## Validation

- Parsed `deltatech_website_city/views/templates.xml` as XML.
- Ran `node --check` on the website city frontend interaction and tour files.
- Ran `python -m py_compile` on the module Python files.
- Added a small test asserting the template exposes `data-code` from `city.zipcode`.
