### PR TITLE
[IMP] deltatech_image_optimize: WebP for transparent images

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -50,6 +50,12 @@
         <field name="value">85</field>
     </record>
 
+    <!-- WebP quality for images with transparency (alpha preserved). -->
+    <record id="cp_webp_quality" model="ir.config_parameter">
+        <field name="key">deltatech_image_optimize.webp_quality</field>
+        <field name="value">85</field>
+    </record>
+
     <!-- Only recompress variants larger than this many bytes (20 KB). -->
     <record id="cp_variant_min_size" model="ir.config_parameter">
         <field name="key">deltatech_image_optimize.variant_min_size</field>

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -9,8 +9,18 @@ _logger = logging.getLogger(__name__)
 
 try:
     from PIL import Image
+
+    # features.check("webp") can report True while the encoder still fails at
+    # save time on some builds, so probe with a real encode.
+    try:
+        _probe = io.BytesIO()
+        Image.new("RGBA", (1, 1)).save(_probe, format="WEBP")
+        WEBP_OK = True
+    except Exception:  # noqa: BLE001
+        WEBP_OK = False
 except ImportError:  # pragma: no cover
     Image = None
+    WEBP_OK = False
 
 DEFAULT_TARGET_FIELDS = "image_1920,image_variant_1920"
 DEFAULT_VARIANT_FIELDS = "image_1024,image_512,image_256,image_128"
@@ -41,6 +51,7 @@ class IrAttachment(models.Model):
             "min_size": int(get("deltatech_image_optimize.min_size", 102400)),
             "batch": int(get("deltatech_image_optimize.batch", 1000)),
             "flush_every": max(1, int(get("deltatech_image_optimize.flush_every", 20))),
+            "webp_quality": max(1, min(100, int(get("deltatech_image_optimize.webp_quality", 85)))),
             "fields": [
                 name.strip()
                 for name in get("deltatech_image_optimize.target_fields", DEFAULT_TARGET_FIELDS).split(",")
@@ -52,37 +63,57 @@ class IrAttachment(models.Model):
     # Core recompression
     # ------------------------------------------------------------------
     @staticmethod
-    def _dt_image_recompress(raw, quality, max_dim):
+    def _dt_image_recompress(raw, quality, max_dim, webp_quality=85):
         """Recompress raw image bytes.
 
         - photos without transparency -> JPEG (quality tuned, progressive)
-        - images with transparency     -> optimized PNG (alpha preserved)
+        - images with transparency     -> WebP (alpha preserved, ~70% smaller
+          than PNG). Note: Odoo cannot resize WebP, so a WebP result must be
+          written directly on its attachment, never through the record field
+          (that would trigger a broken variant regeneration).
         - animated GIFs                 -> skipped (never flattened)
 
-        :return: smaller image bytes, or ``None`` when the image cannot be
-            optimized or the result would not be smaller.
+        :return: tuple ``(data, output_format)`` where output_format is
+            ``"JPEG"`` or ``"WEBP"``; or ``(None, None)`` when the image cannot
+            be optimized or the result would not be smaller.
         """
         if not raw or Image is None:
-            return None
+            return None, None
         try:
             img = Image.open(io.BytesIO(raw))
             img.load()
         except Exception:  # noqa: BLE001 - any unreadable image is skipped
-            return None
+            return None, None
         fmt = (img.format or "").upper()
         if fmt == "GIF" and getattr(img, "is_animated", False):
-            return None
+            return None, None
         resample = getattr(Image, "Resampling", Image).LANCZOS
         if max_dim and max(img.size) > max_dim:
             img.thumbnail((max_dim, max_dim), resample)
         has_alpha = img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info)
-        buf = io.BytesIO()
+        data = None
+        out_format = None
         if has_alpha:
-            img.convert("RGBA").save(buf, format="PNG", optimize=True)
+            # WebP preserves alpha and is ~70% smaller than PNG. If the Pillow
+            # build cannot encode WebP, fall back to optimized PNG.
+            if WEBP_OK:
+                try:
+                    buf = io.BytesIO()
+                    img.convert("RGBA").save(buf, format="WEBP", quality=webp_quality, method=6)
+                    data, out_format = buf.getvalue(), "WEBP"
+                except Exception:  # noqa: BLE001 - WebP encoder unavailable at runtime
+                    data = None
+            if data is None:
+                buf = io.BytesIO()
+                img.convert("RGBA").save(buf, format="PNG", optimize=True)
+                data, out_format = buf.getvalue(), "PNG"
         else:
+            buf = io.BytesIO()
             img.convert("RGB").save(buf, format="JPEG", quality=quality, optimize=True, progressive=True)
-        data = buf.getvalue()
-        return data if len(data) < len(raw) else None
+            data, out_format = buf.getvalue(), "JPEG"
+        if len(data) < len(raw):
+            return data, out_format
+        return None, None
 
     # ------------------------------------------------------------------
     # Batch runner
@@ -123,9 +154,24 @@ class IrAttachment(models.Model):
         flush_every = params["flush_every"]
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
-            data = self._dt_image_recompress(raw, params["quality"], params["max_dim"])
+            data, out_format = self._dt_image_recompress(
+                raw, params["quality"], params["max_dim"], params["webp_quality"]
+            )
             if not data:
                 att.deltatech_image_optimized = now
