### PR TITLE
[IMP] deltatech_image_optimize: decide transparency by real alpha content

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.4.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -66,16 +66,20 @@ class IrAttachment(models.Model):
     def _dt_image_recompress(raw, quality, max_dim, webp_quality=85):
         """Recompress raw image bytes.
 
-        - photos without transparency -> JPEG (quality tuned, progressive)
-        - images with transparency     -> WebP (alpha preserved, ~70% smaller
-          than PNG). Note: Odoo cannot resize WebP, so a WebP result must be
-          written directly on its attachment, never through the record field
-          (that would trigger a broken variant regeneration).
-        - animated GIFs                 -> skipped (never flattened)
+        The transparency is decided by the *actual* alpha content, not just the
+        mode (many product images are RGBA/palette but fully opaque):
+
+        - effectively opaque (or no alpha) -> JPEG (quality tuned, progressive)
+        - genuinely transparent            -> WebP (alpha preserved, ~70%
+          smaller than PNG). Odoo cannot resize WebP, so a WebP result must be
+          written directly on its attachment, never through the record field.
+          If WebP encoding is unavailable, keep an optimized PNG (never flatten
+          real transparency to a solid background).
+        - animated GIFs                    -> skipped (never flattened)
 
         :return: tuple ``(data, output_format)`` where output_format is
-            ``"JPEG"`` or ``"WEBP"``; or ``(None, None)`` when the image cannot
-            be optimized or the result would not be smaller.
+            ``"JPEG"``, ``"WEBP"`` or ``"PNG"``; or ``(None, None)`` when the
+            image cannot be optimized or the result would not be smaller.
         """
         if not raw or Image is None:
             return None, None
@@ -87,15 +91,25 @@ class IrAttachment(models.Model):
         fmt = (img.format or "").upper()
         if fmt == "GIF" and getattr(img, "is_animated", False):
             return None, None
+        # Normalize palette (incl. palette transparency) to a real RGBA/RGB
+        # image so alpha can be inspected reliably.
+        if img.mode == "P":
+            img = img.convert("RGBA" if "transparency" in img.info else "RGB")
         resample = getattr(Image, "Resampling", Image).LANCZOS
         if max_dim and max(img.size) > max_dim:
             img.thumbnail((max_dim, max_dim), resample)
-        has_alpha = img.mode in ("RGBA", "LA") or (img.mode == "P" and "transparency" in img.info)
+        # Detect *real* transparency: an alpha channel that is actually used.
+        real_alpha = False
+        if img.mode in ("RGBA", "LA"):
+            try:
+                real_alpha = img.getchannel("A").getextrema()[0] < 250
+            except (ValueError, IndexError):  # pragma: no cover
+                real_alpha = True
         data = None
         out_format = None
-        if has_alpha:
-            # WebP preserves alpha and is ~70% smaller than PNG. If the Pillow
-            # build cannot encode WebP, fall back to optimized PNG.
+        if real_alpha:
+            # Preserve transparency: WebP if available, otherwise optimized PNG
+            # (never JPEG, which would fill transparent areas).
             if WEBP_OK:
                 try:
                     buf = io.BytesIO()

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 18.0.1.4.0 (2025)
+
+- Transparency is now decided by the *actual* alpha content, not the mode:
+  RGBA/palette images that are effectively opaque go to JPEG (big savings),
+  only genuinely transparent images go to WebP. Palette images are normalized
+  first. This fixes "transparent" PNGs that previously stayed uncompressed.
+- Genuinely transparent images with no WebP support keep an optimized PNG
+  (never flattened to a solid background).
+
 ## 18.0.1.3.0 (2025)
 
 - Images with transparency are now converted to **WebP** (alpha preserved,

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -36,6 +36,13 @@ class TestImageOptimize(TransactionCase):
         img.save(buf, format="PNG")
         return base64.b64encode(buf.getvalue())
 
+    def _make_opaque_rgba_png(self, size=2000):
+        """Build a large RGBA PNG whose alpha is fully opaque (255)."""
+        img = Image.frombytes("RGB", (size, size), os.urandom(size * size * 3)).convert("RGBA")
+        buf = io.BytesIO()
+        img.save(buf, format="PNG")
+        return base64.b64encode(buf.getvalue())
+
     def _image_attachment(self, partner):
         return (
             self.env["ir.attachment"]
@@ -127,6 +134,29 @@ class TestImageOptimize(TransactionCase):
         img = Image.open(io.BytesIO(new_att.raw))
         self.assertEqual((img.format or "").upper(), "WEBP")
         self.assertIn(img.mode, ("RGBA", "LA"))  # transparency preserved
+
+    def test_opaque_rgba_becomes_jpeg(self):
+        if Image is None:
+            self.skipTest("Pillow not available")
+
+        ICP = self.env["ir.config_parameter"].sudo()
+        ICP.set_param("deltatech_image_optimize.min_size", "1")
+        ICP.set_param("deltatech_image_optimize.quality", "70")
+        ICP.set_param("deltatech_image_optimize.target_fields", "image_1920")
+
+        partner = self.env["res.partner"].create(
+            {"name": "Opaque RGBA Test", "image_1920": self._make_opaque_rgba_png()}
+        )
+        att = self._image_attachment(partner)
+        original_size = att.file_size
+
+        stats = self.env["ir.attachment"]._dt_image_optimize_run(limit=50)
+        self.assertGreaterEqual(stats["optimized"], 1)
+
+        new_att = self._image_attachment(partner)
+        self.assertLess(new_att.file_size, original_size)
+        # Opaque alpha -> flattened to JPEG (no WebP dependency).
+        self.assertEqual(new_att.mimetype, "image/jpeg")
 
     def test_variant_optimize_keeps_original(self):
         if Image is None:


### PR DESCRIPTION
Multe poze RGBA/paletă sunt de fapt opace. Acum decidem după conținutul REAL de alpha: opac → JPEG (economie mare, fără dependență WebP), transparent real → WebP (fallback PNG dacă WebP lipsește, niciodată JPEG care ar umple transparența). Repară PNG-urile 'transparente' care rămâneau necomprimate. Teste 5/5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)