### PR TITLE
[IMP] deltatech_rpc_audit: log actual params for short-shape object calls

### DIFF
--- a/deltatech_rpc_audit/controllers/rpc.py
+++ b/deltatech_rpc_audit/controllers/rpc.py
@@ -159,10 +159,17 @@ def _log_rpc_call(service, rpc_method, params):
         # TEMPORARY DIAGNOSTIC (remove once the caller's param shape is known):
         # some ``service="object"`` callers land here instead of the detailed
         # branch above, meaning ``len(params) < 5`` -- unexpected for a
-        # standard execute_kw call. Log the *shape* only (types/lengths), never
-        # the values, to find out what these callers actually send.
+        # standard execute_kw call. Log the *shape* (types/lengths) plus the
+        # actual values (trimmed) to find out what these callers actually send.
         if service == "object":
-            _logger.info("RPC ip=%s service=%s method=%s SHAPE=%s", ip, service, rpc_method, _shape(params))
+            _logger.info(
+                "RPC ip=%s service=%s method=%s SHAPE=%s PARAMS=%s",
+                ip,
+                service,
+                rpc_method,
+                _shape(params),
+                _trim(params),
+            )
 
 
 class RPC(RPC):


### PR DESCRIPTION
## Summary
- Some `service="object"` RPC callers (e.g. odoo.sh's internal cron dispatcher, seen calling from an internal IP) send fewer than 5 positional params and fall into the existing SHAPE-only diagnostic branch, which never logs the actual values.
- This adds a `PARAMS=` field (trimmed repr, same 500-char cap as the detailed branch) alongside `SHAPE=`, so we can identify what these callers actually invoke.
- Temporary diagnostic — should be reverted once the caller's real param shape is confirmed (tracked in the comment above the code).

## Test plan
- [ ] Deploy to a staging/PTC branch and confirm `PARAMS=` appears in the log next to `SHAPE=` for the internal-IP calls
- [ ] Confirm no exception/regression on normal short "common"/"db" service calls (branch unaffected, only `service == "object"` gets the extra field)
- [ ] Revert this change once the caller identity is confirmed