### PR TITLE
[FIX] deltatech_alternative_website: remove description fields only when present

### DIFF
--- a/deltatech_alternative_website/README.rst
+++ b/deltatech_alternative_website/README.rst
@@ -28,6 +28,21 @@ Website alternative code
 .. contents::
    :local:
 
+Changelog
+=========
+
+18.0.1.1.2 (2026-07-27)
+-----------------------
+
+- Fix: the website search (autocomplete and shop) raised
+  ``ValueError: list.remove(x): x not in list`` when the search bar
+  snippet had the description display turned off. ``website_sale`` only
+  adds ``description`` / ``description_sale`` to ``search_fields`` when
+  ``displayDescription`` is set, while this module removed them
+  unconditionally. They are now removed only when present.
+- Added tests for ``_search_get_detail`` with the description display on
+  and off.
+
 Bug Tracker
 ===========
 

--- a/deltatech_alternative_website/__manifest__.py
+++ b/deltatech_alternative_website/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Website alternative code",
     "summary": "Show alternative code in website",
-    "version": "18.0.1.1.1",
+    "version": "18.0.1.1.2",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_alternative_website/models/product_template.py
+++ b/deltatech_alternative_website/models/product_template.py
@@ -12,8 +12,12 @@ class ProductTemplate(models.Model):
     def _search_get_detail(self, website, order, options):
         values = super()._search_get_detail(website, order, options)
         values["search_fields"] += ["alternative_ids.name"]
-        values["search_fields"].remove("description")
-        values["search_fields"].remove("description_sale")
+        # website_sale only adds the description fields when the search bar is
+        # configured to display the description; removing them unconditionally
+        # raises ValueError when that option is off.
+        for field in ("description", "description_sale"):
+            if field in values["search_fields"]:
+                values["search_fields"].remove(field)
 
         values["mapping"]["alternative_ids.name"] = {"name": "alternative_ids.name", "type": "text", "match": True}
         return values

--- a/deltatech_alternative_website/readme/HISTORY.md
+++ b/deltatech_alternative_website/readme/HISTORY.md
@@ -1,0 +1,10 @@
+## 18.0.1.1.2 (2026-07-27)
+
+- Fix: the website search (autocomplete and shop) raised
+  `ValueError: list.remove(x): x not in list` when the search bar snippet
+  had the description display turned off. `website_sale` only adds
+  `description` / `description_sale` to `search_fields` when
+  `displayDescription` is set, while this module removed them
+  unconditionally. They are now removed only when present.
+- Added tests for `_search_get_detail` with the description display on and
+  off.

