### PR TITLE
[FIX] deltatech_alternative: don't split alternative codes on spaces

### DIFF
--- a/deltatech_alternative/__manifest__.py
+++ b/deltatech_alternative/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Products Alternative",
-    "version": "18.0.2.1.7",
+    "version": "18.0.2.1.8",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Alternative product codes",

--- a/deltatech_alternative/models/product.py
+++ b/deltatech_alternative/models/product.py
@@ -3,6 +3,7 @@
 # See README.rst file on addons root folder for license details
 
 import logging
+import re
 
 from odoo import api, fields, models
 from odoo.osv import expression
@@ -10,6 +11,11 @@ from odoo.tools.safe_eval import safe_eval
 from odoo.tools.sql import create_index, index_exists
 
 _logger = logging.getLogger(__name__)
+
+# Only explicit delimiters separate two codes. Whitespace must NOT be treated as
+# a delimiter: many OEM part numbers contain spaces ("366 200 05 01"), and
+# splitting on them destroys the code and makes the product unsearchable.
+_CODE_SEPARATOR_RE = re.compile(r"[;,]+")
 
 
 def _ensure_trgm_prerequisites(cr):
@@ -225,31 +231,33 @@ class ProductAlternative(models.Model):
 
     @api.model
     def split_multi_codes(self):
-        import re
-
         domain = [
             ("name", "!=", False),
             "|",
-            "|",
             ("name", "like", ";"),
             ("name", "like", ","),
-            ("name", "like", " "),
         ]
         records = self.search(domain, limit=5000)
         for record in records:
             name = (record.name or "").strip()
             if not name:
                 continue
-            codes = [c for c in re.split(r"[;,\s]+", name) if c]
-            if len(codes) > 1:
-                record.write({"name": codes[0]})
-                new_records = [
-                    {
-                        "name": code,
-                        "product_tmpl_id": record.product_tmpl_id.id or False,
-                        "sequence": record.sequence,
-                        "hide": record.hide,
-                    }
-                    for code in codes[1:]
-                ]
-                self.create(new_records)
+            codes = [c.strip() for c in _CODE_SEPARATOR_RE.split(name) if c.strip()]
+            if not codes:
+                continue
+            if len(codes) == 1:
+                # A single code with a stray delimiter around it ("12345, ").
+                if codes[0] != record.name:
+                    record.write({"name": codes[0]})
+                continue
+            record.write({"name": codes[0]})
+            new_records = [
+                {
+                    "name": code,
+                    "product_tmpl_id": record.product_tmpl_id.id or False,
+                    "sequence": record.sequence,
+                    "hide": record.hide,
+                }
+                for code in codes[1:]
+            ]
+            self.create(new_records)

--- a/deltatech_alternative/readme/DESCRIPTION.md
+++ b/deltatech_alternative/readme/DESCRIPTION.md
@@ -28,8 +28,10 @@ Module that extends the standard Odoo product with support for **alternative cod
 ### Multi-code Split (Cron)
 
 - A scheduled action runs **daily** and processes batches of up to **5 000** `product.alternative` records at a time.
-- It detects records where the `name` field contains multiple codes on a single line, separated by **semicolons** (`;`), **commas** (`,`), or **spaces**.
+- It detects records where the `name` field contains multiple codes on a single line, separated by **semicolons** (`;`) or **commas** (`,`).
 - Each such record is split into individual records — one per code — preserving `product_tmpl_id`, `sequence`, and `hide` from the original record.
+- **Spaces are never treated as a separator**: many OEM part numbers contain spaces (for example `366 200 05 01`), so a code is only split on an explicit delimiter.
+- A single code surrounded by stray delimiters (`12345, `) is cleaned up in place, without creating extra records.
 - The cron repeats on subsequent days until all multi-code records have been normalised.
 
 ## Configuration

--- a/deltatech_alternative/readme/HISTORY.md
+++ b/deltatech_alternative/readme/HISTORY.md
@@ -1,0 +1,14 @@
+## 18.0.2.1.8 (2026-07-27)
+
+- Fix: the daily *Alternative: Split multi-code records* cron treated a space as
+  a code delimiter, so every alternative code containing spaces was exploded
+  into meaningless fragments. An OEM code such as
+  `366 200 05 01 MERCEDES 366 200 15 01 MERCEDES` became `366`, `200`, `05`,
+  `01`, `MERCEDES`, ... — the original code no longer existed in the database
+  and the product could not be found by it any more. Because the cron runs
+  daily, it also re-broke records that had been repaired manually.
+  Codes are now split only on explicit delimiters (`;` and `,`).
+- A single code surrounded by stray delimiters (`12345, `) is now cleaned up in
+  place instead of being left untouched.
+- Tests: replaced the space-splitting test with tests asserting that codes
+  containing spaces are preserved, plus tests for stray delimiters.

