### PR TITLE
[PORT] website_sale_attributes, website_stock_availability: ?ppg= filtered the shop by price

### DIFF
--- a/deltatech_website_sale_attributes/__manifest__.py
+++ b/deltatech_website_sale_attributes/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Attribute Values",
     "category": "Website",
     "summary": "Attribute values for products displayed",
-    "version": "19.0.1.0.2",
+    "version": "19.0.1.0.3",
     "license": "LGPL-3",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_sale_attributes/controllers/main.py
+++ b/deltatech_website_sale_attributes/controllers/main.py
@@ -6,8 +6,20 @@ from odoo.addons.website_sale.controllers.main import WebsiteSale
 
 class WebsiteSaleAttribute(WebsiteSale):
     @http.route()
-    def shop(self, page=0, category=None, search="", ppg=False, **post):
-        response = super().shop(page, category, search, ppg, **post)
+    def shop(self, category=None, search="", **kwargs):
+        # Only the two parameters this override actually reads are named; the
+        # rest travels in ``kwargs`` untouched. The previous signature was
+        # ``(page, category, search, ppg)`` and forwarded those positionally,
+        # but core's fourth slot is ``min_price``, so ``ppg`` landed there: a
+        # visitor passing ``?ppg=40`` got the catalogue silently filtered to
+        # products over 40 while the page size stayed at its default. On 19.0
+        # ``ppg`` is not even a core parameter any more, yet declaring it here
+        # still captured it and pushed it into ``min_price``.
+        #
+        # Odoo always invokes endpoints as ``endpoint(**request.params)``
+        # (``odoo/http.py``), so keyword forwarding is both correct and immune
+        # to any further signature change.
+        response = super().shop(category=category, search=search, **kwargs)
 
         if category and search:
             # Folosim domeniul construit de WebsiteSale pentru product.template

--- a/deltatech_website_sale_attributes/readme/HISTORY.md
+++ b/deltatech_website_sale_attributes/readme/HISTORY.md
@@ -1,0 +1,11 @@
+# History
+
+## 19.0.1.0.3 (2026-07-30)
+
+- Fixed `?ppg=` silently filtering the shop by price. The `shop()` override
+  declared `(page, category, search, ppg)` and forwarded those positionally,
+  but core's fourth slot is `min_price`, so `?ppg=40` reached it as
+  `min_price=40` and dropped every cheaper product from the listing while the
+  page size stayed at its default. On 19.0 `ppg` is not a core parameter at
+  all, yet declaring it here still captured it and pushed it into
+  `min_price`. The override now forwards by keyword only.

--- a/deltatech_website_sale_attributes/tests/__init__.py
+++ b/deltatech_website_sale_attributes/tests/__init__.py
@@ -3,3 +3,4 @@
 # See README.rst file on addons root folder for license details
 
 from . import test_website_attributes
+from . import test_shop_signature

