### PR TITLE
[FIX] deltatech_purchase_ubl: mark manually-tracked lines as received so invoice import can bill them

### DIFF
--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "18.0.1.2.2",
+    "version": "18.0.1.2.3",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",

--- a/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
+++ b/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
@@ -405,6 +405,18 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         else:
             SupplierInfo.create(values)
 
+    def _mark_line_received_if_manual(self, line):
+        """Mark a purchase order line as received when its quantity is tracked manually.
+
+        Service/consu products (qty_received_method == "manual") never get a qty_received
+        from stock moves or from _validate_receipt_quantities below, since they have no
+        stock picking. Without this, a line matched from the supplier invoice (e.g. an
+        "Ecovaloare" eco-tax line) stays at qty_to_invoice == 0 and action_create_invoice()
+        silently drops it from the vendor bill, even though it is present on the order.
+        """
+        if line.qty_received_method == "manual":
+            line.qty_received_manual = line.product_qty
+
     def _find_receipt(self, order):
         Picking = self.env["stock.picking"]
         domain = [
@@ -646,6 +658,7 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
                 if vals:
                     line.write(vals)
                     updated_lines_count += 1
+                self._mark_line_received_if_manual(line)
             # Any source lines left unconsumed (product not already on the order) become new lines
             for lines_for_prod in source_map.values():
                 for src_ln in lines_for_prod:
@@ -661,8 +674,9 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
                     }
                     if src_ln.get("discount") and "discount" in self.env["purchase.order.line"]._fields:
                         vals["discount"] = src_ln.get("discount")
-                    POL.create(vals)
+                    new_line = POL.create(vals)
                     added_count += 1
+                    self._mark_line_received_if_manual(new_line)
 
         # Validate receipt
         pick_log = ""

--- a/deltatech_purchase_ubl/readme/HISTORY.md
+++ b/deltatech_purchase_ubl/readme/HISTORY.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [18.0.1.2.3] - 2026-07-18
+
+### Fixed
+- **Bug**: purchase order lines for service products with `purchase_method="receive"` (e.g. Marso's "Ecovaloare" eco-tax lines) never get a `qty_received` from stock moves, since services have no stock picking. Only `_validate_receipt_quantities` (used for physical products) previously set received quantities, so these service lines stayed at `qty_to_invoice == 0` and `action_create_invoice()` silently dropped them from the vendor bill even though they were present on the order.
+  - `_process_invoice_data` now marks a line as received (`qty_received_manual` = ordered quantity) whenever its `qty_received_method` is `"manual"`, for both updated existing lines and newly added ones.
+  - Added test `test_service_line_receive_policy_is_marked_received_for_billing`.
+
 ## [18.0.1.2.2] - 2026-07-14
 
 ### Fixed

--- a/deltatech_purchase_ubl/tests/test_ubl_import.py
+++ b/deltatech_purchase_ubl/tests/test_ubl_import.py
@@ -669,6 +669,80 @@ class TestPurchaseUblImport(TransactionCase):
         # Check message content without hardcoding the currency (company currency may vary)
         self.assertIn("differs from XML total 15.00", wiz.total_check_warning or "")
 
+    def test_service_line_receive_policy_is_marked_received_for_billing(self):
+        """Regression test for the reported Marso "Ecovaloare" bug: a service product
+        with purchase_method="receive" has no stock moves, so its qty_received stays 0
+        unless set explicitly -- otherwise action_create_invoice() silently drops the
+        line from the vendor bill even though it is present on the purchase order.
+        """
+        eco = self.env["product.product"].create(
+            {
+                "name": "Ecovaloare ANVELOPA 15",
+                "default_code": "ECO-15",
+                "type": "service",
+                "purchase_ok": True,
+                "purchase_method": "receive",
+            }
+        )
+        self.env["purchase.order.line"].create(
+            {
+                "order_id": self.po.id,
+                "product_id": eco.id,
+                "name": eco.display_name,
+                "product_qty": 4.0,
+                "price_unit": 1.50,
+                "product_uom": eco.uom_po_id.id,
+                "date_planned": "2025-01-01 00:00:00",
+            }
+        )
+        self.po.button_confirm()
+        self.assertEqual(
+            self.po.order_line.qty_received,
+            0.0,
+            "Sanity check: a fresh service line has no received quantity yet",
+        )
+
+        xml = _xml_invoice(
+            invoice_id="INV-ECO-1",
+            order_ref=self.po.name,
+            lines=[
+                {
+                    "code": "ECO-15",
+                    "name": "Ecovaloare ANVELOPA 15",
+                    "qty": "4",
+                    "price": "1.50",
+                    "line_total": "6.00",
+                    "unit_code": "C62",
+                }
+            ],
+        )
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        wiz = Wiz.with_context(active_model="purchase.order", active_id=self.po.id).create(
+            {
+                "data_file": b64encode(xml),
+                "filename": "eco.xml",
+                "update_prices": True,
+                "create_bill": True,
+                "validate_receipt": False,
+                "create_missing_products": True,
+            }
+        )
+        wiz.action_import()
+
+        pol = self.po.order_line.filtered(lambda l: l.product_id == eco)
+        self.assertEqual(pol.qty_received_method, "manual")
+        self.assertAlmostEqual(
+            pol.qty_received,
+            4.0,
+            places=4,
+            msg="Service line must be marked as received so it can be invoiced",
+        )
+
+        self.assertTrue(self.po.invoice_ids, "Vendor bill should be created")
+        bill = self.po.invoice_ids.sorted(key=lambda m: m.id)[-1]
+        bill_line = bill.invoice_line_ids.filtered(lambda l: l.product_id == eco)
+        self.assertTrue(bill_line, "Ecovaloare line must reach the vendor bill, not be silently dropped")
+
     def test_total_check_log_confirms_when_totals_match(self):
         # Use a fresh PO with a line whose total exactly matches the XML payable_amount
         po = self.env["purchase.order"].create(


### PR DESCRIPTION
## Summary
- Regression found while investigating Terrabit ticket #8947 (PTC, Marso dropshipping invoice import): the client reported that the "Ecovaloare" eco-tax line is present on the purchase order but never makes it onto the vendor bill.
- Root cause: `Ecovaloare` products are services with `purchase_method="receive"`. Services have no stock moves, so `qty_received` is tracked manually (`qty_received_method == "manual"`) and stays 0 unless something writes to it. `_process_invoice_data` (added/updated by #2645) correctly adds/updates these lines on the purchase order from the source invoice, but never touched `qty_received` — so `action_create_invoice()` computes `qty_to_invoice == 0` for the line and silently drops it from the vendor bill, with no warning in the wizard log.
- Fix: `_mark_line_received_if_manual()` sets `qty_received_manual = product_qty` whenever a line's `qty_received_method == "manual"`, applied to both updated existing lines and newly created ones in `_process_invoice_data`.

## Test plan
- [x] Added `test_service_line_receive_policy_is_marked_received_for_billing`: creates a service line with `purchase_method="receive"` on a confirmed PO, runs the invoice import, asserts `qty_received` is set and the vendor bill actually contains the line.
- [x] `-u deltatech_purchase_ubl --test-tags=deltatech_purchase_ubl --stop-after-init` on local `o18_test`: 13 tests, 0 failed, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)