### PR TITLE
[IMP] deltatech_website_product_code: bring the search to parity with 18.0

### DIFF
--- a/deltatech_website_product_code/__manifest__.py
+++ b/deltatech_website_product_code/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Code",
     "summary": "Display product by code in eCommerce",
     "category": "Website",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_product_code/models/product_template.py
+++ b/deltatech_website_product_code/models/product_template.py
@@ -2,13 +2,37 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+import re
+
 from odoo import api, models
 from odoo.fields import Domain
 from odoo.tools import escape_psql, str2bool
 
+_CODE_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9\-_./]{2,}$")
+
+
+def _looks_like_code(term):
+    return bool(_CODE_RE.match(term)) and any(ch.isdigit() for ch in term)
+
 
 class ProductTemplate(models.Model):
     _inherit = "product.template"
+
+    @api.model
+    def _search_build_domain(self, domain_list, search, fields, extra=None):
+        # Drop search terms shorter than the configured minimum length, but only
+        # when at least one usable term remains. Short terms (1-2 chars) cannot
+        # use the GIN trigram indexes (pg_trgm needs >= 3 chars), so they force
+        # sequential scans on product.product / product.alternative while adding
+        # almost no selectivity. If every term is short, the search is kept
+        # intact to preserve correctness over speed.
+        if search:
+            min_len = int(self.env["ir.config_parameter"].sudo().get_param("website_search.min_term_length", 3))
+            terms = search.split()
+            long_terms = [term for term in terms if len(term) >= min_len]
+            if long_terms and len(long_terms) != len(terms):
+                search = " ".join(long_terms)
+        return super()._search_build_domain(domain_list, search, fields, extra=extra)
 
     @api.model
     def _search_fetch(self, search_detail, search, limit, order):
@@ -17,13 +41,41 @@ class ProductTemplate(models.Model):
         # separately, so searching for one such code returns every product
         # containing "352" or "030" or "15" or "97" - pages of noise with the
         # wanted product buried in the middle. When exact-phrase search is on,
-        # the whole term is matched as one string first; the per-term search is
-        # only used as a fallback, so partial-word searches keep working.
+        # the whole term is matched as one string first, and the per-term search
+        # is only used as a fallback.
         phrase = " ".join((search or "").split())
-        if " " in phrase and self._exact_phrase_search_enabled():
+        exact_phrase = " " in phrase and self._exact_phrase_search_enabled()
+        if exact_phrase:
             results, count = self._search_fetch_exact_phrase(search_detail, phrase, limit, order)
             if count:
                 return results, count
+        # When someone pastes a list of product codes into the shop search box,
+        # the default domain ORs every term against every search field in one
+        # WHERE clause. Some fields are plain columns (trigram-indexable) and
+        # some are relational (product_variant_ids.*, alternative_ids.*, resolved
+        # via subqueries); PostgreSQL can't build one combined bitmap plan across
+        # a mix of column and subquery conditions joined by OR, so with
+        # ORDER BY website_sequence LIMIT N it falls back to scanning the table
+        # in that order and evaluating the whole filter per row - measured at
+        # ~10s for 14 pasted codes against ~123k products (EXPLAIN ANALYZE).
+        # Searching one field at a time instead (still ORing all terms within
+        # each field) lets every branch use its own index; ~500x faster on the
+        # same data, same results (still ORed/deduped across all fields).
+        # In exact-phrase mode the terms must additionally look like standalone
+        # codes rather than the groups of one spaced code. A code such as
+        # "999 888 777 666" would otherwise match every product containing any
+        # of its four groups - measured at 472 results on a 10k-product
+        # catalogue, where the per-term AND fallback returns none.
+        terms = [t for t in (search or "").split(" ") if t.strip()]
+        min_terms = self._multi_code_min_terms()
+        code_test = self._looks_like_standalone_code if exact_phrase else _looks_like_code
+        if (
+            min_terms
+            and len(terms) >= min_terms
+            and not search_detail.get("search_extra")
+            and all(code_test(t) for t in terms)
+        ):
+            return self._search_fetch_multi_code(search_detail, terms, limit, order)
         return super()._search_fetch(search_detail, search, limit, order)
 
     def _exact_phrase_search_enabled(self):
