### PR TITLE
[18.0][FIX] deltatech_image_optimize: silence invalid-commit lint in cron

### DIFF
--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -240,5 +240,7 @@ class IrAttachment(models.Model):
         (the cron is the single writer here, so it can grab the GC lock)."""
         self._dt_image_optimize_run()
         self._dt_image_optimize_variants_run()
-        self.env.cr.commit()
+        # the GC needs the optimized attachments committed before it can
+        # safely unlink the old filestore entries
+        self.env.cr.commit()  # pylint: disable=invalid-commit
         self._gc_file_store()


### PR DESCRIPTION
Fixes the failing `pre-commit` CI job on 18.0: the mandatory pylint_odoo hook flags E8102 (invalid-commit) on the `cr.commit()` in `_dt_image_optimize_cron`.

The commit is intentional — the filestore GC needs the optimized attachments committed before it can safely unlink the old entries — so it is marked with `# pylint: disable=invalid-commit` and an explanatory comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)