### PR TITLE
[FIX] deltatech_image_optimize: lower default batch to 50

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Image Optimizer",
-    "version": "18.0.1.5.0",
+    "version": "18.0.1.5.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -19,10 +19,16 @@
         <field name="value">102400</field>
     </record>
 
-    <!-- How many images to process per cron run. -->
+    <!-- How many images to process per cron run. Keep this low: a large
+         batch of big/high-res images can exceed the worker's time/CPU limit,
+         which raises an exception mid-loop that looks identical to a normal
+         per-image failure: the remaining images in that batch get silently
+         flagged as processed without actually being optimized. Tune upward
+         cautiously and verify converted images actually shrank before
+         trusting a higher value. -->
     <record id="cp_batch" model="ir.config_parameter">
         <field name="key">deltatech_image_optimize.batch</field>
-        <field name="value">200</field>
+        <field name="value">50</field>
     </record>
 
     <!-- Flush + drop the ORM cache every N images. Lower it (2-3) for very

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -49,7 +49,7 @@ class IrAttachment(models.Model):
             "quality": max(1, min(95, int(get("deltatech_image_optimize.quality", 85)))),
             "max_dim": int(get("deltatech_image_optimize.max_dim", 1920)),
             "min_size": int(get("deltatech_image_optimize.min_size", 102400)),
-            "batch": int(get("deltatech_image_optimize.batch", 1000)),
+            "batch": int(get("deltatech_image_optimize.batch", 50)),
             "flush_every": max(1, int(get("deltatech_image_optimize.flush_every", 20))),
             "webp_quality": max(1, min(100, int(get("deltatech_image_optimize.webp_quality", 85)))),
             "force_jpeg": get("deltatech_image_optimize.force_jpeg", "0") in ("1", "True", "true"),
@@ -257,7 +257,7 @@ class IrAttachment(models.Model):
             for name in get("deltatech_image_optimize.variant_fields", DEFAULT_VARIANT_FIELDS).split(",")
             if name.strip()
         ]
-        limit = limit or int(get("deltatech_image_optimize.batch", 200))
+        limit = limit or int(get("deltatech_image_optimize.batch", 50))
         flush_every = max(1, int(get("deltatech_image_optimize.flush_every", 20)))
         domain = [
             ("res_field", "in", vfields),

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 18.0.1.5.1 (2025)
+
+- Lower the default/installed `batch` from 200-1000 to **50**. On production,
+  a large batch of big/high-resolution images could exceed the cron worker's
+  time/CPU limit; the resulting interrupt looked like a normal per-image
+  failure and left the rest of that batch silently flagged as "processed"
+  without actually being optimized. A small batch keeps each cron run well
+  within limits. If you raise it, verify converted images actually shrank.
+
 ## 18.0.1.5.0 (2025)
 
 - New `force_jpeg` parameter: when the catalog images are never really


### PR DESCRIPTION
Pe producție, un batch mare (500) de imagini mari a depășit limita de timp/CPU a worker-ului de cron. Întreruperea a arătat identic cu un eșec normal per-imagine, iar restul batch-ului a rămas marcat 'procesat' fără conversie reală (bug tăcut, confirmat empiric: batch=20/50 a convertit corect aceleași imagini). Batch implicit coborât la 50 + documentat riscul. Teste 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)