### PR TITLE
[FIX] deltatech_purchase_ubl: don't drop unmatched invoice lines, auto-create vendor bill

### DIFF
--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.2.1",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",

--- a/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
+++ b/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
@@ -600,31 +600,13 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
                 )
                 updated.append(f"{product.display_name}: {ln.get('price')} {invoice_data.get('currency')}")
 
-        # If the purchase order has no lines, add products from the source document as order lines
+        # Update existing order lines from the source document, then add any remaining
+        # source lines (products not already on the order) as new order lines, instead of
+        # silently dropping them.
         added_count = 0
-        if order and not order.order_line:
-            POL = self.env["purchase.order.line"]
-            for ml in mapped_lines:
-                product = ml.get("product")
-                if not product:
-                    continue
-                vals = {
-                    "order_id": order.id,
-                    "product_id": product.id,
-                    "name": ml.get("name") or product.display_name,
-                    "product_qty": ml.get("qty", 0.0) or 0.0,
-                    "price_unit": ml.get("price", 0.0) or 0.0,
-                    "product_uom_id": product.uom_id.id,
-                    "date_planned": fields.Datetime.now(),
-                }
-                if ml.get("discount") and "discount" in self.env["purchase.order.line"]._fields:
-                    vals["discount"] = ml.get("discount")
-                POL.create(vals)
-                added_count += 1
-
-        # If the purchase order already has lines, update their quantities and prices from the source document
         updated_lines_count = 0
-        if order and order.order_line:
+        if order:
+            POL = self.env["purchase.order.line"]
             # Build a product->list of source lines map to support duplicates
             source_map = {}
             for ml in mapped_lines:
@@ -654,6 +636,23 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
                 if vals:
                     line.write(vals)
                     updated_lines_count += 1
+            # Any source lines left unconsumed (product not already on the order) become new lines
+            for lines_for_prod in source_map.values():
+                for src_ln in lines_for_prod:
+                    product = src_ln.get("product")
+                    vals = {
+                        "order_id": order.id,
+                        "product_id": product.id,
+                        "name": src_ln.get("name") or product.display_name,
+                        "product_qty": src_ln.get("qty", 0.0) or 0.0,
+                        "price_unit": src_ln.get("price", 0.0) or 0.0,
+                        "product_uom_id": product.uom_id.id,
+                        "date_planned": fields.Datetime.now(),
+                    }
+                    if src_ln.get("discount") and "discount" in self.env["purchase.order.line"]._fields:
+                        vals["discount"] = src_ln.get("discount")
+                    POL.create(vals)
+                    added_count += 1
 
         # Validate receipt
         pick_log = ""
@@ -674,7 +673,11 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         bill = False
         bill_log = ""
         duplicate_bill = False
-        if self.create_bill:
+        # Always create the vendor bill when the source document identifies an invoice number,
+        # so the supplier's invoice reference/date are not lost when the user forgets to tick
+        # "Create vendor bill". The checkbox stays available to force bill creation even when
+        # the source has no invoice number.
+        if self.create_bill or invoice_data.get("invoice_id"):
             if order:
                 invoice_ref = invoice_data.get("invoice_id")
                 duplicate_bill = self._find_duplicate_bill(partner, invoice_ref)