--- a/deltatech_website_sale_attributes/tests/test_shop_signature.py
+++ b/deltatech_website_sale_attributes/tests/test_shop_signature.py
@@ -1,0 +1,65 @@
+# ©  2023 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+
+from odoo.tests import tagged
+from odoo.tests.common import HttpCase
+
+
+@tagged("post_install", "-at_install")
+class TestShopSignature(HttpCase):
+    """``?ppg=`` must never filter the shop by price.
+
+    This override used to declare ``shop(self, page, category, search, ppg)``
+    and forward those four positionally. Core's fourth parameter is
+    ``min_price``, so ``?ppg=40`` reached it as ``min_price=40`` and dropped
+    every product cheaper than that from the listing, silently. On 19.0 ``ppg``
+    is not a core parameter at all, which makes the old signature worse rather
+    than better: it captured a value core would otherwise have ignored and
+    pushed it into the price filter.
+
+    Assertions run against a category created here. These tests are
+    ``post_install``, so the global listing holds an unknown number of
+    published products and a single test product can land on page two — and on
+    19.0 ``?ppg=`` cannot widen the page to compensate.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.category = cls.env["product.public.category"].create({"name": "TB Signature Category"})
+        cls.cheap = cls.env["product.template"].create(
+            {
+                "name": "TB Signature Cheap Product",
+                "is_published": True,
+                "list_price": 5.0,
+                "public_categ_ids": [(6, 0, cls.category.ids)],
+            }
+        )
+        cls.category_url = f"/shop/category/{cls.env['ir.http']._slug(cls.category)}"
+
+    def test_ppg_does_not_filter_by_price(self):
+        """A product below the ``ppg`` value must still be listed."""
+        body = self.url_open(f"{self.category_url}?ppg=40").text
+
+        self.assertIn(
+            self.cheap.name,
+            body,
+            "a 5.0 product disappeared under ?ppg=40 — ppg is being read as min_price",
+        )
+
+    def test_min_price_still_filters(self):
+        """The real ``min_price`` parameter must keep working.
+
+        Without this the fix could have passed by disabling price filtering
+        altogether.
+        """
+        body = self.url_open(f"{self.category_url}?min_price=40").text
+
+        self.assertNotIn(
+            self.cheap.name,
+            body,
+            "min_price=40 should have excluded a 5.0 product",
+        )

--- a/deltatech_website_stock_availability/__manifest__.py
+++ b/deltatech_website_stock_availability/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Stock Availability",
     "category": "Website",
     "summary": "eCommerce Stock Availability and lead time",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "depends": ["website", "website_sale_stock", "purchase", "deltatech_vendor_stock"],

--- a/deltatech_website_stock_availability/controllers/main.py
+++ b/deltatech_website_stock_availability/controllers/main.py
@@ -6,8 +6,19 @@ from odoo.addons.website_sale.controllers import main
 
 class WebsiteSale(main.WebsiteSale):
     @http.route()
-    def shop(self, page=0, category=None, search="", ppg=False, **post):
-        response = super().shop(page, category, search, ppg, **post)
+    def shop(self, **kwargs):
+        # No parameter is restated here on purpose. The previous signature was
+        # ``(page, category, search, ppg)`` and forwarded those positionally,
+        # but core's fourth slot is ``min_price``, so ``ppg`` landed there: a
+        # visitor passing ``?ppg=40`` got the catalogue silently filtered to
+        # products over 40 while the page size stayed at its default. On 19.0
+        # ``ppg`` is not even a core parameter any more, yet declaring it here
+        # still captured it and pushed it into ``min_price``.
+        #
+        # Odoo always invokes endpoints as ``endpoint(**request.params)``
+        # (``odoo/http.py``), so accepting ``**kwargs`` and forwarding it is
+        # both correct and immune to any further signature change.
+        response = super().shop(**kwargs)
         availability_all = request.httprequest.args.get("availability_all", True)
         availability_in_stock = request.httprequest.args.get("availability_in_stock", False)
         availability_vendor = request.httprequest.args.get("availability_vendor", False)

--- a/deltatech_website_stock_availability/readme/HISTORY.md
+++ b/deltatech_website_stock_availability/readme/HISTORY.md
@@ -1,0 +1,11 @@
+# History
+
+## 19.0.1.0.9 (2026-07-30)
+
+- Fixed `?ppg=` silently filtering the shop by price. The `shop()` override
+  declared `(page, category, search, ppg)` and forwarded those positionally,
+  but core's fourth slot is `min_price`, so `?ppg=40` reached it as
+  `min_price=40` and dropped every cheaper product from the listing while the
+  page size stayed at its default. On 19.0 `ppg` is not a core parameter at
+  all, yet declaring it here still captured it and pushed it into
+  `min_price`. The override now forwards by keyword only.


### PR DESCRIPTION
Port of #2703 to 19.0. Same defect — and 19.0 makes the old signature *worse*, not better.

## The bug

Both modules declared:

```python
def shop(self, page=0, category=None, search="", ppg=False, **post):
    response = super().shop(page, category, search, ppg, **post)
```

Core 19.0:

```python
def shop(self, page=0, category=None, search='', min_price=0.0, max_price=0.0, tags='', **post)
```

Fourth positional slot is `min_price`. `/shop?ppg=40` → `min_price=40` → every product cheaper than 40 vanishes from the listing, silently.

**19.0 has no `ppg` core parameter at all.** Core would have ignored the query value entirely. Declaring it in the override is what captured it and fed it to the price filter — the old signature actively introduced a bug that would not otherwise exist here.

## The fix

Same shape as 18.0: name only what each override reads, forward the rest by keyword.

```python
# website_stock_availability — reads no routing parameter
def shop(self, **kwargs):
    response = super().shop(**kwargs)

# website_sale_attributes — reads category and search
def shop(self, category=None, search="", **kwargs):
    response = super().shop(category=category, search=search, **kwargs)
```

Odoo always invokes endpoints as `endpoint(**request.params)` (`odoo/http.py`), so nothing is lost by not restating parameters, and no future signature change can break it again.

## The test differs from 18.0

It asserts against a category created by the test, not the global listing.

Found while porting: the suite is `post_install`, the shop held **27 published products against `shop_ppg=21`**, and the newly created test product landed on page two. On 18.0 `?ppg=40` widens the page and hides that; on 19.0 `ppg` is ignored, so the assertion failed for a reason unrelated to the bug. Anchoring on a category removes pagination from the equation entirely.

## Verification

Through `.venv/bin/python`:

- with the fix: **7/7 passing**
- with the old signature restored: **1 failed** — `'TB Signature Cheap Product' not found` under `?ppg=40`

The second run is the one that matters: it proves the test actually catches the defect rather than passing vacuously.

`test_min_price_still_filters` guards the other direction — the fix could otherwise have "passed" by disabling price filtering altogether.

🤖 Generated with [Claude Code](https://claude.com/claude-code)