### PR TITLE
[FIX] deltatech_invoice_to_draft: enable and fix the tests

### DIFF
--- a/deltatech_invoice_to_draft/tests/__init__.py
+++ b/deltatech_invoice_to_draft/tests/__init__.py
@@ -1,1 +1,1 @@
-# from . import test_invoice_to_draft
+from . import test_invoice_to_draft

--- a/deltatech_invoice_to_draft/tests/test_invoice_to_draft.py
+++ b/deltatech_invoice_to_draft/tests/test_invoice_to_draft.py
@@ -4,28 +4,43 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged("post_install", "-at_install")
-class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
+class TestInvoiceToDraft(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.group_reset = cls.env.ref("deltatech_invoice_to_draft.group_reset_to_draft_account_move")
         cls.invoice = cls.init_invoice("in_invoice", products=cls.product_a + cls.product_b)
         cls.invoice.action_post()
 
-    def test_show_reset_to_draft_button(cls):
-        # Check the _compute_show_reset_to_draft_button method
-        cls.invoice._compute_show_reset_to_draft_button()
-        cls.assertEqual(
-            cls.invoice.show_reset_to_draft_button,
-            cls.env.user.has_group("deltatech_invoice_to_draft.group_reset_to_draft_account_move"),
-            "The show_reset_to_draft_button field should be computed correctly",
+    def _show_reset_to_draft_button(self):
+        """Recompute the field, ignoring any value cached before the group changed."""
+        self.invoice.invalidate_recordset(["show_reset_to_draft_button"])
+        return self.invoice.show_reset_to_draft_button
+
+    def test_reset_to_draft_hidden_without_group(self):
+        """A user outside the group cannot reset a posted move to draft."""
+        self.env.user.group_ids -= self.group_reset
+        self.assertFalse(self.env.user.has_group("deltatech_invoice_to_draft.group_reset_to_draft_account_move"))
+        self.assertFalse(
+            self._show_reset_to_draft_button(),
+            "Reset to Draft must stay hidden for a user without the dedicated group",
         )
 
-    def test_button_draft_cancel(cls):
-        # Check the button_draft_cancel method
-        cls.invoice.button_draft_cancel()
-        cls.assertEqual(
-            cls.invoice.state,
-            "cancel",
-            "The state of the account move should be 'cancel' after calling button_draft_cancel",
+    def test_reset_to_draft_visible_with_group(self):
+        """A user in the group keeps the native Reset to Draft button.
+
+        Together with the previous test this proves the group is what hides the button:
+        the native compute allows it on this invoice, only the group gates it.
+        """
+        self.env.user.group_ids |= self.group_reset
+        self.assertTrue(
+            self._show_reset_to_draft_button(),
+            "Reset to Draft must be available for a user in the dedicated group",
         )
+
+    def test_button_draft_cancel(self):
+        """The shortcut takes a posted move straight to cancelled."""
+        self.assertEqual(self.invoice.state, "posted")
+        self.invoice.button_draft_cancel()
+        self.assertEqual(self.invoice.state, "cancel")


### PR DESCRIPTION
Urmare la [#2698](https://github.com/dhongu/deltatech/pull/2698), unde am semnalat că testele modulului sunt dezactivate.

## Problema

`tests/__init__.py` avea importul comentat din 18.0, deci `--test-tags=deltatech_invoice_to_draft` nu colecta nimic. Migrarea pe 19.0 a trecut fără ca testele să fi fost executate vreodată — inclusiv fix-ul de `setUpClass` din #2698 a rămas neverificat.

Iar odată activate, testele nu verificau de fapt restricția pe care o implementează modulul:

```python
# înainte — ambii termeni sunt False pentru utilizatorul de test, care nu e în grup
cls.assertEqual(
    cls.invoice.show_reset_to_draft_button,
    cls.env.user.has_group("...group_reset_to_draft_account_move"),
)
```

Aserția trecea fără să demonstreze nimic: dacă cineva ar fi scos filtrarea pe grup din override, testul ar fi prins-o doar accidental, iar cazul pozitiv (utilizator **în** grup → butonul reapare) nu era acoperit deloc.

## Ce s-a schimbat

- Reactivat importul din `tests/__init__.py`.
- Două teste complementare în locul celui tautologic: fără grup butonul rămâne ascuns, cu grup redevine disponibil. Împreună dovedesc că **grupul** e ce ascunde butonul — compute-ul nativ îl permite pe acea factură, altfel testul pozitiv ar cădea.
- `test_button_draft_cancel` asertează și starea de plecare (`posted`), nu doar cea finală.
- Metodele foloseau `cls` în loc de `self`, iar clasa se numea `TestAccountMoveInInvoiceOnchanges` — rest de copy-paste fără legătură cu modulul.
- Recalcularea câmpului trece prin `invalidate_recordset`, ca valoarea cached de dinainte de schimbarea grupului să nu falsifice rezultatul.

Notă pentru 19: câmpul de grupuri pe `res.users` e `group_ids` (`groups_id` a fost redenumit).

## Verificare

Rulat local pe bază nouă fără demo:

```
deltatech_invoice_to_draft: 5 tests 1.55s
0 failed, 0 error(s) of 3 tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)