### PR TITLE
[IMP] deltatech_rpc_audit: TEMPORARY shape-only diagnostic for short-circuit calls

### DIFF
--- a/deltatech_rpc_audit/__manifest__.py
+++ b/deltatech_rpc_audit/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "RPC Audit Log",
     "summary": "Log XML-RPC / JSON-RPC calls with the real client IP",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.2.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Technical",

--- a/deltatech_rpc_audit/controllers/rpc.py
+++ b/deltatech_rpc_audit/controllers/rpc.py
@@ -102,6 +102,22 @@ def _trim(value):
     return text
 
 
+def _shape(value):
+    """Structure-only description of a value: never its content.
+
+    Used by the TEMPORARY diagnostic below to figure out why some
+    ``service="object"`` calls fall through to the short log line (expected
+    shape is 7 positional params; some caller sends something shorter).
+    Reports only type names and container lengths, so it cannot leak a
+    password, model name or business value.
+    """
+    if isinstance(value, list | tuple):
+        return (type(value).__name__, len(value), [_shape(item) for item in value])
+    if isinstance(value, dict):
+        return (type(value).__name__, len(value))
+    return type(value).__name__
+
+
 def _log_rpc_call(service, rpc_method, params):
     # Cheapest guard first: if the logger is muted (e.g. raised above INFO via
     # log_handler), do no work at all -- not even repr() of the arguments.
@@ -140,6 +156,13 @@ def _log_rpc_call(service, rpc_method, params):
     else:
         # common / db services: never log credentials, only the RPC method.
         _logger.info("RPC ip=%s service=%s method=%s", ip, service, rpc_method)
+        # TEMPORARY DIAGNOSTIC (remove once the caller's param shape is known):
+        # some ``service="object"`` callers land here instead of the detailed
+        # branch above, meaning ``len(params) < 5`` -- unexpected for a
+        # standard execute_kw call. Log the *shape* only (types/lengths), never
+        # the values, to find out what these callers actually send.
+        if service == "object":
+            _logger.info("RPC ip=%s service=%s method=%s SHAPE=%s", ip, service, rpc_method, _shape(params))
 
 
 class RPC(RPC):

--- a/deltatech_rpc_audit/readme/HISTORY.md
+++ b/deltatech_rpc_audit/readme/HISTORY.md
@@ -1,5 +1,17 @@
 # History
 
+## 18.0.1.2.1 (2026-07-13) — TEMPORARY diagnostic, revert once answered
+
+- On PTC production, all `service="object"` calls from an internal IP
+  (`10.0.21.88`) fall through to the short log line (`RPC ip=... service=object
+  method=execute_kw`) instead of the detailed one, meaning `len(params) < 5`
+  for every one of them — unexpected for a standard 7-element `execute_kw`
+  payload. Added a structure-only diagnostic log (`_shape()`: type names and
+  container lengths, never actual values, so it cannot leak a password or
+  business data) on that fallback path, to capture the real shape of these
+  calls. **Remove this diagnostic once the shape is known** — it is not meant
+  to stay in the module long-term.
+
 ## 18.0.1.2.0 (2026-06-30)
 
 - Log the full `execute_kw` payload: in addition to db / uid / model / method /


### PR DESCRIPTION
On PTC production, every `service="object"` `execute_kw` call from internal IP `10.0.21.88` falls through to the short audit log line instead of the detailed one — meaning `len(params) < 5`, unexpected for a standard 7-element `execute_kw` payload (`[db, uid, password, model, method, args, kwargs]`). Hypothesis: this caller wraps everything into a single list argument instead of sending positional params.

This adds a structure-only diagnostic (`_shape()`: type names + container lengths, **never actual values**, so it cannot leak a password/model/business data) on that fallback path, only for `service == "object"`.

**This is a TEMPORARY diagnostic, not a permanent feature.** Plan:
1. Merge + let it deploy on PTC production.
2. Capture a few `SHAPE=...` log lines from `10.0.21.88`.
3. Open a follow-up PR reverting this specific diagnostic once the shape is known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)