### PR TITLE
[FIX] website_sale_attributes, website_stock_availability: ?ppg= filtered the shop by price

### DIFF
--- a/deltatech_website_sale_attributes/__manifest__.py
+++ b/deltatech_website_sale_attributes/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Attribute Values",
     "category": "Website",
     "summary": "Attribute values for products displayed",
-    "version": "18.0.1.0.2",
+    "version": "18.0.1.0.3",
     "license": "LGPL-3",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_sale_attributes/controllers/main.py
+++ b/deltatech_website_sale_attributes/controllers/main.py
@@ -7,8 +7,18 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class WebsiteSaleAttribute(WebsiteSale):
     @http.route()
-    def shop(self, page=0, category=None, search="", ppg=False, **post):
-        response = super().shop(page, category, search, ppg, **post)
+    def shop(self, category=None, search="", **kwargs):
+        # Only the two parameters this override actually reads are named; the
+        # rest travels in ``kwargs`` untouched. The previous signature was
+        # ``(page, category, search, ppg)`` and forwarded those positionally,
+        # but core grew ``min_price``/``max_price`` in fourth and fifth place,
+        # so ``ppg`` landed in ``min_price``: a visitor passing ``?ppg=40`` got
+        # the catalogue silently filtered to products over 40 while the page
+        # size stayed at its default. Odoo always invokes endpoints as
+        # ``endpoint(**request.params)`` (``odoo/http.py``), so keyword
+        # forwarding is both correct and immune to any further signature
+        # change — including 19.0, where ``ppg`` became ``tags``.
+        response = super().shop(category=category, search=search, **kwargs)
 
         if category and search:
             # Folosim domeniul construit de WebsiteSale pentru product.template

--- a/deltatech_website_sale_attributes/readme/HISTORY.md
+++ b/deltatech_website_sale_attributes/readme/HISTORY.md
@@ -1,0 +1,11 @@
+# History
+
+## 18.0.1.0.3 (2026-07-30)
+
+- Fixed `?ppg=` silently filtering the shop by price. The `shop()` override
+  declared `(page, category, search, ppg)` and forwarded those positionally,
+  but core's fourth parameter is `min_price`, so `?ppg=40` reached it as
+  `min_price=40` and dropped every cheaper product from the listing while the
+  page size stayed at its default. The override now names only the parameters
+  it reads and forwards the rest by keyword, which also survives the 19.0
+  signature where `ppg` became `tags`.

--- a/deltatech_website_sale_attributes/tests/__init__.py
+++ b/deltatech_website_sale_attributes/tests/__init__.py
@@ -3,3 +3,4 @@
 # See README.rst file on addons root folder for license details
 
 from . import test_website_attributes
+from . import test_shop_signature

