### PR TITLE
[FIX] deltatech_website_product_code: don't OR-expand a missing code in exact-phrase mode

### DIFF
--- a/deltatech_website_product_code/__manifest__.py
+++ b/deltatech_website_product_code/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Code",
     "summary": "Display product by code in eCommerce",
     "category": "Website",
-    "version": "18.0.1.3.0",
+    "version": "18.0.1.3.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_product_code/models/product_template.py
+++ b/deltatech_website_product_code/models/product_template.py
@@ -41,10 +41,11 @@ class ProductTemplate(models.Model):
         # separately, so searching for one such code returns every product
         # containing "352" or "030" or "15" or "97" - pages of noise with the
         # wanted product buried in the middle. When exact-phrase search is on,
-        # the whole term is matched as one string first; the per-term search is
-        # only used as a fallback, so pasted code lists keep working.
+        # the whole term is matched as one string first, and only the per-term
+        # AND search of the mixin is used as a fallback.
         phrase = " ".join((search or "").split())
-        if " " in phrase and self._exact_phrase_search_enabled():
+        exact_phrase = " " in phrase and self._exact_phrase_search_enabled()
+        if exact_phrase:
             results, count = self._search_fetch_exact_phrase(search_detail, phrase, limit, order)
             if count:
                 return results, count
@@ -60,10 +61,17 @@ class ProductTemplate(models.Model):
         # Searching one field at a time instead (still ORing all terms within
         # each field) lets every branch use its own index; ~500x faster on the
         # same data, same results (still ORed/deduped across all fields).
