### PR TITLE
[18.0][FIX] deltatech_account_analytic: recompute distribution on team change

### DIFF
--- a/deltatech_account_analytic/__manifest__.py
+++ b/deltatech_account_analytic/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech Account Analytic",
     "summary": "Analytic lines enhancements",
-    "version": "18.0.0.0.4",
+    "version": "18.0.0.0.5",
     "author": "Terrabit, Dan Stoica",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_account_analytic/models/account_move.py
+++ b/deltatech_account_analytic/models/account_move.py
@@ -1,12 +1,13 @@
 # ©  2023-now Terrabit
 # See README.rst file on addons root folder for license details
 
-from odoo import models
+from odoo import api, models
 
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
+    @api.depends("move_id.team_id")
     def _compute_analytic_distribution(self):
         """
         Cautare dupa team_id


### PR DESCRIPTION
_compute_analytic_distribution looks up the distribution model by move_id.team_id but never declared it as a dependency, so lines kept their stale (often empty) analytic distribution whenever the sales team was changed on an existing invoice (e.g. duplicate + change channel), instead of only at creation time.