### PR TITLE
[FIX] deltatech_sale_stage: real depends_override

### DIFF
--- a/deltatech_sale_stage/pyproject.toml
+++ b/deltatech_sale_stage/pyproject.toml
@@ -4,9 +4,13 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_delivery_status = "odoo-addon-deltatech-delivery-status @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_delivery_status"
+deltatech_widget_many2one_badge = "odoo-addon-deltatech-widget-many2one-badge @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_widget_many2one_badge"
+
 [project]
 name = "odoo-addon-deltatech-sale-stage"
-
-dependencies = [
-    "odoo-addon-deltatech-widget-many2one-badge @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_widget_many2one_badge",
-]
+dynamic = ["dependencies"]


### PR DESCRIPTION
## Summary
pyproject.toml folosea stilul static vechi, complet ignorat de whool, si lipsea complet dependenta de deltatech_delivery_status (desi e in manifest depends). Descoperit la validarea CI-ului pe bitshop_marketplace, unde deltatech_marketplace_sale_stage depinde direct de acest modul.

## Test plan
- [ ] CI verde pe acest PR