### PR TITLE
[FIX] deltatech_sale_stage: real depends_override

### DIFF
--- a/deltatech_sale_stage/pyproject.toml
+++ b/deltatech_sale_stage/pyproject.toml
@@ -4,8 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_widget_many2one_badge = "odoo-addon-deltatech-widget-many2one-badge @ git+https://github.com/dhongu/deltatech.git@19.0#subdirectory=deltatech_widget_many2one_badge"
+
 [project]
 name = "odoo-addon-deltatech-sale-stage"
-dependencies = [
-    "odoo-addon-deltatech-widget-many2one-badge @ git+https://github.com/dhongu/deltatech.git@19.0#subdirectory=deltatech_widget_many2one_badge"
-]
+dynamic = ["dependencies"]


### PR DESCRIPTION
## Summary
pyproject.toml folosea stilul static vechi (\`dependencies = [...]\`), complet ignorat de \`whool\` (dependentele se calculeaza mereu dinamic din manifest + \`[tool.whool.depends_override]\`). Il convertim la depends_override real.

Descoperit in timp ce validam CI-ul pe noul repo \`bitshop_marketplace\`, unde \`deltatech_marketplace_sale_stage\` depinde direct de acest modul si esua la instalare izolata (pip cauta un pachet inexistent pe index).

## Test plan
- [ ] CI verde pe acest PR