### PR TITLE
[FIX] pyproject: depends_override complet pentru dependentele intra-repo (26 module)

### DIFF
--- a/deltatech_account_edi_ubl_gln/pyproject.toml
+++ b/deltatech_account_edi_ubl_gln/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_gln = "odoo-addon-deltatech-gln @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_gln"
+
 [project]
 name = "odoo-addon-deltatech-account-edi-ubl-gln"
+dynamic = ["dependencies"]

--- a/deltatech_alternative_website/pyproject.toml
+++ b/deltatech_alternative_website/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_alternative = "odoo-addon-deltatech-alternative @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_alternative"
+
 [project]
 name = "odoo-addon-deltatech-alternative-website"
+dynamic = ["dependencies"]

--- a/deltatech_business_process_documentation/pyproject.toml
+++ b/deltatech_business_process_documentation/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_business_process = "odoo-addon-deltatech-business-process @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_business_process"
+
 [project]
 name = "odoo-addon-deltatech-business-process-documentation"
+dynamic = ["dependencies"]

--- a/deltatech_business_process_handover_document/pyproject.toml
+++ b/deltatech_business_process_handover_document/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_business_process = "odoo-addon-deltatech-business-process @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_business_process"
+
 [project]
 name = "odoo-addon-deltatech-business-process-handover-document"
+dynamic = ["dependencies"]

--- a/deltatech_category_group/pyproject.toml
+++ b/deltatech_category_group/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_sale_commission = "odoo-addon-deltatech-sale-commission @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_sale_commission"
+
 [project]
 name = "odoo-addon-deltatech-category-group"
+dynamic = ["dependencies"]

--- a/deltatech_data_sheet_website/pyproject.toml
+++ b/deltatech_data_sheet_website/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_data_sheet = "odoo-addon-deltatech-data-sheet @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_data_sheet"
+
 [project]
 name = "odoo-addon-deltatech-data-sheet-website"
+dynamic = ["dependencies"]

--- a/deltatech_expenses/pyproject.toml
+++ b/deltatech_expenses/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_partner_generic = "odoo-addon-deltatech-partner-generic @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_partner_generic"
+
 [project]
 name = "odoo-addon-deltatech-expenses"
+dynamic = ["dependencies"]

--- a/deltatech_generic_partner_restriction/pyproject.toml
+++ b/deltatech_generic_partner_restriction/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_partner_generic = "odoo-addon-deltatech-partner-generic @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_partner_generic"
+
 [project]
 name = "odoo-addon-deltatech-generic-partner-restriction"
+dynamic = ["dependencies"]

--- a/deltatech_mrp_simple_barcode/pyproject.toml
+++ b/deltatech_mrp_simple_barcode/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_mrp_simple = "odoo-addon-deltatech-mrp-simple @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_mrp_simple"
+
 [project]
 name = "odoo-addon-deltatech-mrp-simple-barcode"
+dynamic = ["dependencies"]

--- a/deltatech_payment_forecast/pyproject.toml
+++ b/deltatech_payment_forecast/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_average_payment_period = "odoo-addon-deltatech-average-payment-period @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_average_payment_period"
+
 [project]
 name = "odoo-addon-deltatech-payment-forecast"
+dynamic = ["dependencies"]

--- a/deltatech_price_categ/pyproject.toml
+++ b/deltatech_price_categ/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_purchase_price = "odoo-addon-deltatech-purchase-price @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_purchase_price"
+
 [project]
 name = "odoo-addon-deltatech-price-categ"
+dynamic = ["dependencies"]

--- a/deltatech_product_catalog/pyproject.toml
+++ b/deltatech_product_catalog/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_alternative = "odoo-addon-deltatech-alternative @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_alternative"
+
 [project]
 name = "odoo-addon-deltatech-product-catalog"
+dynamic = ["dependencies"]

--- a/deltatech_product_margin/pyproject.toml
+++ b/deltatech_product_margin/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_product_trade_markup = "odoo-addon-deltatech-product-trade-markup @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_product_trade_markup"
+
 [project]
 name = "odoo-addon-deltatech-product-margin"
+dynamic = ["dependencies"]

--- a/deltatech_purchase_phase/pyproject.toml
+++ b/deltatech_purchase_phase/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_widget_many2one_badge = "odoo-addon-deltatech-widget-many2one-badge @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_widget_many2one_badge"
+
 [project]
 name = "odoo-addon-deltatech-purchase-phase"
+dynamic = ["dependencies"]

--- a/deltatech_purchase_price/pyproject.toml
+++ b/deltatech_purchase_price/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_product_trade_markup = "odoo-addon-deltatech-product-trade-markup @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_product_trade_markup"
+
 [project]
 name = "odoo-addon-deltatech-purchase-price"