+        # This must not run in exact-phrase mode: there, a term containing
+        # spaces is one code, not a list of codes, so ORing its groups produces
+        # exactly the noise that mode exists to remove. A code such as
+        # "999 888 777 666" would otherwise match every product containing any
+        # of the four groups - measured at 472 results on a 10k-product
+        # catalogue, where the per-term AND fallback returns none.
         terms = [t for t in (search or "").split(" ") if t.strip()]
         min_terms = self._multi_code_min_terms()
         if (
-            min_terms
+            not exact_phrase
+            and min_terms
             and len(terms) >= min_terms
             and not search_detail.get("search_extra")
             and all(_looks_like_code(t) for t in terms)

--- a/deltatech_website_product_code/readme/DESCRIPTION.md
+++ b/deltatech_website_product_code/readme/DESCRIPTION.md
@@ -28,4 +28,6 @@
     ``352 030 15 97`` returns the product with that code instead of every
     product containing ``352``, ``030``, ``15`` or ``97``. If no product
     matches the whole term, the regular per-term search is used as a
-    fallback, so pasted code lists keep working.
+    fallback. Note that the multi-code fast path above is disabled while
+    this is on, since a term containing spaces is then one code rather
+    than a list of codes.

--- a/deltatech_website_product_code/readme/HISTORY.rst
+++ b/deltatech_website_product_code/readme/HISTORY.rst
@@ -1,3 +1,18 @@
+18.0.1.3.1 (2026-07-27)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Fixed**
+
+- Exact-phrase search no longer chains its fallback into the pasted-code-list
+  fast path. A code whose groups each look like a standalone code, for example
+  ``999 888 777 666``, was treated as four pasted codes when the whole term
+  matched nothing, so the search returned every product containing any single
+  group - measured at 472 results on a 10 000-product catalogue, where the
+  per-term fallback returns none. In exact-phrase mode a term containing spaces
+  is one code, so the OR expansion is now skipped and the search falls back to
+  the per-term AND behaviour of the mixin. The fast path is unchanged when
+  ``website_search.exact_phrase`` is off.
+
 18.0.1.3.0 (2026-07-27)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/deltatech_website_product_code/tests/test_exact_phrase_search.py
+++ b/deltatech_website_product_code/tests/test_exact_phrase_search.py
@@ -76,16 +76,31 @@ class TestExactPhraseSearch(TransactionCase):
         self.assertIn(self.exact_product, results)
         self.assertIn(self.noise_product, results)
 
-    def test_exact_phrase_keeps_pasted_code_lists_working(self):
+    def test_exact_phrase_does_not_or_expand_a_missing_code(self):
+        # "100 200 300 999" looks like four pasted codes to the multi-code fast
+        # path, which would OR them and return every product containing any one
+        # group - the very noise exact-phrase search exists to remove. In this
+        # mode a spaced term is one code, so a missing code returns nothing
+        # rather than an OR expansion.
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertFalse(self._search("100 200 300 999"))
+
+    def test_pasted_code_lists_still_work_when_exact_phrase_is_off(self):
         codes = ["ZQY111111", "ZQY222222", "ZQY333333", "ZQY444444"]
         products = self.ProductTemplate.browse()
         for code in codes[:2]:
             products |= self._create_product(f"Rulment {code}", code)
+        # Default configuration: the multi-code fast path resolves the list.
+        self.assertEqual(self._search(" ".join(codes)), products)
+
+    def test_pasted_code_lists_are_not_or_expanded_with_exact_phrase(self):
+        codes = ["ZQY111111", "ZQY222222", "ZQY333333", "ZQY444444"]
+        for code in codes[:2]:
+            self._create_product(f"Rulment {code}", code)
         self.set_param("website_search.exact_phrase", "True")
-        # The pasted list is not a phrase any product contains, so the
-        # multi-code fast path still resolves it.
-        results = self._search(" ".join(codes))
-        self.assertEqual(results, products)
+        # No product carries all four codes, and the OR path is off in this
+        # mode, so the list resolves to nothing.
+        self.assertFalse(self._search(" ".join(codes)))
 
     def test_single_term_search_is_unaffected(self):
         self.set_param("website_search.exact_phrase", "True")


### PR DESCRIPTION
Follow-up to dhongu/deltatech#2680, found while verifying it on the customer's staging build (helpdesk ticket #9007).

## Symptom

Same catalogue, same data, via the public `/website/snippet/autocomplete` endpoint:

| search term | production (without the feature) | staging (18.0.1.3.0) |
|---|---|---|
| `366 200 05 01` (real code) | 60 | **2** ✅ |
| `999 888 777 666` (no such code) | 0 | **472** ❌ |

The second row is the opposite of what the feature is for.

## Cause

When the whole term matched nothing, the fallback chained into the pasted-code-list fast path added in 18.0.1.2.0. Every group of `999 888 777 666` satisfies `_looks_like_code` (at least 3 characters, contains a digit) and there are 4 of them, which is `website_search.multi_code_min_terms`. So the term was treated as four pasted codes and ORed together, matching every product containing any single group.

Narrow but reachable trigger: 4+ groups of 3+ characters each, with the whole code absent from the catalogue. Verified by bisecting the term on staging — 3 groups returned 4 results (per-term AND), 4 groups returned 472. Mercedes-style codes such as `352 030 15 97` end in 2-character groups, which is why the original testing did not surface it.

## Fix

In exact-phrase mode a term containing spaces is one code, not a list of codes, so the OR expansion is skipped and the search falls back to the per-term AND behaviour of the mixin (0 results for a missing code, same as before the feature).

The fast path is untouched when `website_search.exact_phrase` is off, which is the default, so no other installation changes behaviour. The trade-off is explicit: a site cannot have both exact-phrase search and pasted-code-list OR search, because the two make opposite assumptions about what spaces mean.

## Tests

- `test_exact_phrase_does_not_or_expand_a_missing_code` — the regression itself
- `test_pasted_code_lists_still_work_when_exact_phrase_is_off` — the fast path is preserved by default
- `test_pasted_code_lists_are_not_or_expanded_with_exact_phrase` — documents the trade-off

Replaces `test_exact_phrase_keeps_pasted_code_lists_working`, which asserted the behaviour being removed.

Both new tests were verified to fail with the guard removed and pass with it in place. Full suite: 11 tests for this addon, 27 including `deltatech_alternative`, 0 failures.

## 19.0

Not applicable: the pasted-code-list fast path (18.0.1.2.0) was never ported to 19.0, so the 19.0 version (dhongu/deltatech#2683) has nothing to chain into and is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)