@@ -42,6 +94,51 @@ class ProductTemplate(models.Model):
 
         results = model.search(domain, limit=limit, order=search_detail.get("order", order))
         count = model.search_count(domain) if limit and limit == len(results) else len(results)
+        return results, count
+
+    def _looks_like_standalone_code(self, term):
+        # Tells a pasted list of whole codes apart from the groups of a single
+        # code written with spaces. OEM part numbers are split into short
+        # groups ("366 200 05 01", "0798 318 0" - one to four characters each),
+        # while a code that stands on its own is longer. Measured over the
+        # ~6 800 spaced codes of an agricultural-parts catalogue: no single code
+        # reached four groups of five characters or more, whereas the rows
+        # holding several codes on one line consistently did.
+        min_length = self._standalone_code_min_length()
+        return _looks_like_code(term) and (not min_length or len(term) >= min_length)
+
+    def _standalone_code_min_length(self):
+        param = self.env["ir.config_parameter"].sudo().get_param("website_search.standalone_code_min_length", "5")
+        try:
+            return int(param)
+        except (ValueError, TypeError):
+            return 0
+
+    def _multi_code_min_terms(self):
+        # False/0/empty/anything non-numeric disables the fast path, falling
+        # back to the legacy behavior - int("False") would otherwise raise.
+        param = self.env["ir.config_parameter"].sudo().get_param("website_search.multi_code_min_terms", "4")
+        try:
+            return int(param)
+        except (ValueError, TypeError):
+            return 0
+
+    def _search_fetch_multi_code(self, search_detail, terms, limit, order):
+        base_domain = Domain.AND(search_detail["base_domain"])
+        model = self.sudo() if search_detail.get("requires_sudo") else self
+        branch_limit = max(limit * 20, 500)
+
+        all_ids = set()
+        for field_name in search_detail["search_fields"]:
+            term_domain = Domain.OR([Domain(field_name, "ilike", escape_psql(term)) for term in terms])
+            all_ids.update(model.search(base_domain & term_domain, limit=branch_limit, order="id").ids)
+
+        if not all_ids:
+            return model.browse(), 0
+
+        final_domain = Domain("id", "in", list(all_ids))
+        results = model.search(final_domain, limit=limit, order=search_detail.get("order", order))
+        count = model.search_count(final_domain) if limit and limit == len(results) else len(results)
         return results, count
 
     def _search_render_results(self, fetch_fields, mapping, icon, limit):

--- a/deltatech_website_product_code/models/res_config_settings.py
+++ b/deltatech_website_product_code/models/res_config_settings.py
@@ -4,14 +4,19 @@
 
 from odoo import fields, models
 
+# Parameter name -> default used when it was never set. These must match the
+# defaults read in product.template, otherwise saving the settings page without
+# touching anything would change the behaviour of the shop.
+INT_PARAMS = {
+    "website_search.standalone_code_min_length": ("website_search_standalone_code_min_length", 5),
+    "website_search.multi_code_min_terms": ("website_search_multi_code_min_terms", 4),
+    "website_search.min_term_length": ("website_search_min_term_length", 3),
+}
+
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    # A boolean is safe to store through `config_parameter`: core writes False
-    # by deleting the parameter, and the search reads a missing parameter as
-    # False too. Numeric settings would need explicit get/set, since a zero is
-    # also stored as False and would silently restore the default.
     website_search_exact_phrase = fields.Boolean(
         string="Search The Whole Term",
         config_parameter="website_search.exact_phrase",
@@ -20,3 +25,45 @@ class ResConfigSettings(models.TransientModel):
         "the product having that code instead of every product containing '352', '030', '15' or "
         "'97'. When no product matches the whole term, the regular search is used.",
     )
