### PR TITLE
[19.0][FIX] deltatech_website_sale_status: elimină referința la câmpul inexistent partner_id.mobile

### DIFF
--- a/deltatech_website_sale_status/__manifest__.py
+++ b/deltatech_website_sale_status/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Sale Order status",
     "category": "Website",
     "summary": "Additional filters sales orders by status ",
-    "version": "19.0.2.0.4",
+    "version": "19.0.2.0.5",
     "license": "OPL-1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_sale_status/readme/HISTORY.md
+++ b/deltatech_website_sale_status/readme/HISTORY.md
@@ -1,0 +1,10 @@
+## 19.0.2.0.5 (2026-07-23)
+
+- Fix: the "Phone" search field added to the sale order search view
+  (`view_sales_order_filter`) still referenced `partner_id.mobile`, a field
+  removed from `res.partner` in Odoo 19 (only `phone` remains). Since this
+  field is named `partner_id` like the native one, it gets auto-populated by
+  the `search_default_partner_id` context — used, among others, by the
+  "Sales" button in the bank reconciliation widget — which raised
+  `ValueError: Invalid field res.partner.mobile` on every use. The filter now
+  only matches on `partner_id.phone`.

--- a/deltatech_website_sale_status/views/sale_view.xml
+++ b/deltatech_website_sale_status/views/sale_view.xml
@@ -67,7 +67,7 @@
                 <field
                     name="partner_id"
                     string="Phone"
-                    filter_domain="['|',('partner_id.phone', 'ilike', self),('partner_id.mobile', 'ilike', self)]"
+                    filter_domain="[('partner_id.phone', 'ilike', self)]"
                 />
                 <filter string="Placed" name="stage_placed" domain="[('stage', '=', 'placed')]" />
                 <filter string="In process" name="stage_in_process" domain="[('stage', '=', 'in_process')]" />


### PR DESCRIPTION


Câmpul mobile a fost eliminat din res.partner în Odoo 19 (a rămas doar phone), iar filtrul de căutare "Phone" din view_sales_order_filter încă îl referea. Cum acest câmp e numit tot partner_id, contextul search_default_partner_id (folosit de butonul "Sales" din widget-ul de reconciliere bancară) îl popula automat, provocând ValueError: Invalid field res.partner.mobile la fiecare click.