--- a/deltatech_alternative_website/static/description/index.html
+++ b/deltatech_alternative_website/static/description/index.html
@@ -379,31 +379,51 @@ ul.auto-toc {
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
-<li><a class="reference internal" href="#bug-tracker" id="toc-entry-1">Bug Tracker</a></li>
-<li><a class="reference internal" href="#credits" id="toc-entry-2">Credits</a><ul>
-<li><a class="reference internal" href="#authors" id="toc-entry-3">Authors</a></li>
-<li><a class="reference internal" href="#maintainers" id="toc-entry-4">Maintainers</a></li>
+<li><a class="reference internal" href="#changelog" id="toc-entry-1">Changelog</a><ul>
+<li><a class="reference internal" href="#section-1" id="toc-entry-2">18.0.1.1.2 (2026-07-27)</a></li>
+</ul>
+</li>
+<li><a class="reference internal" href="#bug-tracker" id="toc-entry-3">Bug Tracker</a></li>
+<li><a class="reference internal" href="#credits" id="toc-entry-4">Credits</a><ul>
+<li><a class="reference internal" href="#authors" id="toc-entry-5">Authors</a></li>
+<li><a class="reference internal" href="#maintainers" id="toc-entry-6">Maintainers</a></li>
 </ul>
 </li>
 </ul>
 </div>
+<div class="section" id="changelog">
+<h1><a class="toc-backref" href="#toc-entry-1">Changelog</a></h1>
+<div class="section" id="section-1">
+<h2><a class="toc-backref" href="#toc-entry-2">18.0.1.1.2 (2026-07-27)</a></h2>
+<ul class="simple">
+<li>Fix: the website search (autocomplete and shop) raised
+<tt class="docutils literal">ValueError: list.remove(x): x not in list</tt> when the search bar
+snippet had the description display turned off. <tt class="docutils literal">website_sale</tt> only
+adds <tt class="docutils literal">description</tt> / <tt class="docutils literal">description_sale</tt> to <tt class="docutils literal">search_fields</tt> when
+<tt class="docutils literal">displayDescription</tt> is set, while this module removed them
+unconditionally. They are now removed only when present.</li>
+<li>Added tests for <tt class="docutils literal">_search_get_detail</tt> with the description display on
+and off.</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
-<h1><a class="toc-backref" href="#toc-entry-1">Bug Tracker</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-3">Bug Tracker</a></h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.
 In case of trouble, please check there if your issue has already been reported.</p>
 <p>Do not contact contributors directly about support or help with technical issues.</p>
 </div>
 <div class="section" id="credits">
-<h1><a class="toc-backref" href="#toc-entry-2">Credits</a></h1>
+<h1><a class="toc-backref" href="#toc-entry-4">Credits</a></h1>
 <div class="section" id="authors">
-<h2><a class="toc-backref" href="#toc-entry-3">Authors</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-5">Authors</a></h2>
 <ul class="simple">
 <li>Terrabit</li>
 <li>Dorin Hongu</li>
 </ul>
 </div>
 <div class="section" id="maintainers">
-<h2><a class="toc-backref" href="#toc-entry-4">Maintainers</a></h2>
+<h2><a class="toc-backref" href="#toc-entry-6">Maintainers</a></h2>
 <p>Current maintainer:</p>
 <p><a class="reference external image-reference" href="https://github.com/dhongu"><img alt="dhongu" src="https://github.com/dhongu.png?size=40px" /></a></p>
 <p>This module is part of the <a class="reference external" href="https://github.com/dhongu/deltatech/tree/18.0/deltatech_alternative_website">dhongu/deltatech</a> project on GitHub.</p>

--- a/deltatech_alternative_website/tests/__init__.py
+++ b/deltatech_alternative_website/tests/__init__.py
@@ -3,3 +3,4 @@
 # See README.rst file on addons root folder for license details
 
 from . import test_controller
+from . import test_search_get_detail

--- a/deltatech_alternative_website/tests/test_search_get_detail.py
+++ b/deltatech_alternative_website/tests/test_search_get_detail.py
@@ -1,0 +1,46 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestSearchGetDetail(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env["website"].get_current_website()
+        cls.ProductTemplate = cls.env["product.template"]
+
+    def _search_detail(self, display_description):
+        # Same options the search bar snippet posts to
+        # /website/snippet/autocomplete, where every display option can be
+        # turned off from the website editor.
+        options = {
+            "displayImage": True,
+            "displayDescription": display_description,
+            "displayExtraLink": True,
+            "displayDetail": True,
+            "display_currency": self.website.currency_id,
+        }
+        return self.ProductTemplate._search_get_detail(self.website, None, options)
+
+    def test_alternative_code_is_searchable(self):
+        detail = self._search_detail(True)
+        self.assertIn("alternative_ids.name", detail["search_fields"])
+        self.assertIn("alternative_ids.name", detail["mapping"])
+
+    def test_description_is_dropped_when_displayed(self):
+        detail = self._search_detail(True)
+        self.assertNotIn("description", detail["search_fields"])
+        self.assertNotIn("description_sale", detail["search_fields"])
+
+    def test_description_not_displayed(self):
+        # website_sale does not add the description fields at all in this case,
+        # so removing them must not raise.
+        detail = self._search_detail(False)
+        self.assertNotIn("description", detail["search_fields"])
+        self.assertNotIn("description_sale", detail["search_fields"])
+        self.assertIn("alternative_ids.name", detail["search_fields"])


### PR DESCRIPTION
## Problem

`product.template._search_get_detail` removed `description` and `description_sale` from `search_fields` unconditionally:

```python
values["search_fields"].remove("description")
values["search_fields"].remove("description_sale")
```

But `website_sale` adds those fields **only** when the search options carry `displayDescription: True` (see `odoo/addons/website_sale/models/product_template.py`, `with_description`). The search bar snippet posts `displayDescription: false` to `/website/snippet/autocomplete` whenever the *Description* display option is turned off in the website editor, so the override raised:

```
ValueError: list.remove(x): x not in list
```

→ HTTP 500 on autocomplete and on the shop search. Reproduced on the flodel18 database by calling `_search_get_detail` with `displayDescription: False`.

## Fix

Remove each field only if it is present.

## Tests

New `tests/test_search_get_detail.py` calls `_search_get_detail` with the description display both on and off, and checks the alternative code stays searchable.

Verified on `o18_test_alt`:
- with the fix: `0 failed, 0 error(s) of 3 tests`
- with the previous code: `0 failed, 1 error(s) of 3 tests` (`ValueError: list.remove(x): x not in list`)

Version bumped to `18.0.1.1.2`, `readme/HISTORY.md` created, README/index regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)