+    # The integers below deliberately avoid `config_parameter`: that mechanism
+    # stores a zero as False, which deletes the parameter and therefore restores
+    # the default. Zero means "disabled" here, so it has to be written out.
+    website_search_standalone_code_min_length = fields.Integer(
+        string="Shortest Standalone Code",
+        default=5,
+        help="Used only while the whole term is searched, to tell a pasted list of complete codes "
+        "from the groups of a single code written with spaces. Terms shorter than this are taken "
+        "to be groups of one code, so they are never searched separately. Use 0 to accept terms of "
+        "any length as codes.",
+    )
+    website_search_multi_code_min_terms = fields.Integer(
+        string="Pasted Code Lists",
+        default=4,
+        help="Number of code-looking terms pasted together before the search starts looking for "
+        "any of them, instead of requiring a single product to match them all. Use 0 to disable.",
+    )
+    website_search_min_term_length = fields.Integer(
+        string="Shortest Search Term",
+        default=3,
+        help="Terms shorter than this are ignored, since they cannot use the database indexes and "
+        "only slow the search down. Kept when every term is shorter than this, so that such a "
+        "search still returns its results. Use 0 to keep every term.",
+    )
+
+    def get_values(self):
+        res = super().get_values()
+        get_param = self.env["ir.config_parameter"].sudo().get_param
+        for param, (field_name, default) in INT_PARAMS.items():
+            try:
+                res[field_name] = int(get_param(param, default))
+            except (TypeError, ValueError):
+                # A non-numeric value (e.g. the legacy "False") disables it.
+                res[field_name] = 0
+        return res
+
+    def set_values(self):
+        res = super().set_values()
+        set_param = self.env["ir.config_parameter"].sudo().set_param
+        for param, (field_name, _default) in INT_PARAMS.items():
+            set_param(param, str(self[field_name]))
+        return res

--- a/deltatech_website_product_code/readme/DESCRIPTION.md
+++ b/deltatech_website_product_code/readme/DESCRIPTION.md
@@ -3,6 +3,9 @@
   - Display product page using internal code
   - Display product code in product page
   - Display product code in search results
+  - Fast search when several product codes are pasted at once in the shop
+    search box (finds any matching product instead of requiring all codes
+    to match the same product)
   - Optional exact-phrase search, for catalogues whose codes contain
     spaces (OEM part numbers such as ``352 030 15 97``)
 
@@ -12,6 +15,13 @@
 
 - Configuration (Website > Configuration > Settings, *Product Search*):
 
+  - ``website_search.min_term_length`` (default ``3``): search terms
+    shorter than this are ignored, since they cannot use the trigram
+    indexes and only slow down the search.
+  - ``website_search.multi_code_min_terms`` (default ``4``): minimum
+    number of code-looking terms (e.g. ``AMAT1-12345``) pasted together
+    before the fast multi-code search kicks in. Set to ``False`` or ``0``
+    to disable it and fall back to the regular search.
   - ``website_search.exact_phrase`` (default ``False``): search the whole
     term as a single string instead of splitting it on spaces. Enable it
     for catalogues whose codes contain spaces, so that searching
@@ -19,3 +29,8 @@
     product containing ``352``, ``030``, ``15`` or ``97``. If no product
     matches the whole term, the regular per-term search is used as a
     fallback.
+  - ``website_search.standalone_code_min_length`` (default ``5``): only
+    used while exact-phrase search is on, to tell a pasted list of whole
+    codes from the groups of a single spaced code. Terms shorter than this
+    are taken to be groups of one code, so they are never ORed together.
+    Set to ``False`` or ``0`` to accept terms of any length as codes.

