### PR TITLE
CI: path-filtering (test only changed addons)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,6 +50,55 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+          fetch-depth: 0
+
+      - name: Determine changed addons
+        id: changed
+        run: |
+          set -e
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          else
+            BASE_SHA="${{ github.event.before }}"
+          fi
+          if [ -z "$BASE_SHA" ] || [ "$BASE_SHA" = "0000000000000000000000000000000000000000" ] || ! git cat-file -e "$BASE_SHA" 2>/dev/null; then
+            echo "No usable base commit, running the full test suite."
+            echo "addons=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          FULL_RUN=0
+          ADDONS=""
+          for f in $CHANGED_FILES; do
+            dir="${f%%/*}"
+            if [ "$dir" = "$f" ] || [[ "$dir" == .* ]]; then
+              # Changed file at repo root (requirements.txt, setup.cfg, ...) or under a
+              # dotdir (.github, ...): can affect the whole repo, fall back to a full run.
+              FULL_RUN=1
+              break
+            fi
+            if [ ! -f "$dir/__manifest__.py" ]; then
+              # Changed path is not inside a recognizable addon, play it safe.
+              FULL_RUN=1
+              break
+            fi
+            case ",$ADDONS," in
+              *,"$dir",*) ;;
+              *) ADDONS="${ADDONS:+$ADDONS,}$dir" ;;
+            esac
+          done
+
+          if [ "$FULL_RUN" = "1" ]; then
+            echo "Change outside a single addon detected, running the full test suite."
+            echo "addons=" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changed addons: $ADDONS"
+            echo "addons=$ADDONS" >> "$GITHUB_OUTPUT"
+          fi
       - name: Install addons and dependencies
         run: oca_install_addons
       - name: Check licenses
@@ -62,11 +111,15 @@ jobs:
           pip install -r requirements.txt
 
       - name: Initialize test db
+        env:
+          INCLUDE: ${{ steps.changed.outputs.addons }}
         run: oca_init_test_database
 
       - name: Run tests and generate coverage report
         # You may need to adjust 'oca_run_tests' or the preceding commands
         # to ensure it generates a file like coverage.xml
+        env:
+          INCLUDE: ${{ steps.changed.outputs.addons }}
         run: oca_run_tests
 
       - name: Upload code coverage to Codecov


### PR DESCRIPTION
Adaugă pasul `Determine changed addons` (INCLUDE din git diff vs base) pe test job. oca_init_test_database + oca_run_tests testează doar modulele modificate; orice schimbare la fișier root sau dotdir (.github) → rulare completă. Același mecanism ca în bitshop 19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)