--- a/deltatech_purchase_ubl/readme/HISTORY.md
+++ b/deltatech_purchase_ubl/readme/HISTORY.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [19.0.1.2.1] - 2026-07-14
+
+### Fixed
+- **Bug** (ported from 18.0 PR #2645): when the purchase order already had lines, source lines whose product wasn't already on the order (e.g. an "Ecovaloare" line added by the supplier that wasn't on the original PO) were silently dropped — no new order line was created and no message was shown. `_process_invoice_data` now adds any unconsumed matched source line as a new purchase order line, mirroring the behavior already used when the order has no lines.
+  - Added test `test_new_product_added_as_line_when_order_already_has_lines`.
+- **Bug** (ported from 18.0 PR #2645): the supplier's invoice number/date (`invoice_id`/`issue_date` from the source document) were lost whenever the user ran the import wizard without ticking "Create vendor bill" (its default), then created the vendor bill later from the standard purchase order flow. `_process_invoice_data` now auto-creates the vendor bill whenever the source document identifies an invoice number, regardless of the "Create vendor bill" checkbox.
+  - Added test `test_vendor_bill_auto_created_when_invoice_id_present`.
+
 ## [19.0.1.2.0] - 2026-07-05
 
 ### Changed

--- a/deltatech_purchase_ubl/tests/test_ubl_import.py
+++ b/deltatech_purchase_ubl/tests/test_ubl_import.py
@@ -253,6 +253,126 @@ class TestPurchaseUblImport(TransactionCase):
         self.assertTrue(sinfo)
         self.assertAlmostEqual(sinfo.price, 9.99, places=2)
 
+    def test_new_product_added_as_line_when_order_already_has_lines(self):
+        # PO already has one line for an existing product
+        kg_uom = self.env.ref("uom.product_uom_kgm")
+        existing_product = self.env["product.product"].create(
+            {
+                "name": "Existing",
+                "default_code": "VEND-EXIST",
+                "is_storable": True,
+                "uom_id": kg_uom.id,
+                "purchase_ok": True,
+            }
+        )
+        self.env["purchase.order.line"].create(
+            {
+                "order_id": self.po.id,
+                "product_id": existing_product.id,
+                "name": existing_product.display_name,
+                "product_qty": 1.0,
+                "price_unit": 5.0,
+                "product_uom_id": existing_product.uom_id.id,
+                "date_planned": "2025-01-01 00:00:00",
+            }
+        )
+        # Invoice matches the existing line AND has an extra product not yet on the order
+        # (e.g. an "Ecovaloare" line added by the supplier that was not on the original PO)
+        xml = _xml_invoice(
+            order_ref=self.po.name,
+            lines=[
+                {
+                    "code": "VEND-EXIST",
+                    "name": "Existing",
+                    "qty": "7",
+                    "price": "9.99",
+                    "line_total": "69.93",
+                    "unit_code": "KGM",
+                },
+                {
+                    "code": "VEND-NEW",
+                    "name": "New From UBL",
+                    "qty": "3",
+                    "price": "12.50",
+                    "line_total": "37.50",
+                    "unit_code": "KGM",
+                },
+            ],
+        )
+        _ = self._run_wizard(xml, self.po)
+
+        # Existing line still updated
+        pol_existing = self.po.order_line.filtered(lambda l: l.product_id == existing_product)
+        self.assertTrue(pol_existing)
+        self.assertAlmostEqual(pol_existing.product_qty, 7.0, places=4)
+
+        # New product must be added as a new order line, not silently dropped
+        new_product = self.env["product.product"].search([("name", "=", "New From UBL")], limit=1)
+        self.assertTrue(new_product, "Product should be created from UBL line")
+        pol_new = self.po.order_line.filtered(lambda l: l.product_id == new_product)
+        self.assertTrue(pol_new, "New product from invoice must be added as a purchase order line")
+        self.assertAlmostEqual(pol_new.product_qty, 3.0, places=4)
+        self.assertAlmostEqual(pol_new.price_unit, 12.50, places=2)
+
+    def test_vendor_bill_auto_created_when_invoice_id_present(self):
+        # Even with create_bill unticked, a vendor bill must be created (and its ref/date
+        # filled from the source document) whenever the source has an invoice number,
+        # otherwise the supplier's invoice reference/date are lost.
+        kg_uom = self.env.ref("uom.product_uom_kgm")
+        product = self.env["product.product"].create(
+            {
+                "name": "Existing",
+                "default_code": "VEND-EXIST",
+                "is_storable": True,
+                "uom_id": kg_uom.id,
+                "purchase_ok": True,
+                "purchase_method": "purchase",
+            }
+        )
+        self.env["purchase.order.line"].create(
+            {
+                "order_id": self.po.id,
+                "product_id": product.id,
+                "name": product.display_name,
+                "product_qty": 7.0,
+                "price_unit": 9.99,
+                "product_uom_id": product.uom_id.id,
+                "date_planned": "2025-01-01 00:00:00",
+            }
+        )
+        self.po.button_confirm()
+        xml = _xml_invoice(
+            invoice_id="INV-777",
+            order_ref=self.po.name,
+            lines=[
+                {
+                    "code": "VEND-EXIST",
+                    "name": "Existing",
+                    "qty": "7",
+                    "price": "9.99",
+                    "line_total": "69.93",
+                    "unit_code": "KGM",
+                }
+            ],
+        )
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        wiz = Wiz.with_context(active_model="purchase.order", active_id=self.po.id).create(
+            {
+                "data_file": b64encode(xml),
+                "filename": "test.xml",
+                "update_prices": True,
+                "create_bill": False,
+                "validate_receipt": False,
+                "create_missing_products": True,
+            }
+        )
+        wiz.action_import()
+
+        self.assertTrue(self.po.invoice_ids, "Vendor bill should be auto-created when source has an invoice number")
+        inv = self.po.invoice_ids.sorted(key=lambda m: m.id)[-1]
+        self.assertEqual(inv.ref, "INV-777")
+        self.assertEqual(str(inv.invoice_date), "2025-01-01")
+
     def test_product_match_by_name_no_spaces(self):
         # Create a product with spaces in name
         product = self.env["product.product"].create(


### PR DESCRIPTION
## Summary
Port of 18.0 [#2645](https://github.com/dhongu/deltatech/pull/2645) to 19.0:
- When the purchase order already had lines, source lines whose product wasn't already on the order (e.g. an "Ecovaloare" line added by the supplier) were silently dropped instead of being added as new order lines.
- The vendor bill is now created automatically whenever the source document identifies an invoice number, regardless of the "Create vendor bill" checkbox, so the supplier's invoice ref/date are not lost when the user forgets to tick it.

Adapted to 19.0 API (`product_uom_id` instead of `product_uom`, no `uom_po_id`). The `deltatech_select_journal` `_convert()` fix from the 18.0 PR does not apply here — that module has no Python code yet on 19.0.

Both bugs were reported by the client on helpdesk ticket 8947 (PTC dropshipping invoice import: Marso/Delta/Procar/Sigemo).

## Test plan
- [x] `test_new_product_added_as_line_when_order_already_has_lines` — reproduces the Marso/ecovaloare case
- [x] `test_vendor_bill_auto_created_when_invoice_id_present` — vendor bill auto-created with correct ref/invoice_date even with "Create vendor bill" unticked
- [x] Full `deltatech_purchase_ubl` test suite passes on a clean 19.0 database (27 tests, 0 failures, 0 errors)