+dynamic = ["dependencies"]

--- a/deltatech_sale_add_extra_line_pos/pyproject.toml
+++ b/deltatech_sale_add_extra_line_pos/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_sale_add_extra_line = "odoo-addon-deltatech-sale-add-extra-line @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_sale_add_extra_line"
+
 [project]
 name = "odoo-addon-deltatech-sale-add-extra-line-pos"
+dynamic = ["dependencies"]

--- a/deltatech_sale_commission/pyproject.toml
+++ b/deltatech_sale_commission/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_sale_margin = "odoo-addon-deltatech-sale-margin @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_sale_margin"
+
 [project]
 name = "odoo-addon-deltatech-sale-commission"
+dynamic = ["dependencies"]

--- a/deltatech_sale_contact/pyproject.toml
+++ b/deltatech_sale_contact/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_contact = "odoo-addon-deltatech-contact @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_contact"
+
 [project]
 name = "odoo-addon-deltatech-sale-contact"
+dynamic = ["dependencies"]

--- a/deltatech_sale_multiple_website/pyproject.toml
+++ b/deltatech_sale_multiple_website/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_sale_multiple = "odoo-addon-deltatech-sale-multiple @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_sale_multiple"
+
 [project]
 name = "odoo-addon-deltatech-sale-multiple-website"
+dynamic = ["dependencies"]

--- a/deltatech_sale_pallet_website/pyproject.toml
+++ b/deltatech_sale_pallet_website/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_sale_pallet = "odoo-addon-deltatech-sale-pallet @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_sale_pallet"
+
 [project]
 name = "odoo-addon-deltatech-sale-pallet-website"
+dynamic = ["dependencies"]

--- a/deltatech_saleorder_pickup_list/pyproject.toml
+++ b/deltatech_saleorder_pickup_list/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_stock_inventory = "odoo-addon-deltatech-stock-inventory @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_stock_inventory"
+
 [project]
 name = "odoo-addon-deltatech-saleorder-pickup-list"
+dynamic = ["dependencies"]

--- a/deltatech_saleorder_type/pyproject.toml
+++ b/deltatech_saleorder_type/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_record_type = "odoo-addon-deltatech-record-type @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_record_type"
+
 [project]
 name = "odoo-addon-deltatech-saleorder-type"
+dynamic = ["dependencies"]

--- a/deltatech_stock_inventory_product_display/pyproject.toml
+++ b/deltatech_stock_inventory_product_display/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_stock_inventory = "odoo-addon-deltatech-stock-inventory @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_stock_inventory"
+
 [project]
 name = "odoo-addon-deltatech-stock-inventory-product-display"
+dynamic = ["dependencies"]

--- a/deltatech_warehouse_map/pyproject.toml
+++ b/deltatech_warehouse_map/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_putaway_strategy = "odoo-addon-deltatech-putaway-strategy @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_putaway_strategy"
+
 [project]
 name = "odoo-addon-deltatech-warehouse-map"
+dynamic = ["dependencies"]

--- a/deltatech_website_sale_status/pyproject.toml
+++ b/deltatech_website_sale_status/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_delivery_status = "odoo-addon-deltatech-delivery-status @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_delivery_status"
+
 [project]
 name = "odoo-addon-deltatech-website-sale-status"
+dynamic = ["dependencies"]

--- a/deltatech_website_stock_availability/pyproject.toml
+++ b/deltatech_website_stock_availability/pyproject.toml
@@ -4,5 +4,12 @@ requires = [
 ]
 build-backend = "whool.buildapi"
 
+# Dependențele se generează din __manifest__.py de către whool;
+# modulele nepublicate pe wheelhouse se declară prin depends_override,
+# iar `dynamic` obligă pyproject-dependencies să întrebe backend-ul.
+[tool.whool.depends_override]
+deltatech_vendor_stock = "odoo-addon-deltatech-vendor-stock @ git+https://github.com/dhongu/deltatech.git@18.0#subdirectory=deltatech_vendor_stock"
+
 [project]
 name = "odoo-addon-deltatech-website-stock-availability"
+dynamic = ["dependencies"]


### PR DESCRIPTION
## Summary
Acelasi fix sistematic ca #2613 (19.0), aplicat pe 18.0: 26 de module cu dependente intra-repo nedeclarate in pyproject.toml. Fara override, pip-ul care instaleaza modulul din git (cross-repo, ex. bitshop/bitshop_marketplace CI) primeste requirement-uri PyPI inexistente.

## Test plan
- [ ] CI verde pe acest PR
- [ ] CI bitshop@18.0 si bitshop_marketplace@18.0 trec dupa merge