### PR TITLE
[IMP] deltatech_website_product_code: exact-phrase search for codes with spaces

### DIFF
--- a/deltatech_website_product_code/__manifest__.py
+++ b/deltatech_website_product_code/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Code",
     "summary": "Display product by code in eCommerce",
     "category": "Website",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_product_code/models/product_template.py
+++ b/deltatech_website_product_code/models/product_template.py
@@ -6,7 +6,7 @@ import re
 
 from odoo import api, models
 from odoo.osv import expression
-from odoo.tools import escape_psql
+from odoo.tools import escape_psql, str2bool
 
 _CODE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-_./]{2,}$")
 
@@ -36,6 +36,18 @@ class ProductTemplate(models.Model):
 
     @api.model
     def _search_fetch(self, search_detail, search, limit, order):
+        # Codes may contain spaces (OEM part numbers such as "352 030 15 97").
+        # The default search splits the term on spaces and matches each piece
+        # separately, so searching for one such code returns every product
+        # containing "352" or "030" or "15" or "97" - pages of noise with the
+        # wanted product buried in the middle. When exact-phrase search is on,
+        # the whole term is matched as one string first; the per-term search is
+        # only used as a fallback, so pasted code lists keep working.
+        phrase = " ".join((search or "").split())
+        if " " in phrase and self._exact_phrase_search_enabled():
+            results, count = self._search_fetch_exact_phrase(search_detail, phrase, limit, order)
+            if count:
+                return results, count
         # When someone pastes a list of product codes into the shop search box,
         # the default domain ORs every term against every search field in one
         # WHERE clause. Some fields are plain columns (trigram-indexable) and
@@ -58,6 +70,25 @@ class ProductTemplate(models.Model):
         ):
             return self._search_fetch_multi_code(search_detail, terms, limit, order)
         return super()._search_fetch(search_detail, search, limit, order)
+
+    def _exact_phrase_search_enabled(self):
+        param = self.env["ir.config_parameter"].sudo().get_param("website_search.exact_phrase", "False")
+        return str2bool(param, False)
+
+    def _search_fetch_exact_phrase(self, search_detail, phrase, limit, order):
+        """Search the whole term as a single string, in any of the search fields."""
+        base_domain = search_detail["base_domain"]
+        model = self.sudo() if search_detail.get("requires_sudo") else self
+
+        subdomains = [[(field_name, "ilike", escape_psql(phrase))] for field_name in search_detail["search_fields"]]
+        extra = search_detail.get("search_extra")
+        if extra:
+            subdomains.append(extra(self.env, phrase))
+        domain = expression.AND(base_domain + [expression.OR(subdomains)])
+
+        results = model.search(domain, limit=limit, order=search_detail.get("order", order))
+        count = model.search_count(domain) if limit and limit == len(results) else len(results)
+        return results, count
 
     def _multi_code_min_terms(self):
         # False/0/empty/anything non-numeric disables the fast path, falling

--- a/deltatech_website_product_code/readme/DESCRIPTION.md
+++ b/deltatech_website_product_code/readme/DESCRIPTION.md
@@ -6,6 +6,8 @@
   - Fast search when several product codes are pasted at once in the shop
     search box (finds any matching product instead of requiring all codes
     to match the same product)
+  - Optional exact-phrase search, for catalogues whose codes contain
+    spaces (OEM part numbers such as ``352 030 15 97``)
 
 - Usage:
 
@@ -20,3 +22,10 @@
     number of code-looking terms (e.g. ``AMAT1-12345``) pasted together
     before the fast multi-code search kicks in. Set to ``False`` or ``0``
     to disable it and fall back to the regular search.
+  - ``website_search.exact_phrase`` (default ``False``): search the whole
+    term as a single string instead of splitting it on spaces. Enable it
+    for catalogues whose codes contain spaces, so that searching
+    ``352 030 15 97`` returns the product with that code instead of every
+    product containing ``352``, ``030``, ``15`` or ``97``. If no product
+    matches the whole term, the regular per-term search is used as a
+    fallback, so pasted code lists keep working.

