### PR TITLE
[IMP] deltatech_website_product_code: exact-phrase search for codes with spaces (19.0 port)

### DIFF
--- a/deltatech_website_product_code/__manifest__.py
+++ b/deltatech_website_product_code/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Code",
     "summary": "Display product by code in eCommerce",
     "category": "Website",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.1.0",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_product_code/models/product_template.py
+++ b/deltatech_website_product_code/models/product_template.py
@@ -2,11 +2,47 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
-from odoo import models
+from odoo import api, models
+from odoo.fields import Domain
+from odoo.tools import escape_psql, str2bool
 
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+
+    @api.model
+    def _search_fetch(self, search_detail, search, limit, order):
+        # Codes may contain spaces (OEM part numbers such as "352 030 15 97").
+        # The default search splits the term on spaces and matches each piece
+        # separately, so searching for one such code returns every product
+        # containing "352" or "030" or "15" or "97" - pages of noise with the
+        # wanted product buried in the middle. When exact-phrase search is on,
+        # the whole term is matched as one string first; the per-term search is
+        # only used as a fallback, so partial-word searches keep working.
+        phrase = " ".join((search or "").split())
+        if " " in phrase and self._exact_phrase_search_enabled():
+            results, count = self._search_fetch_exact_phrase(search_detail, phrase, limit, order)
+            if count:
+                return results, count
+        return super()._search_fetch(search_detail, search, limit, order)
+
+    def _exact_phrase_search_enabled(self):
+        param = self.env["ir.config_parameter"].sudo().get_param("website_search.exact_phrase", "False")
+        return str2bool(param, False)
+
+    def _search_fetch_exact_phrase(self, search_detail, phrase, limit, order):
+        """Search the whole term as a single string, in any of the search fields."""
+        model = self.sudo() if search_detail.get("requires_sudo") else self
+
+        subdomains = [Domain(field_name, "ilike", escape_psql(phrase)) for field_name in search_detail["search_fields"]]
+        extra = search_detail.get("search_extra")
+        if extra:
+            subdomains.append(extra(self.env, phrase))
+        domain = Domain.AND(search_detail["base_domain"]) & Domain.OR(subdomains)
+
+        results = model.search(domain, limit=limit, order=search_detail.get("order", order))
+        count = model.search_count(domain) if limit and limit == len(results) else len(results)
+        return results, count
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):
         fetch_fields += ["default_code", "display_name"]

--- a/deltatech_website_product_code/readme/DESCRIPTION.md
+++ b/deltatech_website_product_code/readme/DESCRIPTION.md
@@ -3,7 +3,19 @@
   - Display product page using internal code
   - Display product code in product page
   - Display product code in search results
+  - Optional exact-phrase search, for catalogues whose codes contain
+    spaces (OEM part numbers such as ``352 030 15 97``)
 
 - Usage:
 
   - Use link: /shop/product-code/\<code\>
+
+- Configuration (optional, System Parameters):
+
+  - ``website_search.exact_phrase`` (default ``False``): search the whole
+    term as a single string instead of splitting it on spaces. Enable it
+    for catalogues whose codes contain spaces, so that searching
+    ``352 030 15 97`` returns the product with that code instead of every
+    product containing ``352``, ``030``, ``15`` or ``97``. If no product
+    matches the whole term, the regular per-term search is used as a
+    fallback.

--- a/deltatech_website_product_code/readme/HISTORY.md
+++ b/deltatech_website_product_code/readme/HISTORY.md
@@ -1,0 +1,13 @@
+## 19.0.1.1.0 (2026-07-27)
+
+- Optional exact-phrase search on the shop, new system parameter
+  `website_search.exact_phrase` (default `False`). When enabled, the search
+  term is matched as one single string instead of being split on spaces.
+  Catalogues using OEM part numbers that contain spaces could not be searched
+  by code: looking for `352 030 15 97` matched every product containing `352`
+  or `030` or `15` or `97`, returning pages of results with the wanted product
+  somewhere in the middle. If nothing matches the whole term, the search falls
+  back to the per-term behaviour, so partial-word searches are unaffected.
+  Ported from 18.0.1.3.0; uses `odoo.fields.Domain` instead of the deprecated
+  `odoo.osv.expression` helpers.
+- Tests for the exact-phrase search, including the fallback paths.

--- a/deltatech_website_product_code/tests/__init__.py
+++ b/deltatech_website_product_code/tests/__init__.py
@@ -2,5 +2,6 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+from . import test_exact_phrase_search
 from . import test_product_code
 from . import test_website_product_code

