### PR TITLE
[FIX] deltatech_mrp: corectează semnul value în analiza costurilor de producție (O19)

### DIFF
--- a/deltatech_mrp/__manifest__.py
+++ b/deltatech_mrp/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "MRP Extension",
     "summary": "MRP Extension",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.0.4",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_mrp/models/mrp_cost.py
+++ b/deltatech_mrp/models/mrp_cost.py
@@ -29,7 +29,7 @@ class DeltatechCostDetail(models.Model):
 
                 SELECT max(sm.id) AS id,
                     sm.raw_material_production_id AS production_id,
-                    SUM (-sm.value) AS amount,
+                    SUM (sm.value) AS amount,
                     pc.cost_categ
                 FROM
                     stock_move sm

--- a/deltatech_mrp/report/deltatech_mrp_report.py
+++ b/deltatech_mrp/report/deltatech_mrp_report.py
@@ -120,10 +120,10 @@ SELECT s.id, s.id as production_id,
 left join (
 SELECT
     sm.raw_material_production_id AS production_id,
-   SUM (-sm.value) AS consumed_val,
-      CASE WHEN pc.cost_categ='semi' THEN SUM (-sm.value) else 0.0 end as  consumed_sem_val,
-      CASE WHEN pc.cost_categ='pak' THEN SUM (-sm.value) else 0.0 end as  consumed_pak_val,
-      CASE WHEN pc.cost_categ='raw' THEN SUM (-sm.value) else 0.0 end as  consumed_raw_val
+   SUM (sm.value) AS consumed_val,
+      CASE WHEN pc.cost_categ='semi' THEN SUM (sm.value) else 0.0 end as  consumed_sem_val,
+      CASE WHEN pc.cost_categ='pak' THEN SUM (sm.value) else 0.0 end as  consumed_pak_val,
+      CASE WHEN pc.cost_categ='raw' THEN SUM (sm.value) else 0.0 end as  consumed_raw_val
     FROM
         stock_move sm
 


### PR DESCRIPTION
## Problemă
Raportul pivot **„Analiză costuri producție"** (`deltatech.mrp.report`) și detaliul de cost (`deltatech.cost.detail`) afișau **toate valorile negative** (Val consumuri, materii prime, ambalaje, semifabricate, Valoare producție, Preț actual) după migrarea pe Odoo 19. Semnalat pe productivul Romchim (tichet #9043), vizibil pe iunie 2026.

## Cauză
Ambele view-uri SQL folosesc `stock_move.value` și negau valoarea consumurilor cu `SUM(-sm.value)` — convenția **Odoo 18**, unde mișcările de ieșire aveau `value` **negativ**, deci negarea le făcea pozitive.

În **Odoo 19** valorizarea de pe `stock.move` s-a schimbat: `_get_valued_qty()` întoarce cantitate pozitivă și `move.value = standard_price * valued_qty`, deci `value` este magnitudine **pozitivă și pentru ieșiri** (semnul e dat de `is_in`/`is_out`). Negarea inversa semnul → toate coloanele negative.

Confirmat empiric pe productiv: consumurile de producție din iunie 2026 (`raw_material_production_id` setat, `is_out=true`) au `value > 0`.

## Fix
`SUM(-sm.value)` → `SUM(sm.value)` în ambele view-uri:
- `report/deltatech_mrp_report.py` (consumed_val, consumed_semi/pak/raw)
- `models/mrp_cost.py` (deltatech.cost.detail.amount)

Bump `19.0.1.0.3` → `19.0.1.0.4` pentru ca `-u deltatech_mrp` să recreeze view-ul (`init()`).

Tichet #9043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)