--- a/deltatech_website_product_code/readme/HISTORY.rst
+++ b/deltatech_website_product_code/readme/HISTORY.rst
@@ -1,3 +1,19 @@
+18.0.1.3.0 (2026-07-27)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Added**
+
+- Optional exact-phrase search on the shop, new system parameter
+  ``website_search.exact_phrase`` (default ``False``). When enabled, the
+  search term is matched as one single string instead of being split on
+  spaces. Catalogues using OEM part numbers that contain spaces could not
+  be searched by code: looking for ``352 030 15 97`` matched every product
+  containing ``352`` or ``030`` or ``15`` or ``97``, returning pages of
+  results with the wanted product somewhere in the middle. If nothing
+  matches the whole term, the search falls back to the per-term behaviour,
+  so pasted code lists and partial-word searches are unaffected.
+- Tests for the exact-phrase search, including the fallback paths.
+
 18.0.1.2.0 (2026-07-20)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/deltatech_website_product_code/tests/__init__.py
+++ b/deltatech_website_product_code/tests/__init__.py
@@ -1,0 +1,5 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from . import test_exact_phrase_search

--- a/deltatech_website_product_code/tests/test_exact_phrase_search.py
+++ b/deltatech_website_product_code/tests/test_exact_phrase_search.py
@@ -1,0 +1,89 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestExactPhraseSearch(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env["website"].get_current_website()
+        cls.ProductTemplate = cls.env["product.template"]
+        cls.set_param = cls.env["ir.config_parameter"].sudo().set_param
+
+        # The wanted product: its code contains spaces, as OEM part numbers do.
+        cls.exact_product = cls._create_product("Bucsa ZQX", "ZQX 100 200 300")
+        # Noise: every term of the code above appears in the name, but not as a
+        # single string, so only the per-term search can match it.
+        cls.noise_product = cls._create_product("Suport ZQX 100 sau 200 ori 300", "ZQXNOISE")
+
+    @classmethod
+    def _create_product(cls, name, default_code):
+        return cls.ProductTemplate.create(
+            {
+                "name": name,
+                "default_code": default_code,
+                "is_published": True,
+                "website_sequence": 1,
+            }
+        )
+
+    def _search(self, search, limit=20):
+        options = {
+            "displayImage": False,
+            "displayDescription": False,
+            "displayExtraLink": False,
+            "displayDetail": False,
+        }
+        search_detail = self.ProductTemplate._search_get_detail(self.website, None, options)
+        results, _count = self.ProductTemplate._search_fetch(search_detail, search, limit, None)
+        return results
+
+    def test_disabled_by_default_splits_the_term(self):
+        results = self._search("ZQX 100 200 300")
+        self.assertIn(self.exact_product, results)
+        self.assertIn(self.noise_product, results, "without exact phrase search the term is split per word")
+
+    def test_exact_phrase_returns_only_the_matching_code(self):
+        self.set_param("website_search.exact_phrase", "True")
+        results = self._search("ZQX 100 200 300")
+        self.assertEqual(results, self.exact_product)
+
+    def test_exact_phrase_ignores_extra_whitespace(self):
+        self.set_param("website_search.exact_phrase", "True")
+        results = self._search("  ZQX   100 200  300 ")
+        self.assertEqual(results, self.exact_product)
+
+    def test_exact_phrase_matches_a_code_inside_a_longer_value(self):
+        # Alternative codes are often kept several per line; the searched code
+        # is then a substring of the stored value.
+        product = self._create_product("Bucsa ZQW", "ZQW 11 22 MERCEDES ZQW 33 44 MERCEDES")
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertEqual(self._search("ZQW 33 44"), product)
+
+    def test_exact_phrase_falls_back_when_the_phrase_has_no_match(self):
+        self.set_param("website_search.exact_phrase", "True")
+        # No product contains "ZQX 300 100" as a single string, so the search
+        # degrades to the per-term behaviour instead of returning nothing.
+        results = self._search("ZQX 300 100")
+        self.assertIn(self.exact_product, results)
+        self.assertIn(self.noise_product, results)
+
+    def test_exact_phrase_keeps_pasted_code_lists_working(self):
+        codes = ["ZQY111111", "ZQY222222", "ZQY333333", "ZQY444444"]
+        products = self.ProductTemplate.browse()
+        for code in codes[:2]:
+            products |= self._create_product(f"Rulment {code}", code)
+        self.set_param("website_search.exact_phrase", "True")
+        # The pasted list is not a phrase any product contains, so the
+        # multi-code fast path still resolves it.
+        results = self._search(" ".join(codes))
+        self.assertEqual(results, products)
+
+    def test_single_term_search_is_unaffected(self):
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertEqual(self._search("ZQXNOISE"), self.noise_product)

--- a/deltatech_website_product_code/tests/test_exact_phrase_search.py
+++ b/deltatech_website_product_code/tests/test_exact_phrase_search.py
@@ -33,11 +33,14 @@ class TestExactPhraseSearch(TransactionCase):
         )
 
     def _search(self, search, limit=20):
