### PR TITLE
[19.0][FIX] deltatech_expenses: acces pe linie, import pe decont închis, cont diurnă, set_paid (POPVAL-COS runda 2)

### DIFF
--- a/deltatech_expenses/__manifest__.py
+++ b/deltatech_expenses/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Expenses Deduction",
     "summary": "Expenses Deduction & Disposition of Cashing",
-    "version": "19.0.3.1.0",
+    "version": "19.0.3.2.0",
     "category": "Accounting & Finance",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_expenses/models/account_voucher.py
+++ b/deltatech_expenses/models/account_voucher.py
@@ -16,8 +16,3 @@ class AccountVoucher(models.Model):
     #     if "expenses_deduction_id" in self.env.context:
     #         value["expenses_deduction_id"] = self.env.context["expenses_deduction_id"]
     #     return value
-
-    def set_paid(self):
-        for voucher_to_pay in self:
-            if voucher_to_pay.amount_residual == 0.0:
-                voucher_to_pay.update({"payment_state": "paid"})

--- a/deltatech_expenses/models/deltatech_expenses_deduction.py
+++ b/deltatech_expenses/models/deltatech_expenses_deduction.py
@@ -35,18 +35,18 @@ class DeltatechExpensesDeduction(models.Model):
 
     @api.model
     def _default_account_diem(self):
+        # `account.account` are `company_ids` (many2many) în O19, nu `company_id` — căutarea pe
+        # `company_id` arunca ValueError, prins tăcut de un `except Exception` care mascase
+        # complet eroarea; contul de diurnă implicit nu se completa niciodată automat (runda 2,
+        # tichet POPVAL-COS).
         account_pool = self.env["account.account"]
-        try:
+        account_id = account_pool.search(
+            [("code", "=ilike", "625%"), ("company_ids", "in", self.env.company.id)], limit=1
+        )  # Cheltuieli cu deplasari
+        if not account_id:
             account_id = account_pool.search(
-                [("code", "=ilike", "625%"), ("company_id", "=", self.env.company.id)], limit=1
-            )  # Cheltuieli cu deplasari
-        except Exception:
-            try:
-                account_id = account_pool.search(
-                    [("account_type", "=", "expense"), ("company_id", "=", self.env.company.id)], limit=1
-                )
-            except Exception:
-                account_id = False
+                [("account_type", "=", "expense"), ("company_ids", "in", self.env.company.id)], limit=1
+            )
         return account_id
 
     number = fields.Char(string="Number", size=32, readonly=True, default="/")
