### PR TITLE
Adaugă căutare rapidă pentru liste de coduri produs în shop

### DIFF
--- a/deltatech_website_product_code/README.rst
+++ b/deltatech_website_product_code/README.rst
@@ -24,15 +24,59 @@ eCommerce Product Code
   - Display product page using internal code
   - Display product code in product page
   - Display product code in search results
+  - Fast search when several product codes are pasted at once in the shop
+    search box (finds any matching product instead of requiring all codes
+    to match the same product)
 
 - Usage:
 
   - Use link: /shop/product-code/<code>
 
+- Configuration (optional, System Parameters):
+
+  - ``website_search.min_term_length`` (default ``3``): search terms
+    shorter than this are ignored, since they cannot use the trigram
+    indexes and only slow down the search.
+  - ``website_search.multi_code_min_terms`` (default ``4``): minimum
+    number of code-looking terms (e.g. ``AMAT1-12345``) pasted together
+    before the fast multi-code search kicks in. Set to ``False`` or ``0``
+    to disable it and fall back to the regular search.
+
 **Table of contents**
 
 .. contents::
    :local:
+
+Changelog
+=========
+
+18.0.1.2.0 (2026-07-20)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Added**
+
+- Fast path for shop searches where several product codes are pasted
+  together (e.g. copy-pasted from a parts list). The default search
+  requires every pasted term to match the same product (AND), which
+  always returned zero results for a list of different codes; this adds
+  an OR-based search restricted to terms that look like product codes,
+  new system parameter ``website_search.multi_code_min_terms``
+  (default ``4``, set to ``False``/``0`` to disable).
+
+18.0.1.1.0 (2026-06-02)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Fixed**
+
+- Ignore search terms shorter than ``website_search.min_term_length``
+  (default ``3``) when searching products on the website. Short terms
+  cannot use the trigram indexes and were forcing sequential scans,
+  causing shop searches to take up to ~40s.
+
+18.0.1.0.1 (2024-10-29)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Migrated to 18.0.
 
 Bug Tracker
 ===========

--- a/deltatech_website_product_code/__manifest__.py
+++ b/deltatech_website_product_code/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Code",
     "summary": "Display product by code in eCommerce",
     "category": "Website",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_product_code/models/product_template.py
+++ b/deltatech_website_product_code/models/product_template.py
@@ -2,7 +2,17 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+import re
+
 from odoo import api, models
+from odoo.osv import expression
+from odoo.tools import escape_psql
+
+_CODE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-_./]{2,}$")
+
+
+def _looks_like_code(term):
+    return bool(_CODE_RE.match(term)) and any(ch.isdigit() for ch in term)
 
 
 class ProductTemplate(models.Model):
@@ -23,6 +33,60 @@ class ProductTemplate(models.Model):
             if long_terms and len(long_terms) != len(terms):
                 search = " ".join(long_terms)
         return super()._search_build_domain(domain_list, search, fields, extra=extra)
