### PR TITLE
[FIX] deltatech_queue_job: make the cron trigger debounce work

### DIFF
--- a/deltatech_queue_job/__manifest__.py
+++ b/deltatech_queue_job/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech  Queue Job Enhancements",
     "summary": "Deltatech Queue Job",
     "author": "Terrabit, Dorin Hongu",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.3.0",
     "license": "AGPL-3",
     "website": "https://www.terrabit.ro",
     "category": "Others",

--- a/deltatech_queue_job/models/queue_job.py
+++ b/deltatech_queue_job/models/queue_job.py
@@ -4,7 +4,7 @@
 import logging
 import threading
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from odoo import _, api, fields, models, modules
 
@@ -230,25 +230,50 @@ class QueueJob(models.Model):
 
     @api.model
     def _cron_trigger(self, at=None):
-        domain = [("queue_job_runner", "=", True)]
-        crones = self.env["ir.cron"].sudo().search(domain)
+        """Trigger the runner crons, debouncing redundant triggers.
+
+        ``at`` may be None (run as soon as possible), a datetime, or a list of
+        datetimes (the OCA job runner passes the delayed job ETAs as a list).
+        A request is skipped when a pending trigger already fires between now
+        and the requested time, since that run will pick the jobs up anyway.
+
+        The previous implementation compared against ``search(..., limit=1)``
+        without an order or a future filter, so it usually looked at a stale
+        past trigger and created a new one on every call - measured in
+        production at 4,312 trigger inserts in 13 hours. Passing the ETA list
+        also built a ``('call_at', '=', [...])`` domain, spamming the log with
+        osv.expression warnings.
+        """
+        crons = self.env["ir.cron"].sudo().search([("queue_job_runner", "=", True)])
         res = "nothing"
 
-        for cron in crones:
-            trigger_domain = [("cron_id", "=", cron.id)]
-            if at:
-                trigger_domain.append(("call_at", "=", at))
-            trigger = self.env["ir.cron.trigger"].search(trigger_domain, limit=1)
+        now = fields.Datetime.now()
+        if at is None:
+            at_list = [now + timedelta(seconds=5)]
+        elif isinstance(at, datetime):
+            at_list = [at]
+        else:
+            at_list = list(at)
+        # past ETAs mean "as soon as possible"; earliest first, so the first
+        # trigger created debounces the later requests of the same call
+        at_list = sorted(max(at_trigger, now) for at_trigger in at_list)
 
-            if trigger and trigger.call_at >= fields.Datetime.now():
-                # triggerul exista si e in viitor - valid
-                res = "exists"
-            else:
-                # nu exista SAU e in trecut - retriggeram
-                res = "triggered"
-                # calculam at_trigger local, fara sa modificam parametrul `at`
-                at_trigger = at or fields.Datetime.now() + timedelta(seconds=5)
-                cron._trigger(at=at_trigger)
-                _logger.info(f"CRON trigger scheduled for {cron.name} at {at_trigger}")
+        for cron in crons:
+            for at_trigger in at_list:
+                covered = self.env["ir.cron.trigger"].search_count(
+                    [
+                        ("cron_id", "=", cron.id),
+                        ("call_at", ">=", now),
+                        ("call_at", "<=", at_trigger),
+                    ],
+                    limit=1,
+                )
+                if covered:
+                    if res == "nothing":
+                        res = "exists"
+                else:
+                    res = "triggered"
+                    cron._trigger(at=at_trigger)
+                    _logger.debug("CRON trigger scheduled for %s at %s", cron.name, at_trigger)
 
         return res

--- a/deltatech_queue_job/readme/HISTORY.md
+++ b/deltatech_queue_job/readme/HISTORY.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 18.0.1.3.0
+
+- Fix: `_cron_trigger` debounce actually works now. It used to compare against
+  `search(..., limit=1)` with no ordering and no future filter, so it usually
+  looked at a stale past trigger and created a new `ir.cron.trigger` on every
+  call - measured in production at 4,312 trigger inserts in 13 hours (one per
+  queue job creation). A request is now skipped when a pending trigger already
+  fires between now and the requested time.
+- Fix: calling `_cron_trigger` with a list of ETAs (as the OCA job runner does
+  for delayed jobs) built a `('call_at', '=', [...])` domain, spamming the log
+  with osv.expression warnings. The ETAs are handled individually, earliest
+  first, so the first trigger created debounces the later ones; past ETAs are
+  clamped to now.
+
 ## 18.0.1.2.0
 
 - When a new job is created, automatically move older jobs left in the

--- a/deltatech_queue_job/tests/__init__.py
+++ b/deltatech_queue_job/tests/__init__.py
@@ -1,4 +1,5 @@
 # ©  2024 Deltatech
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
+from . import test_cron_trigger_debounce
 from . import test_identity_key_dedup

