### PR TITLE
[IMP] deltatech_image_optimize: configurable flush_every + GC in cron

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -25,6 +25,13 @@
         <field name="value">200</field>
     </record>
 
+    <!-- Flush + drop the ORM cache every N images. Lower it (2-3) for very
+         high-resolution images (e.g. 20 MP) to keep memory flat. -->
+    <record id="cp_flush_every" model="ir.config_parameter">
+        <field name="key">deltatech_image_optimize.flush_every</field>
+        <field name="value">20</field>
+    </record>
+
     <!-- Original image fields to optimize (comma separated res_field values). -->
     <record id="cp_target_fields" model="ir.config_parameter">
         <field name="key">deltatech_image_optimize.target_fields</field>

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -1,4 +1,5 @@
 import base64
+import gc
 import io
 import logging
 
@@ -39,6 +40,7 @@ class IrAttachment(models.Model):
             "max_dim": int(get("deltatech_image_optimize.max_dim", 1920)),
             "min_size": int(get("deltatech_image_optimize.min_size", 102400)),
             "batch": int(get("deltatech_image_optimize.batch", 1000)),
+            "flush_every": max(1, int(get("deltatech_image_optimize.flush_every", 20))),
             "fields": [
                 name.strip()
                 for name in get("deltatech_image_optimize.target_fields", DEFAULT_TARGET_FIELDS).split(",")
@@ -117,7 +119,8 @@ class IrAttachment(models.Model):
         # Decoded images and their raw bytes are heavy; flush and drop the ORM
         # cache regularly so memory stays flat over large batches (otherwise a
         # single batch can exhaust the worker/shell memory and get killed).
-        flush_every = 20
+        # For high-resolution images (e.g. 20 MP) lower flush_every to 2-3.
+        flush_every = params["flush_every"]
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
             data = self._dt_image_recompress(raw, params["quality"], params["max_dim"])
@@ -157,6 +160,7 @@ class IrAttachment(models.Model):
             if index % flush_every == 0:
                 self.env.flush_all()
                 self.env.invalidate_all()
+                gc.collect()
 
         _logger.info(
             "Image optimizer: scanned=%s optimized=%s freed=%.1f MB",
@@ -189,6 +193,7 @@ class IrAttachment(models.Model):
             if name.strip()
         ]
         limit = limit or int(get("deltatech_image_optimize.batch", 200))
+        flush_every = max(1, int(get("deltatech_image_optimize.flush_every", 20)))
         domain = [
             ("res_field", "in", vfields),
             ("deltatech_image_optimized", "=", False),
@@ -215,9 +220,10 @@ class IrAttachment(models.Model):
             if data:
                 freed += len(raw) - len(data)
                 optimized += 1
-            if index % 20 == 0:
+            if index % flush_every == 0:
                 self.env.flush_all()
                 self.env.invalidate_all()
+                gc.collect()
 
         _logger.info(
             "Image optimizer (variants): scanned=%s optimized=%s freed=%.1f MB",
@@ -229,6 +235,10 @@ class IrAttachment(models.Model):
 
     @api.model
     def _dt_image_optimize_cron(self):
-        """Entry point for the scheduled action: originals then variants."""
+        """Entry point for the scheduled action: originals then variants,
+        followed by a filestore GC so the freed space is actually reclaimed
+        (the cron is the single writer here, so it can grab the GC lock)."""
         self._dt_image_optimize_run()
         self._dt_image_optimize_variants_run()
+        self.env.cr.commit()
+        self._gc_file_store()

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 18.0.1.2.0 (2025)
+
+- Configurable `flush_every` parameter (memory flush/invalidate/gc frequency).
+  Lower it to 2-3 for very high-resolution images (e.g. 20 MP) so the cron and
+  batch runs stay within memory on heavy images.
+- `gc.collect()` at each flush point.
+- The scheduled action now runs a filestore GC at the end (single writer →
+  can grab the lock), so cron-driven runs actually reclaim disk space.
+
 ## 18.0.1.1.0 (2025)
 
 - Step 2 — recompress the stored resized variants (image_1024/512/256/128)

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -70,10 +70,16 @@ class TestImageOptimize(TransactionCase):
         ICP.set_param("deltatech_image_optimize.quality", "70")
         ICP.set_param("deltatech_image_optimize.target_fields", "image_1920")
 
+        # Drain any pre-existing backlog (demo images from other installed
+        # modules) so the run below only sees the attachment created here.
+        Attachment = self.env["ir.attachment"]
+        while Attachment._dt_image_optimize_run(limit=200)["scanned"]:
+            pass
+
         self.env["res.partner"].create({"name": "Image Optimize Test 2", "image_1920": self._make_big_jpeg()})
-        self.env["ir.attachment"]._dt_image_optimize_run(limit=50)
+        Attachment._dt_image_optimize_run(limit=50)
         # Everything processed is flagged, so a second run finds nothing new.
-        stats = self.env["ir.attachment"]._dt_image_optimize_run(limit=50)
+        stats = Attachment._dt_image_optimize_run(limit=50)
         self.assertEqual(stats["optimized"], 0)
 
     def test_variant_optimize_keeps_original(self):
@@ -84,9 +90,7 @@ class TestImageOptimize(TransactionCase):
         ICP.set_param("deltatech_image_optimize.variant_min_size", "1")
         ICP.set_param("deltatech_image_optimize.variant_quality", "60")
 
-        partner = self.env["res.partner"].create(
-            {"name": "Variant Test", "image_1920": self._make_big_jpeg()}
-        )
+        partner = self.env["res.partner"].create({"name": "Variant Test", "image_1920": self._make_big_jpeg()})
         orig_att = self._image_attachment(partner)
         orig_1920 = orig_att.raw  # keep the master bytes to prove they don't change
 


### PR DESCRIPTION
Producția are poze de 20 MP (~60 MB decodate) → invalidarea fixă la 20 dădea OOM. Acum `flush_every` e configurabil (pune-l pe 2-3 pt. poze mari) + gc.collect() la flush + GC de filestore în cron (worker unic → ia lock-ul). Teste 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)