### PR TITLE
[IMP] deltatech_image_optimize: force_jpeg for non-transparent catalogs

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.4.0",
+    "version": "18.0.1.5.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -56,6 +56,14 @@
         <field name="value">85</field>
     </record>
 
+    <!-- Set to 1 when product images are never really transparent (solid
+         colored background). Alpha is then ignored and everything goes to
+         JPEG (max savings, no WebP dependency). -->
+    <record id="cp_force_jpeg" model="ir.config_parameter">
+        <field name="key">deltatech_image_optimize.force_jpeg</field>
+        <field name="value">0</field>
+    </record>
+
     <!-- Only recompress variants larger than this many bytes (20 KB). -->
     <record id="cp_variant_min_size" model="ir.config_parameter">
         <field name="key">deltatech_image_optimize.variant_min_size</field>

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -52,6 +52,7 @@ class IrAttachment(models.Model):
             "batch": int(get("deltatech_image_optimize.batch", 1000)),
             "flush_every": max(1, int(get("deltatech_image_optimize.flush_every", 20))),
             "webp_quality": max(1, min(100, int(get("deltatech_image_optimize.webp_quality", 85)))),
+            "force_jpeg": get("deltatech_image_optimize.force_jpeg", "0") in ("1", "True", "true"),
             "fields": [
                 name.strip()
                 for name in get("deltatech_image_optimize.target_fields", DEFAULT_TARGET_FIELDS).split(",")
@@ -63,7 +64,7 @@ class IrAttachment(models.Model):
     # Core recompression
     # ------------------------------------------------------------------
     @staticmethod
-    def _dt_image_recompress(raw, quality, max_dim, webp_quality=85):
+    def _dt_image_recompress(raw, quality, max_dim, webp_quality=85, force_jpeg=False):
         """Recompress raw image bytes.
 
         The transparency is decided by the *actual* alpha content, not just the
@@ -99,8 +100,10 @@ class IrAttachment(models.Model):
         if max_dim and max(img.size) > max_dim:
             img.thumbnail((max_dim, max_dim), resample)
         # Detect *real* transparency: an alpha channel that is actually used.
+        # With force_jpeg, alpha is ignored entirely (images that are not truly
+        # transparent, e.g. a solid colored background) -> always JPEG.
         real_alpha = False
-        if img.mode in ("RGBA", "LA"):
+        if not force_jpeg and img.mode in ("RGBA", "LA"):
             try:
                 real_alpha = img.getchannel("A").getextrema()[0] < 250
             except (ValueError, IndexError):  # pragma: no cover
@@ -169,7 +172,7 @@ class IrAttachment(models.Model):
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
             data, out_format = self._dt_image_recompress(
-                raw, params["quality"], params["max_dim"], params["webp_quality"]
+                raw, params["quality"], params["max_dim"], params["webp_quality"], params["force_jpeg"]
             )
             if not data:
                 att.deltatech_image_optimized = now
@@ -247,6 +250,7 @@ class IrAttachment(models.Model):
         get = self.env["ir.config_parameter"].sudo().get_param
         quality = max(1, min(95, int(get("deltatech_image_optimize.variant_quality", 85))))
         webp_quality = max(1, min(100, int(get("deltatech_image_optimize.webp_quality", 85))))
+        force_jpeg = get("deltatech_image_optimize.force_jpeg", "0") in ("1", "True", "true")
         min_size = int(get("deltatech_image_optimize.variant_min_size", 20480))
         vfields = [
             name.strip()
@@ -269,7 +273,7 @@ class IrAttachment(models.Model):
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
             # max_dim=0 -> no resize, only a lower quality re-encode.
-            data, out_format = self._dt_image_recompress(raw, quality, 0, webp_quality)
+            data, out_format = self._dt_image_recompress(raw, quality, 0, webp_quality, force_jpeg)
             vals = {"deltatech_image_optimized": now}
             if data:
                 vals["raw"] = data

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 18.0.1.5.0 (2025)
+
+- New `force_jpeg` parameter: when the catalog images are never really
+  transparent (solid colored background), set it to 1 to ignore the alpha
+  channel and always produce JPEG (max savings, no WebP dependency).
+
 ## 18.0.1.4.0 (2025)
 
 - Transparency is now decided by the *actual* alpha content, not the mode:

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -158,6 +158,31 @@ class TestImageOptimize(TransactionCase):
         # Opaque alpha -> flattened to JPEG (no WebP dependency).
         self.assertEqual(new_att.mimetype, "image/jpeg")
 
+    def test_force_jpeg_ignores_transparency(self):
+        if Image is None:
+            self.skipTest("Pillow not available")
+
+        ICP = self.env["ir.config_parameter"].sudo()
+        ICP.set_param("deltatech_image_optimize.min_size", "1")
+        ICP.set_param("deltatech_image_optimize.quality", "70")
+        ICP.set_param("deltatech_image_optimize.target_fields", "image_1920")
+        ICP.set_param("deltatech_image_optimize.force_jpeg", "1")
+
+        # A transparent PNG that would normally go to WebP:
+        partner = self.env["res.partner"].create(
+            {"name": "Force JPEG Test", "image_1920": self._make_big_transparent_png()}
+        )
+        att = self._image_attachment(partner)
+        original_size = att.file_size
+
+        stats = self.env["ir.attachment"]._dt_image_optimize_run(limit=50)
+        self.assertGreaterEqual(stats["optimized"], 1)
+
+        new_att = self._image_attachment(partner)
+        self.assertLess(new_att.file_size, original_size)
+        # force_jpeg -> JPEG regardless of the alpha channel.
+        self.assertEqual(new_att.mimetype, "image/jpeg")
+
     def test_variant_optimize_keeps_original(self):
         if Image is None:
             self.skipTest("Pillow not available")


### PR DESCRIPTION
Când pozele nu-s cu adevărat transparente (fundal colorat opac, alpha = artefact), `force_jpeg=1` ignoră alpha și produce mereu JPEG (economie maximă, fără dependență WebP). Teste 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)