### PR TITLE
[FIX] deltatech_sale_multiple: accept string quantities in the rule helpers

### DIFF
--- a/deltatech_sale_multiple/__manifest__.py
+++ b/deltatech_sale_multiple/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Qty Multiple",
     "summary": "Sale quantity multiple",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Sales",

--- a/deltatech_sale_multiple/models/product.py
+++ b/deltatech_sale_multiple/models/product.py
@@ -124,6 +124,11 @@ class ProductProduct(models.Model):
     def _normalize_sale_quantity(self, quantity: float, product_uom) -> float:
         """Round a positive quantity up so all configured rules are satisfied."""
         self.ensure_one()
+        # This runs from create()/write() on the raw values dict, before the ORM
+        # coerces the field, so the quantity may still be a string (EDI imports,
+        # data loads, RPC callers). Cast it instead of raising a TypeError on the
+        # comparison below.
+        quantity = float(quantity or 0.0)
         if quantity <= 0:
             return quantity
 
@@ -146,6 +151,7 @@ class ProductProduct(models.Model):
     def _valid_sale_quantity_at_most(self, quantity: float, product_uom) -> float:
         """Return the greatest rule-compliant quantity not exceeding ``quantity``."""
         self.ensure_one()
+        quantity = float(quantity or 0.0)
         if quantity <= 0:
             return 0.0
 

--- a/deltatech_sale_multiple/tests/test_sale.py
+++ b/deltatech_sale_multiple/tests/test_sale.py
@@ -41,6 +41,17 @@ class TestSaleMultiple(TransactionCase):
         line = self._create_line(quantity=7.0)
         self.assertEqual(line.product_uom_qty, 10.0)
 
+    def test_create_accepts_string_quantity(self):
+        """EDI imports and data loads pass the quantity as a string: the rules
+        must still apply instead of raising a TypeError on the comparison."""
+        line = self._create_line(quantity="7.0")
+        self.assertEqual(line.product_uom_qty, 10.0)
+
+    def test_write_accepts_string_quantity(self):
+        line = self._create_line(quantity=10.0)
+        line.write({"product_uom_qty": "7.0"})
+        self.assertEqual(line.product_uom_qty, 10.0)
+
     def test_batch_write_applies_rules_to_every_line(self):
         lines = self._create_line(quantity=10.0) | self._create_line(quantity=15.0)
         lines.write({"product_uom_qty": 7.0})


### PR DESCRIPTION
## Problem

The `create()`/`write()` hooks introduced in b2173afa9 ("Fix sale quantity rules for Odoo 19") pass the **raw values dict** to `_normalize_sale_quantity` — the quantity as the caller supplied it, before the ORM coerces it to float. Any caller that legitimately passes a string hits `if quantity <= 0` and raises:

```
TypeError: '<=' not supported between instances of 'str' and 'int'
```

`xmltodict` returns every XML value as `str`, so this fires on every EDI order import. Data loads and RPC clients are affected the same way.

## Impact observed in production

On the Romchim database (Odoo 19.0+e) this silently broke the EDInet order import. The `TypeError` is a Python error, not an SQL one, so the cursor stays usable: the `sale.order` header `INSERT` survives the enclosing `try/except` in `deltatech_edinet.corn_import_edinet`, the loop finishes "normally", and the transaction commits. Result — **orders imported with a correct header and zero lines**, no error surfaced anywhere except the log.

13 Hornbach/Dedeman orders were affected before anyone connected the two. Ticket 9080.

## Fix

Cast the quantity in `_normalize_sale_quantity` and in `_valid_sale_quantity_at_most` (same latent defect).

The companion fix at the data source is terrabit-solutions/bitshop#19.0-fix-edi-numeric-cast — that one stops the string from being produced, this one keeps the helpers safe for every other caller. Both are worth having.

## Tests

Two regression tests, one for `create()` and one for `write()`. Verified they reproduce the defect: with the cast removed, `test_create_accepts_string_quantity` fails with exactly the production `TypeError`.

```
deltatech_sale_multiple: 13 tests 0.89s 536 queries
0 failed, 0 error(s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)