--- a/deltatech_website_product_code/readme/HISTORY.md
+++ b/deltatech_website_product_code/readme/HISTORY.md
@@ -1,3 +1,22 @@
+## 19.0.1.3.0 (2026-07-28)
+
+- Brought the search to parity with 18.0.1.5.0 by porting the three features
+  that had been left on 18.0:
+  - short search terms are dropped (`website_search.min_term_length`,
+    default `3`), since they cannot use the trigram indexes and only force
+    sequential scans;
+  - a pasted list of product codes is resolved by looking for any of them
+    instead of requiring one product to match them all
+    (`website_search.multi_code_min_terms`, default `4`), searching one field
+    at a time so every branch can use its own index;
+  - while exact-phrase search is on, that list is only recognised when every
+    term is long enough to be a code of its own
+    (`website_search.standalone_code_min_length`, default `5`), so the groups
+    of a spaced code such as `999 888 777 666` are never ORed together.
+- All four parameters are editable from *Website > Configuration > Settings*.
+- Domains are built with `odoo.fields.Domain` instead of the deprecated
+  `odoo.osv.expression` helpers used on 18.0.
+
 ## 19.0.1.2.0 (2026-07-28)
 
 - The exact-phrase search can now be switched on from *Website >

--- a/deltatech_website_product_code/tests/test_exact_phrase_search.py
+++ b/deltatech_website_product_code/tests/test_exact_phrase_search.py
@@ -63,8 +63,8 @@ class TestExactPhraseSearch(TransactionCase):
         self.assertEqual(results, self.exact_product)
 
     def test_exact_phrase_matches_a_code_inside_a_longer_value(self):
-        # Codes are often kept several per line; the searched code is then a
-        # substring of the stored value.
+        # Alternative codes are often kept several per line; the searched code
+        # is then a substring of the stored value.
         product = self._create_product("Bucsa ZQW", "ZQW 11 22 MERCEDES ZQW 33 44 MERCEDES")
         self.set_param("website_search.exact_phrase", "True")
         self.assertEqual(self._search("ZQW 33 44"), product)
@@ -76,6 +76,49 @@ class TestExactPhraseSearch(TransactionCase):
         results = self._search("ZQX 300 100")
         self.assertIn(self.exact_product, results)
         self.assertIn(self.noise_product, results)
+
+    def test_exact_phrase_does_not_or_expand_a_missing_code(self):
+        # "100 200 300 999" is one code written in groups, not four pasted
+        # codes. Without the standalone-code test the multi-code fast path would
+        # OR the groups and return every product containing any one of them -
+        # the very noise exact-phrase search exists to remove.
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertFalse(self._search("100 200 300 999"))
+
+    def test_exact_phrase_treats_four_character_groups_as_one_code(self):
+        # Boundary of website_search.standalone_code_min_length (5): groups of
+        # four characters still belong to a single code.
+        self.set_param("website_search.exact_phrase", "True")
+        self.assertFalse(self._search("1000 2000 3000 9999"))
+
+    def test_pasted_code_lists_still_work_when_exact_phrase_is_off(self):
+        codes = ["ZQY111111", "ZQY222222", "ZQY333333", "ZQY444444"]
+        products = self.ProductTemplate.browse()
+        for code in codes[:2]:
+            products |= self._create_product(f"Rulment {code}", code)
+        # Default configuration: the multi-code fast path resolves the list.
+        self.assertEqual(self._search(" ".join(codes)), products)
+
+    def test_pasted_code_lists_still_work_with_exact_phrase(self):
+        codes = ["ZQY111111", "ZQY222222", "ZQY333333", "ZQY444444"]
+        products = self.ProductTemplate.browse()
+        for code in codes[:2]:
+            products |= self._create_product(f"Rulment {code}", code)
+        self.set_param("website_search.exact_phrase", "True")
+        # Each term is long enough to be a code of its own, so the list is
+        # resolved by the multi-code fast path even in exact-phrase mode.
+        self.assertEqual(self._search(" ".join(codes)), products)
+
+    def test_terms_shorter_than_the_minimum_are_dropped(self):
+        product = self._create_product("Rulment ZQZ12345", "ZQZ12345")
+        # "ab" is shorter than website_search.min_term_length (3). Terms are
+        # ANDed, so without dropping it the product could not be found.
+        self.assertIn(product, self._search("ZQZ12345 ab"))
+
+    def test_a_search_made_only_of_short_terms_is_kept(self):
+        product = self._create_product("Set ab cd", "ZQZSHORT")
+        # Every term is short, so the search is kept intact rather than emptied.
+        self.assertIn(product, self._search("ab cd"))
 
     def test_single_term_search_is_unaffected(self):
         self.set_param("website_search.exact_phrase", "True")

