### PR TITLE
[FIX] deltatech_website_product_code: exact-phrase search only for terms with a digit

### DIFF
--- a/deltatech_website_product_code/__manifest__.py
+++ b/deltatech_website_product_code/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Code",
     "summary": "Display product by code in eCommerce",
     "category": "Website",
-    "version": "18.0.1.5.0",
+    "version": "18.0.1.5.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_product_code/models/product_template.py
+++ b/deltatech_website_product_code/models/product_template.py
@@ -43,8 +43,13 @@ class ProductTemplate(models.Model):
         # wanted product buried in the middle. When exact-phrase search is on,
         # the whole term is matched as one string first, and the per-term search
         # is only used as a fallback.
+        # Only terms carrying a digit are treated this way. A term made of words
+        # alone is somebody describing a product, not quoting a code: matching
+        # "Lant CLAAS" as one string would drop "Lant combina agricola CLAAS",
+        # while the shopper means every word, in any position. Codes contain
+        # digits, which is also what _looks_like_code() requires.
         phrase = " ".join((search or "").split())
-        exact_phrase = " " in phrase and self._exact_phrase_search_enabled()
+        exact_phrase = " " in phrase and any(ch.isdigit() for ch in phrase) and self._exact_phrase_search_enabled()
         if exact_phrase:
             results, count = self._search_fetch_exact_phrase(search_detail, phrase, limit, order)
             if count:

--- a/deltatech_website_product_code/readme/DESCRIPTION.md
+++ b/deltatech_website_product_code/readme/DESCRIPTION.md
@@ -28,7 +28,9 @@
     ``352 030 15 97`` returns the product with that code instead of every
     product containing ``352``, ``030``, ``15`` or ``97``. If no product
     matches the whole term, the regular per-term search is used as a
-    fallback.
+    fallback. Only terms containing a digit are treated this way: a term
+    made of words alone (``Lant CLAAS``) is a description rather than a
+    code, so its words keep being searched separately.
   - ``website_search.standalone_code_min_length`` (default ``5``): only
     used while exact-phrase search is on, to tell a pasted list of whole
     codes from the groups of a single spaced code. Terms shorter than this

--- a/deltatech_website_product_code/readme/HISTORY.rst
+++ b/deltatech_website_product_code/readme/HISTORY.rst
@@ -1,3 +1,17 @@
+18.0.1.5.1 (2026-07-28)
+~~~~~~~~~~~~~~~~~~~~~~~
+
+**Fixed**
+
+- Exact-phrase search is now limited to terms carrying a digit. A term made of
+  words alone is somebody describing a product, not quoting a code, and matching
+  it as one string dropped the products whose words are spread out: on a live
+  catalogue ``Lant CLAAS`` returned only the 24 products containing that exact
+  wording, hiding ``Lant combina agricola CLAAS`` and the rest of the 145 that
+  carry both words. Word-only searches are again matched per word, while codes -
+  which contain digits, as ``_looks_like_code()`` already requires - keep the
+  whole-term behaviour.
+
 18.0.1.5.0 (2026-07-28)
 ~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/deltatech_website_product_code/tests/test_exact_phrase_search.py
+++ b/deltatech_website_product_code/tests/test_exact_phrase_search.py
@@ -56,6 +56,17 @@ class TestExactPhraseSearch(TransactionCase):
         results = self._search("ZQX 100 200 300")
         self.assertEqual(results, self.exact_product)
 
+    def test_a_search_of_words_only_is_never_matched_as_a_phrase(self):
+        # A term without digits describes a product rather than quoting a code.
+        # Matching it as one string would drop the products whose words are
+        # spread out, which is not what the shopper means.
+        spread = self._create_product("Lant combina agricola ZQCLAAS", "ZQL001")
+        literal = self._create_product("Lant ZQCLAAS", "ZQL002")
+        self.set_param("website_search.exact_phrase", "True")
+        results = self._search("Lant ZQCLAAS")
+        self.assertIn(literal, results)
+        self.assertIn(spread, results, "words are searched separately when the term has no digit")
+
     def test_exact_phrase_ignores_extra_whitespace(self):
         self.set_param("website_search.exact_phrase", "True")
         results = self._search("  ZQX   100 200  300 ")


### PR DESCRIPTION
Reported by the customer after the production rollout of dhongu/deltatech#2685. Helpdesk ticket #9007.

## Problem

The code side works, but word searches became too strict. Measured on the live catalogue through the shop search box:

| search | returned | should return |
|---|---|---|
| `Lant CLAAS` | 24 | **145** |
| `Fulie CLAAS` | 5 | **58** |
| `Pinion CAPELLO` | 14 | **44** |

Only the products worded exactly that way came back. `Lant combina agricola CLAAS` and `Lant transportor lateral CLAAS` were hidden, although they carry both words. In the customer's words: they want every product whose name includes *Pinion* **and** *CAPELLO*, but not those carrying only one of them.

## Cause

Exact-phrase search applied to any multi-word term. But a term made of words alone is somebody describing a product, not quoting a code — matching it as one string is the wrong interpretation of what a shopper means.

## Fix

The whole-term pass is limited to terms carrying a **digit**. That is the same signal `_looks_like_code()` already uses, and it separates the two intents cleanly:

| term | has digit | route |
|---|---|---|
| `Lant CLAAS`, `Fulie CLAAS`, `Pinion CAPELLO` | no | per word (AND) |
| `disc de frana`, `ulei de motor` | no | per word (AND) |
| `366 200 05 01`, `000 090 15 51`, `0798 318 0` | yes | whole term |
| `Ulei 15w-40` | yes | whole term, then falls back per word |

Nothing measured for the ticket regresses: `366 200 05 01` still returns 2 products instead of 60. A product name that happens to contain a digit is still tried as a phrase first, but the existing fallback catches it — verified on the live catalogue: the phrase matches nothing and the per-word search returns its 14 products.

No new parameter: the digit test plus the existing fallback is self-correcting, so there is nothing to tune.

## Tests

New `test_a_search_of_words_only_is_never_matched_as_a_phrase` — two products, one worded literally and one with the words spread out; with the mode on, both are returned.

Every existing test keeps passing unchanged, since each of them searches a term containing digits. 17 tests for the addon, 0 failures.

## Stopgap while this ships

Turning `website_search.exact_phrase` off in *Website > Configuration > Settings* restores word searches immediately, at the cost of the code precision from the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)