--- a/deltatech_website_product_code/tests/test_exact_phrase_search.py
+++ b/deltatech_website_product_code/tests/test_exact_phrase_search.py
@@ -1,0 +1,82 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests import tagged
+from odoo.tests.common import TransactionCase
+
+
+@tagged("post_install", "-at_install")
+class TestExactPhraseSearch(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.website = cls.env["website"].get_current_website()
+        cls.ProductTemplate = cls.env["product.template"]
+        cls.set_param = cls.env["ir.config_parameter"].sudo().set_param
+
+        # The wanted product: its code contains spaces, as OEM part numbers do.
+        cls.exact_product = cls._create_product("Bucsa ZQX", "ZQX 100 200 300")
+        # Noise: every term of the code above appears in the name, but not as a
+        # single string, so only the per-term search can match it.
+        cls.noise_product = cls._create_product("Suport ZQX 100 sau 200 ori 300", "ZQXNOISE")
+
+    @classmethod
+    def _create_product(cls, name, default_code):
+        return cls.ProductTemplate.create(
+            {
+                "name": name,
+                "default_code": default_code,
+                "type": "consu",
+                "is_published": True,
+                "website_sequence": 1,
+            }
+        )
+
+    def _search(self, search, limit=20):
+        # Same options the shop controller passes, so that modules adjusting
+        # search_fields for the optional fields are exercised as in production.
+        options = {
+            "displayImage": True,
+            "displayDescription": True,
+            "displayExtraLink": True,
+            "displayDetail": True,
+            "display_currency": self.website.currency_id,
+        }
+        search_detail = self.ProductTemplate._search_get_detail(self.website, None, options)
+        results, _count = self.ProductTemplate._search_fetch(search_detail, search, limit, None)
+        return results
+
+    def test_disabled_by_default_splits_the_term(self):
+        results = self._search("ZQX 100 200 300")
+        self.assertIn(self.exact_product, results)
+        self.assertIn(self.noise_product, results, "without exact phrase search the term is split per word")
+
+    def test_exact_phrase_returns_only_the_matching_code(self):
+        self.set_param("website_search.exact_phrase", "True")
+        results = self._search("ZQX 100 200 300")
+        self.assertEqual(results, self.exact_product)
+
+    def test_exact_phrase_ignores_extra_whitespace(self):
+        self.set_param("website_search.exact_phrase", "True")
+        results = self._search("  ZQX   100 200  300 ")
+        self.assertEqual(results, self.exact_product)
+
+    def test_exact_phrase_matches_a_code_inside_a_longer_value(self):
+        # Codes are often kept several per line; the searched code is then a
+        # substring of the stored value.
+        product = self._create_product("Bucsa ZQW", "ZQW 11 22 MERCEDES ZQW 33 44 MERCEDES")
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertEqual(self._search("ZQW 33 44"), product)
+
+    def test_exact_phrase_falls_back_when_the_phrase_has_no_match(self):
+        self.set_param("website_search.exact_phrase", "True")
+        # No product contains "ZQX 300 100" as a single string, so the search
+        # degrades to the per-term behaviour instead of returning nothing.
+        results = self._search("ZQX 300 100")
+        self.assertIn(self.exact_product, results)
+        self.assertIn(self.noise_product, results)
+
+    def test_single_term_search_is_unaffected(self):
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertEqual(self._search("ZQXNOISE"), self.noise_product)


### PR DESCRIPTION
Port of **18.0.1.3.0** — dhongu/deltatech#2680. Helpdesk ticket #9007 (FLODEL).

The `auto-port` workflow ran but could not cherry-pick this one: on 19.0 there is no `readme/HISTORY.rst` (modify/delete) and the module already ships a `tests` package (add/add), so both files conflicted and manual porting was required.

## Problem

Core `website.searchable.mixin._search_build_domain()` splits the search term on spaces and matches each piece separately. For catalogues whose product codes contain spaces — OEM part numbers such as `352 030 15 97` — a code cannot be searched at all: the search matches every product containing `352` **or** `030` **or** `15` **or** `97`.

Measured on the customer's production catalogue: searching `366 200 05 01` returned **60** products; with this change it returns **2** (both legitimately carrying that code).

## Solution

New system parameter `website_search.exact_phrase`, **default `False`** — no behaviour change unless enabled. When on, the whole term is matched as a single string against the search fields; if nothing matches the whole term, the search falls back to the per-term behaviour so ordinary multi-word searches never return an empty shop page.

## Differences from the 18.0 version

- Domains are built with `odoo.fields.Domain` (`Domain.AND` / `Domain.OR` / `&`) instead of `odoo.osv.expression.AND/OR`, which raise `DeprecationWarning` since 19.0. This follows what core `_search_build_domain` itself does on 19.0.
- On 18.0 the fallback chains into the pasted-code-list fast path (18.0.1.2.0). That feature was never ported to 19.0, so here the fallback calls `super()` directly. Nothing is lost; the two are independent.
- `readme/HISTORY.md` created (19.0 had no history file for this addon).

Note that 19.0 is generally behind 18.0 for this addon (19.0.1.0.2 vs 18.0.1.3.0): the `min_term_length` filter (18.0.1.1.0) and the multi-code fast path (18.0.1.2.0) are still unported. Deliberately out of scope here.

## Tests

`tests/test_exact_phrase_search.py`, 6 tests: disabled-by-default behaviour, exact match, whitespace normalisation, a code found inside a longer stored value, the no-match fallback, and single-term searches.

Run against Odoo 19 core: **19 tests, 0 failures** for the addon. Verified non-vacuous by deliberately breaking an assertion first and confirming the failure was reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)