### PR TITLE
[IMP] deltatech_reception_note: say what is missing and how to force the reception

### DIFF
--- a/deltatech_reception_note/__manifest__.py
+++ b/deltatech_reception_note/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech reception_note",
     "summary": "Batch reception note",
-    "version": "19.0.0.1.1",
+    "version": "19.0.0.1.2",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "support": "odoo@terrabit.ro",

--- a/deltatech_reception_note/i18n/ro.po
+++ b/deltatech_reception_note/i18n/ro.po
@@ -131,8 +131,8 @@ msgstr "Note recepție"
 #. odoo-python
 #: code:addons/deltatech_reception_note/models/purchase.py:0
 #, python-format
-msgid "Product [{}]{}: quantity: {} {}<br />"
-msgstr "Produs [{}]{}: cantitate: {} {}<br />"
+msgid "Product [{product_code}]{product_name}: quantity: {quantity} {uom}<br />"
+msgstr "Produs [{product_code}]{product_name}: cantitate: {quantity} {uom}<br />"
 
 #. module: deltatech_reception_note
 #: model:ir.model,name:deltatech_reception_note.model_purchase_order
@@ -189,15 +189,24 @@ msgstr "Setează trimis"
 #. odoo-python
 #: code:addons/deltatech_reception_note/models/purchase.py:0
 #, python-format
-msgid "The product [{}]{} is not found in a rfq"
-msgstr "Produsul [{}]{} nu a fost găsit in niciun rfq"
+msgid ""
+"The product [%(default_code)s]%(name)s is not found in a sent RFQ. Tick "
+"'Ignore quantities' to receive it anyway."
+msgstr ""
+"Produsul [%(default_code)s]%(name)s nu se găsește într-o CdO trimisă. Bifați "
+"„Ignoră cantitățile negăsite” pentru a-l recepționa oricum."
 
 #. module: deltatech_reception_note
 #. odoo-python
 #: code:addons/deltatech_reception_note/models/purchase.py:0
 #, python-format
-msgid "The quantity {} of the [{}] {} product is not found in a rfq"
-msgstr "Cantitatea {} pentru produsul [{}] {} nu a fost găsită in niciun rfq"
+msgid ""
+"The quantity %(quantity)s of the [%(default_code)s] %(name)s product is not "
+"found in a sent RFQ. Tick 'Ignore quantities' to receive it anyway."
+msgstr ""
+"Cantitatea %(quantity)s pentru produsul [%(default_code)s] %(name)s nu se "
+"găsește într-o CdO trimisă. Bifați „Ignoră cantitățile negăsite” pentru a o "
+"recepționa oricum."
 
 #. module: deltatech_reception_note
 #: model:ir.ui.menu,name:deltatech_reception_note.menu_action_reception_note_view

--- a/deltatech_reception_note/models/purchase.py
+++ b/deltatech_reception_note/models/purchase.py
@@ -82,7 +82,10 @@ class PurchaseOrder(models.Model):
             if not rfq_lines:
                 if not self.ignore_quantities:
                     found_errors.append(
-                        self.env._("The product [%(default_code)s]%(name)s is not found in a RFQ")
+                        self.env._(
+                            "The product [%(default_code)s]%(name)s is not found in a sent RFQ. "
+                            "Tick 'Ignore quantities' to receive it anyway."
+                        )
                         % {"default_code": line.product_id.default_code, "name": line.product_id.name}
                     )
 
@@ -97,7 +100,8 @@ class PurchaseOrder(models.Model):
                     if not self.ignore_quantities:
                         quantity_errors.append(
                             self.env._(
-                                "The quantity %(quantity)s of the [%(default_code)s] %(name)s product is not found in a RFQ"
+                                "The quantity %(quantity)s of the [%(default_code)s] %(name)s product is not found "
+                                "in a sent RFQ. Tick 'Ignore quantities' to receive it anyway."
                             )
                             % {
                                 "quantity": quantity,

--- a/deltatech_reception_note/readme/HISTORY.md
+++ b/deltatech_reception_note/readme/HISTORY.md
@@ -1,0 +1,10 @@
+## 19.0.0.1.2 (2026-07-29)
+
+- The two errors raised when confirming a reception note now name the missing coverage as a *sent*
+  RFQ and tell the user what to do about it: tick "Ignore quantities" to receive the goods anyway.
+  Until now the message only stated that the product or the quantity was not found, leaving no clue
+  that the field exists.
+- Restored the Romanian translation of those two errors and of the chatter summary of forced
+  quantities. All three had gone stale: the messages were reworked from `.format({})` to named
+  `%`-placeholders without regenerating `i18n/ro.po`, so the `msgid` no longer matched and the
+  translation was silently dropped — the user saw English text on a Romanian database.


### PR DESCRIPTION
Ticket 9034 (PTC upgrade to 19.0) — Teo could not receive goods when the quantity exceeded what was ordered, or when the product was not on a sent RFQ at all, and asked for the reception not to be conditioned by the purchase order.

## What was actually wrong

The flow already supports exactly that, through the **"Ignore quantities"** field on the reception note: the excess quantity is forced, a product with no coverage is added as a new line, and a summary of what was forced is posted in the chatter. The check itself is intended behaviour, unchanged since 18.0.

The problem was the message. It stated only that the product or the quantity "is not found in a RFQ" — nothing about the field that resolves it, so there was no way for the user to get there on their own. Both errors now name the *sent* RFQ explicitly and point at the field.

## And they were untranslated

`i18n/ro.po` carried translations for all three python messages, but with stale msgids: the messages had been reworked from `.format({})` to named `%`-placeholders without regenerating the file, so the `msgid` no longer matched and the translation was **silently dropped** — a Romanian database showed English text. That is why the client saw an English dialog. Fixed for both errors and for the chatter summary of forced quantities (the message shown precisely when the field is used).

## Verified

- every string passed through `self.env._()` in `models/purchase.py` matched against the msgids in `ro.po`: **5 messages, 0 without a translation** (3 were orphaned before this change)
- the 5 existing tests pass

Same stale-msgid class of defect as terrabit-ro/ptc#45, different mechanism: there the `#:` view reference was wrong, here the msgid itself drifted away from the code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)