### PR TITLE
[FIX] deltatech_sale_catalog_website: don't change quantity when zoom…

### DIFF
--- a/deltatech_sale_catalog_website/static/src/product_catalog/image_zoom_field.xml
+++ b/deltatech_sale_catalog_website/static/src/product_catalog/image_zoom_field.xml
@@ -7,7 +7,9 @@
         t-inherit-mode="primary"
     >
         <xpath expr="//img" position="attributes">
-            <attribute name="t-on-click">onImageClick</attribute>
+            <!-- .stop: opening the preview must not bubble to the catalog card's
+                 onGlobalClick, which would add/increment the order quantity. -->
+            <attribute name="t-on-click.stop">onImageClick</attribute>
             <attribute name="role">button</attribute>
         </xpath>
     </t>


### PR DESCRIPTION
…ing image

Clicking a product image opened the full-size preview but the click also bubbled to the catalog card's onGlobalClick, which adds/increments the order quantity. Stop propagation on the image click so it only opens the preview.