+        # Same options the shop controller passes, so that modules adjusting
+        # search_fields for the optional fields are exercised as in production.
         options = {
-            "displayImage": False,
-            "displayDescription": False,
-            "displayExtraLink": False,
-            "displayDetail": False,
+            "displayImage": True,
+            "displayDescription": True,
+            "displayExtraLink": True,
+            "displayDetail": True,
+            "display_currency": self.website.currency_id,
         }
         search_detail = self.ProductTemplate._search_get_detail(self.website, None, options)
         results, _count = self.ProductTemplate._search_fetch(search_detail, search, limit, None)


### PR DESCRIPTION
## Problem

Core `website.searchable.mixin._search_build_domain()` splits the search term on spaces and matches each piece separately. For catalogues whose product codes contain spaces — OEM part numbers such as `352 030 15 97` — a code can therefore not be searched at all: the search matches every product containing `352` **or** `030` **or** `15` **or** `97`, so the customer gets pages of results with the wanted product buried somewhere in the middle.

Reported by a customer selling agricultural/automotive parts, whose alternative codes are Mercedes-style part numbers.

## Solution

New system parameter `website_search.exact_phrase`:

- **default `False`** — no behaviour change for existing installations
- when enabled, the whole search term is matched as **one single string** against the search fields (name, code, variant code, and any field added by other modules such as `alternative_ids.name`)
- if nothing matches the whole term, the search **falls back** to the existing per-term behaviour

The fallback matters: it keeps the multi-code fast path (18.0.1.2.0) working, since a pasted list of different codes is never a phrase that any single product contains. It also avoids returning an empty shop page for ordinary multi-word searches.

Implemented in `_search_fetch()` rather than `_search_build_domain()`, so the result count is available to decide whether the fallback is needed. This covers both the `/shop` search page and the autocomplete dropdown, as both funnel through `_search_fetch()`.

Note: core `_search_find_fuzzy_term()` already returns multi-word terms unchanged, so fuzzy matching never rewrites a code containing spaces.

## Tests

New `tests/test_exact_phrase_search.py` (7 tests) covering:

- disabled by default → the term is still split per word
- enabled → only the product whose code matches the whole term
- extra/duplicate whitespace normalised
- a code found as a substring of a longer stored value (several codes on one line)
- fallback when the phrase matches nothing
- pasted code lists still resolved by the multi-code fast path
- single-term searches unaffected

Verified failing-then-passing (deliberately broken assertion first) so the suite is not passing vacuously.

## Configuration

```
website_search.exact_phrase = True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)