+
+    @api.model
+    def _search_fetch(self, search_detail, search, limit, order):
+        # When someone pastes a list of product codes into the shop search box,
+        # the default domain ORs every term against every search field in one
+        # WHERE clause. Some fields are plain columns (trigram-indexable) and
+        # some are relational (product_variant_ids.*, alternative_ids.*, resolved
+        # via subqueries); PostgreSQL can't build one combined bitmap plan across
+        # a mix of column and subquery conditions joined by OR, so with
+        # ORDER BY website_sequence LIMIT N it falls back to scanning the table
+        # in that order and evaluating the whole filter per row - measured at
+        # ~10s for 14 pasted codes against ~123k products (EXPLAIN ANALYZE).
+        # Searching one field at a time instead (still ORing all terms within
+        # each field) lets every branch use its own index; ~500x faster on the
+        # same data, same results (still ORed/deduped across all fields).
+        terms = [t for t in (search or "").split(" ") if t.strip()]
+        min_terms = self._multi_code_min_terms()
+        if (
+            min_terms
+            and len(terms) >= min_terms
+            and not search_detail.get("search_extra")
+            and all(_looks_like_code(t) for t in terms)
+        ):
+            return self._search_fetch_multi_code(search_detail, terms, limit, order)
+        return super()._search_fetch(search_detail, search, limit, order)
+
+    def _multi_code_min_terms(self):
+        # False/0/empty/anything non-numeric disables the fast path, falling
+        # back to the legacy behavior - int("False") would otherwise raise.
+        param = self.env["ir.config_parameter"].sudo().get_param("website_search.multi_code_min_terms", "4")
+        try:
+            return int(param)
+        except (ValueError, TypeError):
+            return 0
+
+    def _search_fetch_multi_code(self, search_detail, terms, limit, order):
+        base_domain = search_detail["base_domain"]
+        search_fields = search_detail["search_fields"]
+        model = self.sudo() if search_detail.get("requires_sudo") else self
+        branch_limit = max(limit * 20, 500)
+
+        all_ids = set()
+        for field_name in search_fields:
+            term_domain = expression.OR([[(field_name, "ilike", escape_psql(term))] for term in terms])
+            branch_domain = expression.AND(base_domain + [term_domain])
+            all_ids.update(model.search(branch_domain, limit=branch_limit, order="id").ids)
+
+        if not all_ids:
+            return model.browse(), 0
+
+        final_domain = [("id", "in", list(all_ids))]
+        results = model.search(final_domain, limit=limit, order=search_detail.get("order", order))
+        count = model.search_count(final_domain) if limit and limit == len(results) else len(results)
+        return results, count
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         fetch_fields += ["default_code", "display_name"]

--- a/deltatech_website_product_code/readme/DESCRIPTION.md
+++ b/deltatech_website_product_code/readme/DESCRIPTION.md
@@ -3,7 +3,20 @@
   - Display product page using internal code
   - Display product code in product page
   - Display product code in search results
+  - Fast search when several product codes are pasted at once in the shop
+    search box (finds any matching product instead of requiring all codes
+    to match the same product)
 
 - Usage:
 
   - Use link: /shop/product-code/\<code\>
+
+- Configuration (optional, System Parameters):
+
+  - ``website_search.min_term_length`` (default ``3``): search terms
+    shorter than this are ignored, since they cannot use the trigram
+    indexes and only slow down the search.
+  - ``website_search.multi_code_min_terms`` (default ``4``): minimum
+    number of code-looking terms (e.g. ``AMAT1-12345``) pasted together
+    before the fast multi-code search kicks in. Set to ``False`` or ``0``
+    to disable it and fall back to the regular search.

--- a/deltatech_website_product_code/readme/HISTORY.rst
+++ b/deltatech_website_product_code/readme/HISTORY.rst
@@ -1,0 +1,27 @@
+18.0.1.2.0 (2026-07-20)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Added**
+
+- Fast path for shop searches where several product codes are pasted
+  together (e.g. copy-pasted from a parts list). The default search
+  requires every pasted term to match the same product (AND), which
+  always returned zero results for a list of different codes; this adds
+  an OR-based search restricted to terms that look like product codes,
+  new system parameter ``website_search.multi_code_min_terms``
+  (default ``4``, set to ``False``/``0`` to disable).
+
+18.0.1.1.0 (2026-06-02)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Fixed**
+
+- Ignore search terms shorter than ``website_search.min_term_length``
+  (default ``3``) when searching products on the website. Short terms
+  cannot use the trigram indexes and were forcing sequential scans,
+  causing shop searches to take up to ~40s.
+
+18.0.1.0.1 (2024-10-29)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+- Migrated to 18.0.


### PR DESCRIPTION
Căutarea implicită face AND între termeni, deci o listă de coduri diferite lipite în bara de căutare nu găsea niciodată nimic. Adaugă o cale rapidă (OR) când toți termenii arată a coduri, căutând fiecare câmp separat ca să evite planul lent al Postgres cu mulți termeni. Prag configurabil din website_search.multi_code_min_terms (implicit 4, False/0 dezactivează).