### PR TITLE
[FIX] deltatech_purchase_create_bill_button: restore vendor ref copy on Create Bill

### DIFF
--- a/deltatech_purchase_create_bill_button/__init__.py
+++ b/deltatech_purchase_create_bill_button/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/deltatech_purchase_create_bill_button/__manifest__.py
+++ b/deltatech_purchase_create_bill_button/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "images": ["static/description/main_screenshot.png"],
     "name": "Purchase Create Bill Button",
-    "summary": "Restores the one-click Create Bill button on the purchase order form",
+    "summary": "Restores the one-click Create Bill button and vendor reference copy on the purchase order form",
     "version": "19.0.1.0.0",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",

--- a/deltatech_purchase_create_bill_button/models/__init__.py
+++ b/deltatech_purchase_create_bill_button/models/__init__.py
@@ -1,0 +1,1 @@
+from . import purchase_order

--- a/deltatech_purchase_create_bill_button/models/purchase_order.py
+++ b/deltatech_purchase_create_bill_button/models/purchase_order.py
@@ -1,0 +1,18 @@
+# © 2026 Deltatech
+# See README.rst file on addons root folder for license details
+
+from odoo import models
+
+
+class PurchaseOrder(models.Model):
+    _inherit = "purchase.order"
+
+    def _prepare_invoice(self):
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals.update(
+            {
+                "ref": self.partner_ref or "",
+                "payment_reference": self.partner_ref or "",
+            }
+        )
+        return invoice_vals

--- a/deltatech_purchase_create_bill_button/readme/DESCRIPTION.md
+++ b/deltatech_purchase_create_bill_button/readme/DESCRIPTION.md
@@ -4,3 +4,8 @@ In Odoo 19, the "Create Bill" button on the purchase order form was replaced by 
 This module restores the classic one-click "Create Bill" button next to the upload
 widget, so purchase orders can still be invoiced directly, without attaching a file,
 exactly as in Odoo 18.
+
+Odoo 19 also dropped the automatic copy of the purchase order's "Vendor Reference"
+into the vendor bill's "Reference" and "Payment Reference" fields when a bill is
+created from a purchase order. This module restores that copy as well, matching the
+Odoo 18 behavior.


### PR DESCRIPTION
## Summary
- Odoo 19 dropped the automatic copy of `purchase.order.partner_ref` into `account.move.ref`/`payment_reference` on Create Bill (present in 18.0's `_prepare_invoice`).
- Restores it in `deltatech_purchase_create_bill_button`, which already restores the Create Bill button.

Tichet 8951 (Romchim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)