### PR TITLE
[FIX] deltatech_sale_payment: sudo neconsecvent pe transaction_ids in _compute_payment

### DIFF
--- a/deltatech_sale_payment/models/sale.py
+++ b/deltatech_sale_payment/models/sale.py
@@ -76,17 +76,17 @@ class SaleOrder(models.Model):
 
             if not amount:
                 payment_status = "without"
-                if order.transaction_ids:
+                if all_transactions:
                     payment_status = "initiated"
 
-                    cancel_tx = order.transaction_ids.filtered(lambda t: t.state == "cancel")
+                    cancel_tx = all_transactions.filtered(lambda t: t.state == "cancel")
                     if cancel_tx:
                         payment_status = "cancelled"
 
                     for transaction in all_transactions.sorted(lambda a: a.id):
                         provider = transaction.provider_id
 
-                    authorized_transaction_ids = order.transaction_ids.filtered(lambda t: t.state == "authorized")
+                    authorized_transaction_ids = all_transactions.filtered(lambda t: t.state == "authorized")
                     if authorized_transaction_ids:
                         payment_status = "authorized"
                         for transaction in authorized_transaction_ids:


### PR DESCRIPTION
## Context / de ce

Un user fără grupul „Contabilitate / Facturare" (`account.group_account_invoice`) primea eroarea:

```
You do not have enough rights to access the field "transaction_ids" on Comandă de vânzare (sale.order).
Operation: read
```

la simpla deschidere/listare a comenzilor de vânzare — deși nu ar trebui să aibă nevoie de acel grup pentru Vânzări.

## Ce s-a schimbat

`deltatech_sale_payment/models/sale.py` — metoda `_compute_payment` din `SaleOrder`:

- La linia 54 accesul la `transaction_ids` era deja protejat corect: `order.sudo().transaction_ids...` (rezultatul salvat în `all_transactions`).
- În ramura `if not amount:` (fostele linii 79, 82, 89), codul accesa din nou câmpul, dar **fără sudo**: `order.transaction_ids`. Acest acces neprotejat rula verificarea de grup cu drepturile userului curent, nu cu sudo, și pica pentru orice user fără `account.group_account_invoice`.
- Fix: cele trei accese neprotejate au fost înlocuite cu `all_transactions`, variabila deja calculată la linia 54 (echivalentă ca conținut, doar sudo + filtrată de id-uri non-int din onchange), eliminând complet accesul neprotejat la `transaction_ids`.

## Testare

- `pre-commit run --files deltatech_sale_payment/models/sale.py` — trece curat (ruff, pylint_odoo, etc).
- Verificare manuală a diff-ului: logica rămâne identică (aceleași tranzacții), doar sursa citirii se schimbă din `order.transaction_ids` (neprotejat) în `all_transactions` (deja sudo + filtrată).

## Note / riscuri

- Fix minimal, izolat pe un singur fișier — nu schimbă comportamentul funcțional, doar elimină accesul neprotejat.
- Nu au fost necesare modificări de view/security — problema era exclusiv în compute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)