--- a/deltatech_website_product_code/tests/test_settings.py
+++ b/deltatech_website_product_code/tests/test_settings.py
@@ -12,25 +12,53 @@ class TestSearchSettings(TransactionCase):
         super().setUp()
         self.Settings = self.env["res.config.settings"]
         self.ProductTemplate = self.env["product.template"]
+        self.get_param = self.env["ir.config_parameter"].sudo().get_param
 
-    def test_default_matches_the_value_read_by_the_search(self):
-        # Saving the settings page writes every field, so a default that
-        # differed from what the search assumes would silently change the
-        # behaviour of a shop where nobody touched this setting.
+    def test_defaults_match_the_values_read_by_the_search(self):
+        # Saving the settings page writes every field, so a default that differs
+        # from what the search assumes would silently change the behaviour of a
+        # shop where nobody touched these settings.
         settings = self.Settings.create({})
         self.assertFalse(settings.website_search_exact_phrase)
+        self.assertEqual(settings.website_search_standalone_code_min_length, 5)
+        self.assertEqual(settings.website_search_multi_code_min_terms, 4)
+        self.assertEqual(settings.website_search_min_term_length, 3)
+
         settings.execute()
+
         self.assertFalse(self.ProductTemplate._exact_phrase_search_enabled())
+        self.assertEqual(self.ProductTemplate._standalone_code_min_length(), 5)
+        self.assertEqual(self.ProductTemplate._multi_code_min_terms(), 4)
+        self.assertEqual(int(self.get_param("website_search.min_term_length")), 3)
 
     def test_enabling_exact_phrase_from_the_settings(self):
         settings = self.Settings.create({"website_search_exact_phrase": True})
         settings.execute()
         self.assertTrue(self.ProductTemplate._exact_phrase_search_enabled())
 
-    def test_disabling_exact_phrase_from_the_settings(self):
-        self.env["ir.config_parameter"].sudo().set_param("website_search.exact_phrase", "True")
-        settings = self.Settings.create({})
-        self.assertTrue(settings.website_search_exact_phrase)
-        settings.website_search_exact_phrase = False
+    def test_zero_standalone_length_accepts_any_term(self):
+        settings = self.Settings.create(
+            {"website_search_exact_phrase": True, "website_search_standalone_code_min_length": 0}
+        )
         settings.execute()
-        self.assertFalse(self.ProductTemplate._exact_phrase_search_enabled())
+        self.assertEqual(self.ProductTemplate._standalone_code_min_length(), 0)
+        self.assertTrue(self.ProductTemplate._looks_like_standalone_code("366"))
+
+    def test_short_terms_are_not_standalone_codes_by_default(self):
+        self.assertFalse(self.ProductTemplate._looks_like_standalone_code("366"))
+        self.assertTrue(self.ProductTemplate._looks_like_standalone_code("FLO10229"))
+
+    def test_a_disabled_fast_path_survives_saving_the_settings(self):
+        # Zero must be written out, not turned into a missing parameter: the
+        # settings page would otherwise silently restore the default of 4 and
+        # re-enable a fast path the customer had deliberately switched off.
+        self.env["ir.config_parameter"].sudo().set_param("website_search.multi_code_min_terms", "0")
+        settings = self.Settings.create({})
+        self.assertEqual(settings.website_search_multi_code_min_terms, 0)
+        settings.execute()
+        self.assertEqual(self.get_param("website_search.multi_code_min_terms"), "0")
+        self.assertEqual(self.ProductTemplate._multi_code_min_terms(), 0)
+
+    def test_legacy_false_value_is_read_as_disabled(self):
+        self.env["ir.config_parameter"].sudo().set_param("website_search.multi_code_min_terms", "False")
+        self.assertEqual(self.Settings.create({}).website_search_multi_code_min_terms, 0)