@@ -333,6 +333,12 @@ class DeltatechExpensesDeduction(models.Model):
         altei companii, aflate într-o stare neeligibilă sau deja contabilizate este respins, chiar
         dacă interfața ar permite selecția lor (tichet POPVAL-COS)."""
         self.ensure_one()
+        if self.state not in ("draft", "advance"):
+            # `action_open_import_hr_expenses` verifică asta la deschiderea wizard-ului, dar
+            # `action_import`-ul wizard-ului apelează direct această metodă — fără acest guard,
+            # un decont deja Finalizat/Anulat ar putea primi în continuare linii noi (runda 2,
+            # tichet POPVAL-COS).
+            raise UserError(self.env._("Cheltuielile pot fi preluate doar într-un decont în starea Draft sau Advance."))
         line_model = self.env["deltatech.expenses.deduction.line"]
         expenses = expenses.filtered(lambda e: not e.expenses_deduction_id)
         invalid = expenses.filtered(
@@ -637,8 +643,9 @@ class DeltatechExpensesDeduction(models.Model):
                     settle_payable = settle.line_ids.filtered(lambda aml: aml.account_id == payable.account_id)
                     (payable | settle_payable).reconcile()
 
-            # marchează chitanțele fără sold drept plătite
-            vouchers.set_paid()
+            # payment_state se calculează automat de Odoo din reconciliere (chitanța e in_receipt,
+            # deci intră în is_invoice(include_receipts=True)) — nu-l mai forțăm manual (runda 2,
+            # tichet POPVAL-COS: scrierea directă a payment_state ocolea calculul standard).
 
             # Create the account move record.
             line_ids = []

--- a/deltatech_expenses/readme/ROADMAP.md
+++ b/deltatech_expenses/readme/ROADMAP.md
@@ -49,6 +49,50 @@ rol) — altfel un Aprobator/Contabil ar avea nevoie și de grupurile standard d
 doar ca să poată apăsa butoanele acestui modul. Sudo e sigur aici pentru că rulează DUPĂ o validare
 explicită de business (eligibilitate hr.expense / rol pe deducție), nu în locul ei.
 
+## Runda 2 — verificare independentă a clientului (19.0.3.2.0)
+
+Clientul a testat 19.0.3.1.0 independent (17 teste proprii, 0 eșecuri) și a semnalat 10 observații
+suplimentare. Verificate în cod pe 2026-07-11:
+
+- **Liniile de decont fără reguli proprii de acces** — FIXAT. Adăugate `ir.rule` pe
+  `deltatech.expenses.deduction.line` (multi-company + „doar liniile decontului propriu" pentru
+  Angajat + acces complet pentru Aprobator/Contabil), mirror pe regulile de la părinte — până acum
+  restricția exista doar pe `deltatech.expenses.deduction`. Test `test_expenses_line_own_rule_restricts_access`.
+
+- **`_import_hr_expenses` nu verifica starea decontului** — FIXAT (ratat în runda 1). Doar
+  `action_open_import_hr_expenses` verifica `state in (draft, advance)`; `action_import`-ul
+  wizard-ului și `_import_hr_expenses` apelate direct nu verificau, deci un decont deja
+  Finalizat/Anulat putea încă primi linii noi. Adăugat guard explicit. Test
+  `test_import_hr_expenses_rejects_when_deduction_not_open`.
+
+- **`_default_account_diem` folosea `company_id` pe `account.account`** — FIXAT (bug pre-existent,
+  nu introdus în runda 1). În O19 câmpul e `company_ids` (many2many); căutarea pe `company_id`
+  arunca `ValueError`, prins tăcut de un `except Exception` care mascase complet eroarea — contul
+  de diurnă implicit nu se completa niciodată automat. Corectat pe `company_ids`; eliminat și
+  try/except-ul care înghițea eroarea (fail loud e mai sigur decât fail silent). Test
+  `test_default_account_diem_uses_company_ids`.
+
+- **`set_paid()` scria manual `payment_state`** — FIXAT prin eliminare. Metoda custom din
+  `account_voucher.py` (override pe `account.move`, neexistentă în Odoo core) seta
+  `payment_state = "paid"` direct când soldul era zero, în loc să lase Odoo să-l calculeze din
+  reconciliere. Chitanța `in_receipt` intră deja în `is_invoice(include_receipts=True)`, deci
+  `_compute_payment_state` standard se declanșează corect după `.reconcile()` — apelul și metoda au
+  fost eliminate ca redundante și riscante. Testele existente (`test_supplier_payment_reconciles_open_bill`,
+  `test_full_flow_advance_expense_refund_and_zero_542`) confirmă `payment_state` corect fără el.
+
+- **Reconciliere fără potrivire pe document/sumă** — reconfirmat, rămâne pe roadmap (vezi mai jos).
+
+- **Doar administratorii de sistem au rolul Contabil pe staging-ul clientului** — clarificat, nu e
+  bug: migrarea `19.0.3.1.0` rulează doar la **upgrade** de pe o instalare anterioară (Odoo nu
+  migrează la instalare nouă/fresh); pe o instalare fresh rămâne activ doar
+  `base.group_system.implied_ids`, care acoperă doar adminii. Pe un upgrade real de producție
+  (de pe 19.0.3.0.0/19.0.3.1.0 deja instalat), migrarea acordă rolul tuturor userilor interni
+  existenți. De clarificat cu clientul dacă staging-ul e upgrade sau instalare nouă.
+
+- **Sold istoric 542 / câmpuri aprobare necompletate pe deconturile vechi / OCR-Terrabit neadoptat
+  în producție** — confirmate, dar în afara scopului acestui fix (date istorice, nu logică de cod);
+  rămân subiect pentru planul de reconciliere separat discutat cu clientul.
+
 ## Corectitudine
 
 - **Reconciliere supplier_payment fără potrivire exactă pe document/sumă.** După fix-ul de
@@ -64,9 +108,6 @@ explicită de business (eligibilitate hr.expense / rol pe deducție), nu în loc
 - **TVA mixt la import.** Detecția `price_include` este „totul-sau-nimic"
   (`all(taxes.price_include)`). O cheltuială cu o taxă inclusă + una „pe deasupra" simultan este
   mapată greșit. *De tratat per-taxă (caz rar).*
-
-- **`set_paid` tace la reziduu.** Marchează chitanța „plătită" doar dacă soldul este exact zero; la
-  diferențe de rotunjire/valută rămâne tăcut neplătită, fără semnalare. *De adăugat verificare/avertizare.*
 
 ## Migrare
 

--- a/deltatech_expenses/security/security.xml
+++ b/deltatech_expenses/security/security.xml
@@ -55,6 +55,31 @@
         <field name="groups" eval="[(4, ref('group_expenses_approver'))]" />
     </record>
 
+    <!-- Liniile de decont nu aveau nicio regulă proprie: un Angajat cu acces CRUD pe model putea
+         citi/scrie orice linie direct, ocolind restricția „doar decontul propriu" de pe părinte
+         (tichet POPVAL-COS, runda 2). Mirror pe regulile de mai sus, prin decontul părinte. -->
+    <record id="expenses_deduction_line_comp_rule" model="ir.rule">
+        <field name="name">ExpensesDeductionLine multi-company</field>
+        <field name="model_id" ref="model_deltatech_expenses_deduction_line" />
+        <field name="domain_force">
+            ['|', ('expenses_deduction_id.company_id', '=', False), ('expenses_deduction_id.company_id', 'in', company_ids)]
+        </field>
+    </record>
+
+    <record id="expenses_deduction_line_own_rule" model="ir.rule">
+        <field name="name">ExpensesDeductionLine: doar liniile decontului propriu (Angajat)</field>
+        <field name="model_id" ref="model_deltatech_expenses_deduction_line" />
+        <field name="domain_force">[('expenses_deduction_id.employee_id.user_id', '=', user.id)]</field>
+        <field name="groups" eval="[(4, ref('group_expenses_user'))]" />
+    </record>
+
+    <record id="expenses_deduction_line_approver_rule" model="ir.rule">
+        <field name="name">ExpensesDeductionLine: acces complet (Aprobator/Contabil)</field>
+        <field name="model_id" ref="model_deltatech_expenses_deduction_line" />
+        <field name="domain_force">[(1, '=', 1)]</field>
+        <field name="groups" eval="[(4, ref('group_expenses_approver'))]" />
+    </record>
+
     <!-- Administratorii (Settings/Administrator) primesc automat rolul de Contabil pe acest
          modul, ca instalarea/upgrade-ul să rămână funcțional imediat. Plasat în afara
          noupdate="1": spre deosebire de o simplă apartenență user_ids setată o singură dată la

--- a/deltatech_expenses/tests/test_expenses.py
+++ b/deltatech_expenses/tests/test_expenses.py
@@ -828,3 +828,91 @@ class TestExpenses(TransactionCase):
         deduction.with_user(accounting_user).validate_expenses()
         self.assertEqual(deduction.state, "done")
         self.assertEqual(deduction.accounted_by_id, accounting_user)
+
+    def test_default_account_diem_uses_company_ids(self):
+        """_default_account_diem caută pe company_ids (many2many), nu pe company_id — altfel
+        căutarea eșuează silențios și contul de diurnă nu se completează niciodată (tichet
+        POPVAL-COS, runda 2). Companie izolată, ca să nu depindem de ce alte conturi 625% mai
+        există în baza de test."""
+        company_iso = self.env["res.company"].create({"name": "Diem Test Co"})
+        acc_diem_iso = self.env["account.account"].create(
+            {
+                "name": "Cheltuieli deplasari izolat",
+                "code": "625ISO",
+                "account_type": "expense",
+                "company_ids": [(6, 0, [company_iso.id])],
+            }
+        )
+        result = self.env["deltatech.expenses.deduction"].with_company(company_iso)._default_account_diem()
+        self.assertEqual(result, acc_diem_iso)
+
+    def test_import_hr_expenses_rejects_when_deduction_not_open(self):
+        """_import_hr_expenses respinge preluarea într-un decont deja Finalizat/Anulat, nu doar
+        la deschiderea wizard-ului (tichet POPVAL-COS, runda 2)."""
+        deduction = self.env["deltatech.expenses.deduction"].create(
+            {
+                "date_advance": fields.Date.today(),
+                "employee_id": self.employee.id,
+                "journal_id": self.cash_journal.id,
+                "expense_journal_id": self.adv_journal.id,
+                "journal_diem_id": self.diary_journal.id,
+                "account_diem_id": self.acc_exp.id,
+            }
+        )
+        deduction.validate_advance()
+        deduction.validate_expenses()
+        self.assertEqual(deduction.state, "done")
+
+        product = self.env["product.product"].create({"name": "Cheltuiala", "can_be_expensed": True, "type": "consu"})
+        expense = self.env["hr.expense"].create(
+            {
+                "name": "Cheltuiala tarzie",
+                "employee_id": self.employee.id,
+                "product_id": product.id,
+                "total_amount_currency": 50.0,
+                "account_id": self.acc_exp.id,
+            }
+        )
+        expense.approval_state = "approved"
+
+        with self.assertRaises(UserError):
+            deduction._import_hr_expenses(expense)
+        self.assertFalse(expense.expenses_deduction_id)
+
+    def test_expenses_line_own_rule_restricts_access(self):
+        """Un Angajat nu poate citi direct linia unui decont care nu îi aparține — regulă proprie
+        pe modelul de linie, nu doar pe decont (tichet POPVAL-COS, runda 2)."""
+        other_employee = self.env["hr.employee"].create({"name": "Alt Angajat Linie"})
+        deduction = self.env["deltatech.expenses.deduction"].create(
+            {
+                "date_advance": fields.Date.today(),
+                "employee_id": other_employee.id,
+                "journal_id": self.cash_journal.id,
+                "expense_journal_id": self.adv_journal.id,
+                "journal_diem_id": self.diary_journal.id,
+                "account_diem_id": self.acc_exp.id,
+            }
+        )
+        line = self.env["deltatech.expenses.deduction.line"].create(
+            {
+                "expenses_deduction_id": deduction.id,
+                "name": "Cazare",
+                "amount": 100.0,
+                "expense_account_id": self.acc_exp.id,
+                "partner_id": self.supplier.id,
+            }
+        )
+        plain_user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Angajat Linie Test",
+                    "login": "expenses_line_user_test",
+                    "email": "expenses_line_user_test@example.com",
+                    "group_ids": [(6, 0, [self.env.ref("deltatech_expenses.group_expenses_user").id])],
+                }
+            )
+        )
+        with self.assertRaises(AccessError):
+            line.with_user(plain_user).read(["name"])


### PR DESCRIPTION
## Rezumat

Continuare la [#2642](https://github.com/dhongu/deltatech/pull/2642) — clientul POPVAL-COS SRL a testat independent 19.0.3.1.0 pe staging (17 teste proprii, 0 eșecuri) și a semnalat 10 observații suplimentare pe tichetul intern. 4 dintre ele sunt gaps reale, confirmate în cod și corectate aici (versiune nouă: **19.0.3.2.0**):

- **`deltatech.expenses.deduction.line` fără reguli proprii de acces.** Restricția „doar decontul propriu" exista doar pe modelul părinte (`deltatech.expenses.deduction`); un Angajat cu acces CRUD pe modelul de linie putea citi/scrie orice linie direct, ocolind-o. Fix: `ir.rule` mirror pe linie (multi-company + own-record pentru Angajat + acces complet pentru Aprobator/Contabil).
- **`_import_hr_expenses` nu verifica starea decontului însuși.** Doar `action_open_import_hr_expenses` (deschiderea wizard-ului) verifica `state in (draft, advance)` — `action_import`-ul wizard-ului și `_import_hr_expenses` apelate direct nu verificau, deci un decont deja Finalizat/Anulat putea încă primi linii noi. Fix: guard explicit în `_import_hr_expenses`.
- **`_default_account_diem` folosea `company_id` pe `account.account`**, câmp inexistent în Odoo 19 (`company_ids` e many2many). Căutarea arunca `ValueError`, prins tăcut de un `except Exception` — contul de diurnă implicit nu se completa niciodată automat. Fix: `company_ids`; eliminat și try/except-ul care mascase eroarea (bug pre-existent, nu introdus în runda 1).
- **`set_paid()` scria manual `payment_state`** în loc să se bazeze pe calculul standard din reconciliere. Eliminat ca redundant/riscant — chitanța `in_receipt` intră deja în `is_invoice(include_receipts=True)`, deci `_compute_payment_state` se declanșează corect după `.reconcile()`.

Celelalte 6 observații ale clientului (reconciliere fără potrivire exactă pe document, sold istoric 542 neschimbat, câmpurile noi necompletate pe deconturile vechi, OCR neadoptat în producție, diurnă fără plafon în modulul de bază) sunt confirmate dar rămân în afara scopului acestui fix — documentate în `readme/ROADMAP.md`. Punctul despre „doar administratorii au moștenit rolul Contabil" e clarificat ca fiind un artefact al instalării fresh pe staging (migrarea rulează doar la upgrade real), nu un bug.

## Test plan

- [x] `./odoo-bin -u deltatech_expenses --test-tags=deltatech_expenses --stop-after-init` → 21/21 teste trec (3 teste noi + toate cele existente, inclusiv cele din runda 1).
- [x] `./odoo-bin -u l10n_ro_expense_allowance --test-tags=l10n_ro_expense_allowance --stop-after-init` → 11/11 teste trec.
- [ ] Testare pe staging la client înainte de a comunica rezolvarea finală.

🤖 Generated with [Claude Code](https://claude.com/claude-code)