### PR TITLE
[FIX] deltatech_alternative_website: remove description fields only when present (19.0 port)

### DIFF
--- a/deltatech_alternative_website/README.rst
+++ b/deltatech_alternative_website/README.rst
@@ -104,6 +104,21 @@ edit them:
 3. Add one or more alternative/cross-reference codes. These codes will
    immediately be searchable on the website.
 
+Changelog
+=========
+
+19.0.1.0.8 (2026-07-27)
+-----------------------
+
+- Fix: the website search (autocomplete and shop) raised
+  ``ValueError: list.remove(x): x not in list`` when the search bar
+  snippet had the description display turned off. ``website_sale`` only
+  adds ``description`` / ``description_sale`` to ``search_fields`` when
+  ``displayDescription`` is set, while this module removed them
+  unconditionally. They are now removed only when present.
+- Added tests for ``_search_get_detail`` with the description display on
+  and off.
+
 Bug Tracker
 ===========
 

--- a/deltatech_alternative_website/__manifest__.py
+++ b/deltatech_alternative_website/__manifest__.py
@@ -6,7 +6,7 @@
 {
     "name": "Website alternative code",
     "summary": "Show alternative code in website",
-    "version": "19.0.1.0.7",
+    "version": "19.0.1.0.8",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_alternative_website/models/product_template.py
+++ b/deltatech_alternative_website/models/product_template.py
@@ -12,8 +12,12 @@ class ProductTemplate(models.Model):
     def _search_get_detail(self, website, order, options):
         values = super()._search_get_detail(website, order, options)
         values["search_fields"] += ["alternative_ids.name"]
-        values["search_fields"].remove("description")
-        values["search_fields"].remove("description_sale")
+        # website_sale only adds the description fields when the search bar is
+        # configured to display the description; removing them unconditionally
+        # raises ValueError when that option is off.
+        for field in ("description", "description_sale"):
+            if field in values["search_fields"]:
+                values["search_fields"].remove(field)
 
         values["mapping"]["alternative_ids.name"] = {"name": "alternative_ids.name", "type": "text", "match": True}
         return values

--- a/deltatech_alternative_website/readme/HISTORY.md
+++ b/deltatech_alternative_website/readme/HISTORY.md
@@ -1,0 +1,10 @@
+## 19.0.1.0.8 (2026-07-27)
+
+- Fix: the website search (autocomplete and shop) raised
+  `ValueError: list.remove(x): x not in list` when the search bar snippet
+  had the description display turned off. `website_sale` only adds
+  `description` / `description_sale` to `search_fields` when
+  `displayDescription` is set, while this module removed them
+  unconditionally. They are now removed only when present.
+- Added tests for `_search_get_detail` with the description display on and
+  off.

--- a/deltatech_alternative_website/tests/__init__.py
+++ b/deltatech_alternative_website/tests/__init__.py
@@ -3,3 +3,4 @@
 # See README.rst file on addons root folder for license details
 
 from . import test_controller
+from . import test_search_get_detail

--- a/deltatech_alternative_website/tests/test_search_get_detail.py
+++ b/deltatech_alternative_website/tests/test_search_get_detail.py
@@ -1,0 +1,46 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestSearchGetDetail(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env["website"].get_current_website()
+        cls.ProductTemplate = cls.env["product.template"]
+
+    def _search_detail(self, display_description):
+        # Same options the search bar snippet posts to
+        # /website/snippet/autocomplete, where every display option can be
+        # turned off from the website editor.
+        options = {
+            "displayImage": True,
+            "displayDescription": display_description,
+            "displayExtraLink": True,
+            "displayDetail": True,
+            "display_currency": self.website.currency_id,
+        }
+        return self.ProductTemplate._search_get_detail(self.website, None, options)
+
+    def test_alternative_code_is_searchable(self):
+        detail = self._search_detail(True)
+        self.assertIn("alternative_ids.name", detail["search_fields"])
+        self.assertIn("alternative_ids.name", detail["mapping"])
+
+    def test_description_is_dropped_when_displayed(self):
+        detail = self._search_detail(True)
+        self.assertNotIn("description", detail["search_fields"])
+        self.assertNotIn("description_sale", detail["search_fields"])
+
+    def test_description_not_displayed(self):
+        # website_sale does not add the description fields at all in this case,
+        # so removing them must not raise.
+        detail = self._search_detail(False)
+        self.assertNotIn("description", detail["search_fields"])
+        self.assertNotIn("description_sale", detail["search_fields"])
+        self.assertIn("alternative_ids.name", detail["search_fields"])


### PR DESCRIPTION
Port pe 19.0 al PR #2681 (merged în 18.0). Cherry-pick-ul automat a intrat în conflict (versiune din manifest, README/index), așa că portul e făcut manual.

## Problem

`product.template._search_get_detail` elimina `description` și `description_sale` din `search_fields` necondiționat, dar `website_sale` le adaugă doar când opțiunile de căutare conțin `displayDescription: True` (identic în core 19.0, `odoo/addons/website_sale/models/product_template.py`). Cu opțiunea *Description* dezactivată în editorul de website, snippet-ul de căutare trimite `displayDescription: false` la `/website/snippet/autocomplete` și override-ul ridica:

```
ValueError: list.remove(x): x not in list
```

→ eroare 500 la autocomplete și la căutarea din shop.

## Fix

Fiecare câmp e eliminat doar dacă e prezent.

## Tests

`tests/test_search_get_detail.py` apelează `_search_get_detail` cu afișarea descrierii pornită și oprită, și verifică faptul că codul alternativ rămâne în `search_fields`/`mapping`.

Verificat pe baza `o19_test` (install curat): `0 failed, 0 error(s) of 3 tests`.

Versiune `19.0.1.0.7` → `19.0.1.0.8`, `readme/HISTORY.md` creat, README.rst regenerat. `static/description/index.html` nu e inclus: regenerarea lui aduce și migrarea tb-skin v4→v5 plus drift de versiune docutils, fără legătură cu fix-ul.

🤖 Generated with [Claude Code](https://claude.com/claude-code)