--- a/deltatech_queue_job/tests/test_cron_trigger_debounce.py
+++ b/deltatech_queue_job/tests/test_cron_trigger_debounce.py
@@ -1,0 +1,76 @@
+# © 2026 Deltatech
+# See README.rst file on addons root folder for license details
+from datetime import timedelta
+
+from odoo import fields
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCronTriggerDebounce(TransactionCase):
+    """_cron_trigger must create one trigger per real need, not one per call."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.cron = cls.env["ir.cron"].create(
+            {
+                "name": "Test Queue Runner",
+                "model_id": cls.env.ref("queue_job.model_queue_job").id,
+                "state": "code",
+                "code": "True",
+                "queue_job_runner": True,
+            }
+        )
+
+    def cron_triggers(self):
+        return self.env["ir.cron.trigger"].search([("cron_id", "=", self.cron.id)])
+
+    def test_repeated_calls_are_debounced(self):
+        res_first = self.env["queue.job"]._cron_trigger()
+        self.assertEqual(res_first, "triggered")
+        self.assertEqual(len(self.cron_triggers()), 1)
+
+        # the pending trigger covers the second request
+        res_second = self.env["queue.job"]._cron_trigger()
+        self.assertEqual(len(self.cron_triggers()), 1)
+        self.assertIn(res_second, ("exists", "triggered"))  # other runner crons may still trigger
+
+    def test_eta_list_creates_single_covering_trigger(self):
+        now = fields.Datetime.now()
+        etas = [now + timedelta(minutes=10), now + timedelta(minutes=2), now + timedelta(minutes=30)]
+
+        self.env["queue.job"]._cron_trigger(at=etas)
+
+        triggers = self.cron_triggers()
+        # the earliest ETA covers the later ones
+        self.assertEqual(len(triggers), 1)
+        self.assertAlmostEqual((triggers.call_at - (now + timedelta(minutes=2))).total_seconds(), 0, delta=60)
+
+    def test_past_eta_is_clamped_to_now(self):
+        now = fields.Datetime.now()
+
+        self.env["queue.job"]._cron_trigger(at=[now - timedelta(hours=1)])
+
+        triggers = self.cron_triggers()
+        self.assertEqual(len(triggers), 1)
+        self.assertGreaterEqual(triggers.call_at, now - timedelta(seconds=1))
+
+    def test_far_trigger_does_not_cover_immediate_request(self):
+        far = fields.Datetime.now() + timedelta(hours=2)
+        self.env["queue.job"]._cron_trigger(at=far)
+        self.assertEqual(len(self.cron_triggers()), 1)
+
+        # an immediate request is NOT satisfied by a trigger two hours away
+        self.env["queue.job"]._cron_trigger()
+        self.assertEqual(len(self.cron_triggers()), 2)
+
+    def test_single_datetime_argument(self):
+        at = fields.Datetime.now() + timedelta(minutes=5)
+
+        res = self.env["queue.job"]._cron_trigger(at=at)
+
+        self.assertEqual(res, "triggered")
+        triggers = self.cron_triggers()
+        self.assertEqual(len(triggers), 1)
+        self.assertAlmostEqual((triggers.call_at - at).total_seconds(), 0, delta=1)


### PR DESCRIPTION
## Problema (PR 2 din planul de optimizare PTC)

Debounce-ul din `_cron_trigger` nu funcționa practic niciodată, din două defecte:

1. `search(trigger_domain, limit=1)` **fără `order` și fără filtru pe viitor** — returna de regulă un trigger vechi din trecut, condiția `call_at >= now` pica, și se crea un trigger nou la fiecare apel. Măsurat pe logul de producție PTC: **4.312 inserări „CRON trigger scheduled" în 13 ore** — practic una per creare de job — cu churn pe scheduler și contenție pe `ir_cron`.
2. Runner-ul OCA apelează `_cron_trigger(at=list(delayed_etas))` cu **listă**; vechiul cod o punea într-un domeniu `('call_at', '=', [...])` → cele **155 avertismente `osv.expression`** din același log.

## Soluția

- O cerere e sărită când există deja un trigger pending care se declanșează **între now și momentul cerut** — acea rulare preia oricum joburile.
- ETA-urile din listă sunt tratate individual, ordonate crescător — primul trigger creat le acoperă pe următoarele; ETA-urile din trecut sunt aduse la now.
- Semantica `res` („triggered"/„exists"/„nothing") pentru `start_cron_trigger` e păstrată.
- Logul per-trigger coboară la `debug`.

## Teste

**7 teste, 0 eșecuri pe baza reală ptc18** (5 noi + 2 existente).

Sensibilitate verificată empiric: pe codul vechi, 3/5 din testele noi **pică** (lista de ETA-uri creează triggere multiple + warning, clamping-ul lipsește, semantica de acoperire diferă).

Context: face parte din același efort cu terrabit-solutions/bitshop_delivery#41/#43 (bucla cronului de status) — împreună atacă reciclarea workerului de cron de pe PTC (SIGKILL pe memorie la mediana 58s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)