--- a/deltatech_alternative/tests/test_split_codes.py
+++ b/deltatech_alternative/tests/test_split_codes.py
@@ -41,11 +41,18 @@ class TestSplitMultiCodes(TransactionCase):
         names = all_records.mapped("name")
         self.assertEqual(sorted(names), ["AAA", "BBB", "CCC"])
 
-    def test_split_by_space(self):
+    def test_no_split_by_space(self):
+        # Spaces are part of the code (OEM part numbers such as "366 200 05 01"),
+        # never a delimiter.
         self._make("X1 X2 X3")
         all_records = self._split_and_get(None)
-        names = all_records.mapped("name")
-        self.assertEqual(sorted(names), ["X1", "X2", "X3"])
+        self.assertEqual(all_records.mapped("name"), ["X1 X2 X3"])
+
+    def test_no_split_oem_code_with_spaces(self):
+        code = "366 200 05 01 MERCEDES 366 200 15 01 MERCEDES"
+        self._make(code)
+        all_records = self._split_and_get(None)
+        self.assertEqual(all_records.mapped("name"), [code])
 
     # ------------------------------------------------------------------
     # Separatori cu spații suplimentare
@@ -71,7 +78,21 @@ class TestSplitMultiCodes(TransactionCase):
         self._make("C1; C2, C3 C4")
         all_records = self._split_and_get(None)
         names = all_records.mapped("name")
-        self.assertEqual(sorted(names), ["C1", "C2", "C3", "C4"])
+        self.assertEqual(sorted(names), ["C1", "C2", "C3 C4"])
+
+    # ------------------------------------------------------------------
+    # Delimitator rătăcit în jurul unui singur cod
+    # ------------------------------------------------------------------
+
+    def test_stray_delimiter_is_trimmed(self):
+        self._make("98411382, ")
+        all_records = self._split_and_get(None)
+        self.assertEqual(all_records.mapped("name"), ["98411382"])
+
+    def test_stray_leading_delimiter_is_trimmed(self):
+        self._make("; 0018908711")
+        all_records = self._split_and_get(None)
+        self.assertEqual(all_records.mapped("name"), ["0018908711"])
 
     # ------------------------------------------------------------------
     # Record fără separator — nu trebuie atins


### PR DESCRIPTION
## Problem

The daily cron *Alternative: Split multi-code records* (added in #2471) treated a **space** as a code delimiter:

```python
codes = [c for c in re.split(r"[;,\s]+", name) if c]
```

Many OEM part numbers contain spaces. A Mercedes code entered on one line as

```
366 200 05 01 MERCEDES 366 200 15 01 MERCEDES 366 200 22 01 MERCEDES
```

was exploded into the separate records `366`, `200`, `05`, `01`, `MERCEDES`, `366`, `200`, `15`, ... The original code no longer existed anywhere in the database, so the product could no longer be found by it.

Because the cron runs **daily**, it also re-broke records that had been repaired manually — a repair applied in the evening was undone by the next morning.

Verified on the customer database: product `FLO10229` had a single alternative-code row turned into 39 fragments.

## Fix

- Codes are split only on explicit delimiters (`;` and `,`). Whitespace is never a delimiter.
- The domain no longer selects records merely because they contain a space.
- A single code surrounded by stray delimiters (`12345, `) is now cleaned up in place instead of being left untouched.

## Tests

`test_split_by_space` asserted the wrong behaviour and was replaced:

- `test_no_split_by_space` / `test_no_split_oem_code_with_spaces` — codes containing spaces are preserved
- `test_stray_delimiter_is_trimmed` / `test_stray_leading_delimiter_is_trimmed` — stray delimiters cleaned in place
- `test_split_mixed_separators` updated: `"C1; C2, C3 C4"` → `["C1", "C2", "C3 C4"]`

24 tests, 0 failures.

## Note on data repair

This stops the damage but does not repair already-split records. Databases where the cron has run need their alternative codes restored (from a backup or a re-import) **after** this fix is deployed, otherwise the cron undoes the repair again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)