### PR TITLE
[FIX] deltatech_sale_payment: sudo pe invoice.transaction_ids in _compute_payment

### DIFF
--- a/deltatech_sale_payment/models/sale.py
+++ b/deltatech_sale_payment/models/sale.py
@@ -61,7 +61,7 @@ class SaleOrder(models.Model):
                 amount_invoice = invoice.amount_total_signed - invoice.amount_residual_signed
                 if amount_invoice:
                     amount += amount_invoice
-                    transactions = transactions - invoice.transaction_ids.filtered(lambda a: a.is_post_processed)
+                    transactions = transactions - invoice.sudo().transaction_ids.filtered(lambda a: a.is_post_processed)
 
             for transaction in transactions:
                 amount += transaction.amount


### PR DESCRIPTION
## Context / de ce

Continuare a [#2656](https://github.com/dhongu/deltatech/pull/2656) (deja mergeat), care corecta un acces neprotejat la `order.transaction_ids` în `_compute_payment`. După acel fix, un user fără grup de contabilitate (Claudia) a continuat să primească — intermitent — o eroare nouă la deschiderea unor comenzi de vânzare:

```
Failed to read field account.move.transaction_ids
Nu aveți permisiunea de a accesa înregistrările 'Tranzacție plată' (payment.transaction).
Această operațiune este permisă pentru următoarele grupuri:
	- Contabilitate/Facturare
	- Setări
```

Aceasta nu mai e o restricție de câmp (`groups=`), ci o verificare `ir.model.access` la nivel de model pe `payment.transaction`, care în Odoo are acces doar pentru `base.group_system` (Setări) și `account.group_account_invoice` (Contabilitate/Facturare) — vezi `odoo/addons/payment/security/ir.model.access.csv` și `odoo/addons/account_payment/security/ir.model.access.csv`. De aici apariția „random": eroarea apare doar când comanda are cel puțin o factură **postată** cu tranzacții de plată asociate (branch-ul respectiv din `_compute_payment`).

## Ce s-a schimbat

`deltatech_sale_payment/models/sale.py`, în `_compute_payment`, bucla peste facturile postate ale comenzii:

```python
transactions = transactions - invoice.transaction_ids.filtered(lambda a: a.is_post_processed)
```

`invoice` vine din `order.invoice_ids` (fără sudo), iar `account.move.transaction_ids` browsează modelul `payment.transaction`, restricționat pentru useri fără grup de contabilitate. Fix: `invoice.sudo().transaction_ids...`, analog cu `order.sudo().transaction_ids` deja folosit puțin mai sus în aceeași metodă.

## Testare

- `pre-commit run --files deltatech_sale_payment/models/sale.py` — trece curat.
- Verificare manuală a diff-ului — schimbare minimă, un singur `.sudo()` adăugat, fără efect asupra logicii de calcul.

## Note / riscuri

- Fix minimal, izolat, continuă exact aceeași temă ca #2656.
- Nu au fost necesare modificări de `ir.model.access`/`security` — problema era strict lipsa unui `sudo()` în compute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)