--- a/deltatech_website_product_code/views/res_config_settings_views.xml
+++ b/deltatech_website_product_code/views/res_config_settings_views.xml
@@ -12,6 +12,29 @@
                         help="Match the search term as a single string instead of splitting it on spaces. Enable it when product codes contain spaces, so that searching '352 030 15 97' returns the product having that code instead of every product containing '352', '030', '15' or '97'. When no product matches the whole term, the regular search is used."
                     >
                         <field name="website_search_exact_phrase" />
+                        <div class="content-group mt-2" invisible="not website_search_exact_phrase">
+                            <div class="row">
+                                <label for="website_search_standalone_code_min_length" class="col-lg-8 o_light_label" />
+                                <field name="website_search_standalone_code_min_length" />
+                            </div>
+                            <div class="text-muted">
+                                Shortest term still treated as a code of its own. Shorter terms are
+                                taken to be groups of one code, so they are never searched
+                                separately. Use 0 to accept any length.
+                            </div>
+                        </div>
+                    </setting>
+                    <setting
+                        string="Pasted Code Lists"
+                        help="Number of code-looking terms pasted together before the search starts looking for any of them instead of requiring a single product to match them all. Use 0 to disable it."
+                    >
+                        <field name="website_search_multi_code_min_terms" />
+                    </setting>
+                    <setting
+                        string="Shortest Search Term"
+                        help="Terms shorter than this are ignored, since they cannot use the database indexes and only slow the search down. Kept when every term is shorter than this, so that such a search still returns its results."
+                    >
+                        <field name="website_search_min_term_length" />
                     </setting>
                 </block>
             </xpath>


### PR DESCRIPTION
Follow-up to dhongu/deltatech#2686. Helpdesk ticket #9007.

19.0 had only the exact-phrase search (19.0.1.1.0), while the three features it builds on had been left on 18.0 — the branches had drifted apart over three releases. This ports all of them, so a shop behaves the same on both.

## Ported

| feature | 18.0 | parameter |
|---|---|---|
| short terms are dropped | 18.0.1.1.0 | `website_search.min_term_length` (3) |
| pasted code lists resolved with OR, one field at a time | 18.0.1.2.0 | `website_search.multi_code_min_terms` (4) |
| that list only recognised for standalone-looking codes | 18.0.1.4.0 | `website_search.standalone_code_min_length` (5) |
| all four editable from the UI | 18.0.1.5.0 | — |

Without the third one, `999 888 777 666` would be read as four pasted codes and ORed, returning every product containing any single group — 472 results on a 10 000-product catalogue where the correct answer is none.

## Adapted for 19.0

Domains use `odoo.fields.Domain` (`Domain.AND` / `Domain.OR` / `&`) rather than `odoo.osv.expression.AND/OR`, which raise `DeprecationWarning` since 19.0. This affects `_search_fetch_exact_phrase` and `_search_fetch_multi_code`; the latter keeps the per-field loop, since that is what lets each branch use its own index.

`_search_build_domain` uses `search.split()` to match what core does on this branch.

## Tests

33 tests for the addon, 0 failures against Odoo 19 core.

Two tests were added beyond the 18.0 set, covering the term-length filter that had no coverage on either branch:

- `test_terms_shorter_than_the_minimum_are_dropped`
- `test_a_search_made_only_of_short_terms_is_kept`

Worth porting back to 18.0 separately.

The pasted-code tests are inherently non-vacuous: no product carries all four codes, so they can only pass if the OR path actually runs — via core AND semantics they would return nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)