--- a/deltatech_website_sale_attributes/tests/test_shop_signature.py
+++ b/deltatech_website_sale_attributes/tests/test_shop_signature.py
@@ -1,0 +1,52 @@
+# ©  2023 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+
+from odoo.tests import tagged
+from odoo.tests.common import HttpCase
+
+
+@tagged("post_install", "-at_install")
+class TestShopSignature(HttpCase):
+    """``?ppg=`` must page the shop, never filter it by price.
+
+    This override used to declare ``shop(self, page, category, search, ppg)``
+    and forward those four positionally. Core's fourth parameter is
+    ``min_price``, so ``?ppg=40`` reached it as ``min_price=40`` and dropped
+    every product cheaper than that from the listing, silently, while the page
+    size stayed at its default.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.website = cls.env["website"].get_current_website()
+        cls.cheap = cls.env["product.template"].create(
+            {
+                "name": "TB Signature Cheap Product",
+                "is_published": True,
+                "list_price": 5.0,
+            }
+        )
+
+    def test_ppg_does_not_filter_by_price(self):
+        """A product below the ``ppg`` value must still be listed."""
+        body = self.url_open("/shop?ppg=40").text
+
+        self.assertIn(
+            self.cheap.name,
+            body,
+            "a 5.0 product disappeared from /shop?ppg=40 — ppg is being read as min_price",
+        )
+
+    def test_min_price_still_filters(self):
+        """The real ``min_price`` parameter must keep working."""
+        body = self.url_open("/shop?min_price=40").text
+
+        self.assertNotIn(
+            self.cheap.name,
+            body,
+            "min_price=40 should have excluded a 5.0 product",
+        )

--- a/deltatech_website_stock_availability/__manifest__.py
+++ b/deltatech_website_stock_availability/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Stock Availability",
     "category": "Website",
     "summary": "eCommerce Stock Availability and lead time",
-    "version": "18.0.1.0.8",
+    "version": "18.0.1.0.9",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "depends": ["website", "website_sale_stock", "purchase", "deltatech_vendor_stock"],

--- a/deltatech_website_stock_availability/controllers/main.py
+++ b/deltatech_website_stock_availability/controllers/main.py
@@ -6,8 +6,18 @@ from odoo.addons.website_sale.controllers import main
 
 class WebsiteSale(main.WebsiteSale):
     @http.route()
-    def shop(self, page=0, category=None, search="", ppg=False, **post):
-        response = super().shop(page, category, search, ppg, **post)
+    def shop(self, **kwargs):
+        # No parameter is restated here on purpose. The previous signature was
+        # ``(page, category, search, ppg)`` and forwarded those positionally,
+        # but core grew ``min_price``/``max_price`` in fourth and fifth place,
+        # so ``ppg`` landed in ``min_price``: a visitor passing ``?ppg=40`` got
+        # the catalogue silently filtered to products over 40 while the page
+        # size stayed at its default. Odoo always invokes endpoints as
+        # ``endpoint(**request.params)`` (``odoo/http.py``), so accepting
+        # ``**kwargs`` and forwarding it is both correct and immune to any
+        # further signature change — including 19.0, where ``ppg`` became
+        # ``tags``.
+        response = super().shop(**kwargs)
         availability_all = request.httprequest.args.get("availability_all", True)
         availability_in_stock = request.httprequest.args.get("availability_in_stock", False)
         availability_vendor = request.httprequest.args.get("availability_vendor", False)

--- a/deltatech_website_stock_availability/readme/HISTORY.md
+++ b/deltatech_website_stock_availability/readme/HISTORY.md
@@ -1,0 +1,11 @@
+# History
+
+## 18.0.1.0.9 (2026-07-30)
+
+- Fixed `?ppg=` silently filtering the shop by price. The `shop()` override
+  declared `(page, category, search, ppg)` and forwarded those positionally,
+  but core's fourth parameter is `min_price`, so `?ppg=40` reached it as
+  `min_price=40` and dropped every cheaper product from the listing while the
+  page size stayed at its default. The override reads no routing parameter of
+  its own, so it now simply forwards `**kwargs`, which also survives the 19.0
+  signature where `ppg` became `tags`.


### PR DESCRIPTION
## The bug

Both modules override `shop()` with a signature that predates core's price filters:

```python
def shop(self, page=0, category=None, search="", ppg=False, **post):
    response = super().shop(page, category, search, ppg, **post)
```

Core 18.0 ([website_sale/controllers/main.py:234](https://github.com/odoo/odoo/blob/18.0/addons/website_sale/controllers/main.py)):

```python
def shop(self, page=0, category=None, search='', min_price=0.0, max_price=0.0, ppg=False, **post)
```

The fourth positional argument is **`min_price`**, not `ppg`.

## What a visitor sees

`/shop?ppg=40` →  `min_price=40` → `product_template.py:770` builds `[('list_price', '>=', 40)]`.

**Every product cheaper than 40 disappears from the listing**, with nothing in the UI explaining why. Meanwhile the page size stays at its default, because the real `ppg` never arrives.

Any `?ppg=` link — a stored URL, a bookmark, a crawler following the page-size selector — silently truncates the catalogue by price.

## How it surfaced

CI on #2700: a pager test failed with `404 != 200` on `/shop/page/3?ppg=1`, because three published products fitted on one page instead of three. `?ppg=1` had become `min_price=1`. The failure only appears when all addons are installed together, which is why local runs passed.

## The fix

Name only the parameters each override actually reads, forward the rest by keyword:

```python
# website_stock_availability — reads no routing parameter
def shop(self, **kwargs):
    response = super().shop(**kwargs)

# website_sale_attributes — reads category and search
def shop(self, category=None, search="", **kwargs):
    response = super().shop(category=category, search=search, **kwargs)
```

Odoo always invokes endpoints as `endpoint(**request.params)` (`odoo/http.py:2297`), so nothing is lost by not restating parameters — and this shape cannot break again when core reorders its signature. It already survives 19.0, where `ppg` became `tags`.

## Regression test

`deltatech_website_sale_attributes/tests/test_shop_signature.py`:

- a 5.0 product must still be listed on `/shop?ppg=40`
- the same product must be gone on `/shop?min_price=40`

The second assertion matters: it proves the fix did not simply disable price filtering.

## Not fixed here

Three other overrides pass by keyword and are correct: `deltatech_website_sale_attribute_filter`, `deltatech_website_sale_category` (bitshop), `website_sale_product_brand` (others_addons).

Both modules also gained the `readme/HISTORY.md` they were missing.

## To port

19.0 needs the same treatment — the signature there is `(page, category, search, min_price, max_price, tags, **post)`, so any override still declaring `ppg` is already passing it into `tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)