+            elif out_format == "WEBP":
+                # Alpha image -> WebP. Odoo cannot resize WebP, so we must NOT
+                # write through the record (that would regenerate full-size
+                # variants). Write the attachment in place; the variants are
+                # handled separately by _dt_image_optimize_variants_run.
+                try:
+                    att.write({"raw": data, "mimetype": "image/webp", "deltatech_image_optimized": now})
+                except Exception as exc:  # noqa: BLE001
+                    _logger.warning("Image optimize (webp) failed for att %s: %s", att.id, exc)
+                    att.deltatech_image_optimized = now
+                else:
+                    freed += len(raw) - len(data)
+                    optimized += 1
             else:
                 record = self.env[att.res_model].sudo().browse(att.res_id)
                 if not record.exists() or att.res_field not in record._fields:
@@ -186,6 +232,7 @@ class IrAttachment(models.Model):
             return {"scanned": 0, "optimized": 0, "freed": 0}
         get = self.env["ir.config_parameter"].sudo().get_param
         quality = max(1, min(95, int(get("deltatech_image_optimize.variant_quality", 85))))
+        webp_quality = max(1, min(100, int(get("deltatech_image_optimize.webp_quality", 85))))
         min_size = int(get("deltatech_image_optimize.variant_min_size", 20480))
         vfields = [
             name.strip()
@@ -208,10 +255,12 @@ class IrAttachment(models.Model):
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
             # max_dim=0 -> no resize, only a lower quality re-encode.
-            data = self._dt_image_recompress(raw, quality, 0)
+            data, out_format = self._dt_image_recompress(raw, quality, 0, webp_quality)
             vals = {"deltatech_image_optimized": now}
             if data:
                 vals["raw"] = data
+                if out_format == "WEBP":
+                    vals["mimetype"] = "image/webp"
             try:
                 att.write(vals)
             except Exception as exc:  # noqa: BLE001

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 18.0.1.3.0 (2025)
+
+- Images with transparency are now converted to **WebP** (alpha preserved,
+  ~70% smaller than PNG) instead of being kept as PNG. New `webp_quality`
+  parameter (default 85).
+- Because Odoo cannot resize WebP, a WebP original is written directly on its
+  attachment (never through the record field, which would regenerate
+  full-size variants); the variants are converted in place separately.
+- Opaque images keep going to JPEG.
+
 ## 18.0.1.2.0 (2025)
 
 - Configurable `flush_every` parameter (memory flush/invalidate/gc frequency).

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -6,8 +6,16 @@ from odoo.tests import TransactionCase, tagged
 
 try:
     from PIL import Image
+
+    try:
+        _probe = io.BytesIO()
+        Image.new("RGBA", (1, 1)).save(_probe, format="WEBP")
+        WEBP_OK = True
+    except Exception:
+        WEBP_OK = False
 except ImportError:
     Image = None
+    WEBP_OK = False
 
 
 @tagged("post_install", "-at_install")
@@ -18,6 +26,14 @@ class TestImageOptimize(TransactionCase):
         img = Image.frombytes("RGB", (size, size), raw)
         buf = io.BytesIO()
         img.save(buf, format="JPEG", quality=95)
+        return base64.b64encode(buf.getvalue())
+
+    def _make_big_transparent_png(self, size=2000):
+        """Build a large RGBA (transparent) PNG."""
+        raw = os.urandom(size * size * 4)
+        img = Image.frombytes("RGBA", (size, size), raw)
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
         return base64.b64encode(buf.getvalue())
 
     def _image_attachment(self, partner):
@@ -81,6 +97,36 @@ class TestImageOptimize(TransactionCase):
         # Everything processed is flagged, so a second run finds nothing new.
         stats = Attachment._dt_image_optimize_run(limit=50)
         self.assertEqual(stats["optimized"], 0)
+
+    def test_transparent_image_becomes_webp(self):
+        if Image is None:
+            self.skipTest("Pillow not available")
+        if not WEBP_OK:
+            self.skipTest("Pillow build lacks WebP support")
+
+        ICP = self.env["ir.config_parameter"].sudo()
+        ICP.set_param("deltatech_image_optimize.min_size", "1")
+        ICP.set_param("deltatech_image_optimize.webp_quality", "80")
+        ICP.set_param("deltatech_image_optimize.target_fields", "image_1920")
+
+        partner = self.env["res.partner"].create(
+            {"name": "Transparent Test", "image_1920": self._make_big_transparent_png()}
+        )
+        att = self._image_attachment(partner)
+        self.assertTrue(att)
+        original_size = att.file_size
+
+        stats = self.env["ir.attachment"]._dt_image_optimize_run(limit=50)
+        self.assertGreaterEqual(stats["optimized"], 1)
+
+        new_att = self._image_attachment(partner)
+        self.assertLess(new_att.file_size, original_size)
+        self.assertEqual(new_att.mimetype, "image/webp")
+        self.assertTrue(new_att.deltatech_image_optimized)
+        # The stored image must still be a valid WebP that preserves alpha.
+        img = Image.open(io.BytesIO(new_att.raw))
+        self.assertEqual((img.format or "").upper(), "WEBP")
+        self.assertIn(img.mode, ("RGBA", "LA"))  # transparency preserved
 
     def test_variant_optimize_keeps_original(self):
         if Image is None:


### PR DESCRIPTION
PNG-urile cu transparență rămâneau mari (nu le converteam la JPEG ca să nu pierdem alpha). Acum → **WebP** (păstrează alpha, ~70% mai mic). Original WebP scris direct pe atașament (Odoo nu redimensionează WebP → record.write ar strica variantele). Fallback pe PNG dacă Pillow n-are WebP. Teste 3/3 (+1 skip fără WebP local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)