### PR TITLE
[FIX] deltatech_picking_transit: sudo la crearea celui de-al doilea transfer (tichet 8970)

### DIFF
--- a/deltatech_picking_transit/__manifest__.py
+++ b/deltatech_picking_transit/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Stock Auto Transfer",
-    "version": "18.0.0.0.13",
+    "version": "18.0.0.0.14",
     "author": "Terrabit, Voicu Stefan",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_picking_transit/models/stock_picking.py
+++ b/deltatech_picking_transit/models/stock_picking.py
@@ -31,6 +31,10 @@ class StockPicking(models.Model):
         }
 
     def create_second_transfer_wizard(self, final_dest_location_id, picking_type_id):
+        # the operator validating the first transfer may not have access rights
+        # on the operation type / locations of the receiving warehouse
+        picking_type_id = picking_type_id.sudo()
+        final_dest_location_id = final_dest_location_id.sudo()
         for picking in self:
             if picking.picking_type_id.code == "internal":
                 new_picking_vals = {
@@ -39,7 +43,7 @@ class StockPicking(models.Model):
                     "location_dest_id": final_dest_location_id.id,
                     "move_ids_without_package": [],
                 }
-                new_picking = self.env["stock.picking"].create(new_picking_vals)
+                new_picking = self.env["stock.picking"].sudo().create(new_picking_vals)
                 self.copy_move_lines(picking, new_picking)
                 new_picking.action_confirm()
                 # new_picking.action_assign()
@@ -59,7 +63,7 @@ class StockPicking(models.Model):
 
     def copy_move_lines(self, source_picking, target_picking):
         for move in source_picking.move_ids_without_package:
-            move.copy(
+            move.sudo().copy(
                 {
                     "picking_id": target_picking.id,
                     "location_id": source_picking.location_dest_id.id,
@@ -129,15 +133,21 @@ class StockPicking(models.Model):
                             "You must set a partner before validating the picking when you are using 2 step picking with auto create on the second transfer."
                         )
                     )
-                warehouse = self.env["stock.warehouse"].search([("partner_id", "=", picking.partner_id.id)], limit=1)
+                warehouse = (
+                    self.env["stock.warehouse"].sudo().search([("partner_id", "=", picking.partner_id.id)], limit=1)
+                )
                 if warehouse:
-                    next_operation = self.env["stock.picking.type"].search(
-                        [
-                            ("warehouse_id", "=", warehouse.id),
-                            ("code", "=", "internal"),
-                            ("two_step_transfer_use", "=", "reception"),
-                        ],
-                        limit=1,
+                    next_operation = (
+                        self.env["stock.picking.type"]
+                        .sudo()
+                        .search(
+                            [
+                                ("warehouse_id", "=", warehouse.id),
+                                ("code", "=", "internal"),
+                                ("two_step_transfer_use", "=", "reception"),
+                            ],
+                            limit=1,
+                        )
                     )
                     if next_operation:
                         picking.create_second_transfer_wizard(next_operation.default_location_dest_id, next_operation)


### PR DESCRIPTION
# deltatech_picking_transit — sudo la crearea celui de-al doilea transfer

Referință: tichet **8.970**

## Context / de ce

La transferul în doi pași, al doilea transfer se creează în depozitul de destinație, în
numele operatorului care validează primul transfer. Dacă operatorul nu are drepturi pe
tipul de operație / locațiile depozitului de destinație (reguli de înregistrare,
multi-company), fluxul pică cu eroare de acces.

## Ce s-a schimbat

`models/stock_picking.py`:

- `button_validate` (fluxul automat): căutările de `stock.warehouse` și
  `stock.picking.type` se fac acum cu `sudo()`, ca tipul de operație „reception" al
  depozitului de destinație să fie găsit chiar dacă operatorul nu îl vede.
- `create_second_transfer_wizard`: argumentele `picking_type_id` /
  `final_dest_location_id` sunt ridicate la `sudo()`, iar al doilea picking se creează cu
  `sudo()` — astfel `action_confirm()`, `message_post` și `write`-urile ulterioare pe el
  trec de restricțiile operatorului. Acoperă atât fluxul automat cât și wizard-ul manual
  (care apelează aceeași metodă).
- `copy_move_lines`: mutările se copiază cu `move.sudo().copy(...)`, pentru că se
  atașează de picking-ul creat cu sudo în celălalt depozit.

`__manifest__.py`: bump versiune `18.0.0.0.13` → `18.0.0.0.14`.

## Testare

- Modulul nu are teste active (fișierul de test e integral comentat și oricum învechit —
  referă câmpuri care nu mai există).
- Rulat `--test-enable --test-tags /deltatech_picking_transit -u deltatech_picking_transit`
  pe baza locală `datus`: modulul se actualizează și se încarcă fără erori
  (`0 failed, 0 error(s) of 0 tests`).
- pre-commit (ruff, ruff-format, pylint-odoo) verde pe fișierele modificate.

## Versiuni

- Portat și pe 19.0 (PR pereche în același repo, branch `19.0-fix-deltatech_picking_transit`).

## Note / riscuri

- În wizard-ul manual, dropdown-ul de tip de operație rămâne filtrat de drepturile
  operatorului (`name_search` nu rulează cu sudo) — dacă operatorul nu vede deloc tipul de
  operație, nu îl poate selecta manual. Fluxul automat (`auto_second_transfer`) e acoperit
  complet.
- `sudo()` ocolește și regulile multi-company la căutarea depozitului după partener —
  domeniul e specific (partenerul depozitului), deci riscul de potrivire greșită e mic.

Generated with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)