### PR TITLE
[FIX] deltatech_website_category: stop echoing unknown query params into fetched links

### DIFF
--- a/deltatech_website_category/__manifest__.py
+++ b/deltatech_website_category/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Product Category",
     "category": "Website",
     "summary": "Public category",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.1.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_category/controllers/main.py
+++ b/deltatech_website_category/controllers/main.py
@@ -11,6 +11,18 @@ from odoo.addons.website.controllers.main import QueryURL
 
 
 class WebsiteSaleCategory(http.Controller):
+    # Query parameters carried into the links of a fetched branch. Mirrors what
+    # ``WebsiteSale._shop_get_query_url_kwargs`` keeps, minus ``category``,
+    # which the templates supply themselves.
+    _KEPT_QUERY_PARAMS = (
+        "search",
+        "order",
+        "min_price",
+        "max_price",
+        "tags",
+        "attribute_value",
+    )
+
     @http.route(
         "/shop/category_children/<int:category_id>",
         type="http",
@@ -63,15 +75,19 @@ class WebsiteSaleCategory(http.Controller):
         # Rebuild the filter state from the raw args rather than from **kwargs:
         # a repeated parameter (`attribute_value`) collapses to its last value
         # in kwargs, which would silently drop attribute filters from the
-        # fetched links. `category` is excluded because the templates pass
-        # `category=0` to keep it out of these URLs.
+        # fetched links.
+        #
+        # Only the parameters core itself carries over are copied — see
+        # ``WebsiteSale._shop_get_query_url_kwargs``. Anything else a visitor
+        # appends to the URL is dropped instead of being woven into every link
+        # on the page. ``category`` is absent on purpose: the templates pass
+        # ``category=0`` to keep it out of these URLs.
         args = request.httprequest.args
         query = {}
-        for key in args.keys():
-            if key in ("category", "active_category", "offcanvas"):
-                continue
+        for key in self._KEPT_QUERY_PARAMS:
             values = args.getlist(key)
-            query[key] = values if len(values) > 1 else values[0]
+            if values:
+                query[key] = values if len(values) > 1 else values[0]
         keep = QueryURL("/shop", **query)
 
         content = request.env["ir.ui.view"]._render_template(

--- a/deltatech_website_category/readme/HISTORY.md
+++ b/deltatech_website_category/readme/HISTORY.md
@@ -1,3 +1,16 @@
+# History
+
+## 18.0.1.1.1 (2026-07-30)
+
+- `/shop/category_children/<id>` no longer echoes unknown query parameters
+  back into the links of the fetched branch. It copied every raw argument
+  into `QueryURL`, so anything a visitor appended was woven into every link
+  on the page — unlike core, which keeps only its own filter parameters in
+  `_shop_get_query_url_kwargs`. Crawlers that fail to decode HTML entities
+  request `&amp;order=` literally, which Odoo parses as a parameter named
+  `amp;order`; echoing it back would have published a fresh set of URLs on
+  every pass.
+
 ## 18.0.1.1.0 (2026-07-29)
 
 - The shop sidebar now renders only the open branch of the category tree.

--- a/deltatech_website_category/tests/test_lazy_categories.py
+++ b/deltatech_website_category/tests/test_lazy_categories.py
@@ -75,6 +75,26 @@ class TestLazyCategories(HttpCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("order=list_price", response.text)
 
+    def test_children_endpoint_drops_unknown_query_params(self):
+        """Only core's own filter parameters reach the fetched links.
+
+        The endpoint used to copy every raw query argument into ``QueryURL``,
+        so anything a visitor appended was woven into every link on the page.
+        Crawlers that do not decode HTML entities request ``&amp;order=``
+        literally, which Odoo parses as a parameter named ``amp;order``;
+        echoing it back would publish a fresh set of URLs on every pass. Core
+        filters these out in ``_shop_get_query_url_kwargs`` and so does this
+        endpoint now.
+        """
+        response = self.url_open(
+            f"/shop/category_children/{self.root.id}?order=name+asc&amp;order=list_price+desc&utm_source=x"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("order=name", response.text, "a known filter must survive")
+        self.assertNotIn("amp;", response.text, "the bogus parameter must not be echoed back")
+        self.assertNotIn("utm_source", response.text, "unknown parameters must not be echoed back")
+
     def test_children_endpoint_without_children(self):
         """A leaf yields an empty body rather than an error."""
         response = self.url_open(f"/shop/category_children/{self.grandchild.id}")


### PR DESCRIPTION
## The gap

`/shop/category_children/<id>` copied **every** raw query argument into `QueryURL`:

```python
for key in args.keys():
    if key in ("category", "active_category", "offcanvas"):
        continue
    query[key] = ...
keep = QueryURL("/shop", **query)
```

Core does not. [`_shop_get_query_url_kwargs`](https://github.com/odoo/odoo/blob/18.0/addons/website_sale/controllers/main.py) returns a fixed dict — `category`, `search`, `tags`, `min_price`, `max_price`, `order`, `attribute_value` — and drops everything else, including `**post`.

So anything a visitor appended to the URL was woven into every link of the fetched branch.

## Why it matters

Crawlers that fail to decode HTML entities request `&amp;order=` literally. Odoo parses that as a parameter named `amp;order`.

Verified against production: a request carrying `&amp;order=` produces **no link containing `amp;`** — core filters it and keeps generating clean URLs. This endpoint would have echoed it back instead, publishing a fresh set of URLs on every crawl pass.

That is the amplification loop core avoids by design, and this endpoint reopened it.

## Scope

**Not currently exploited.** `category_children` appears **zero times** in the production log that surfaced the 751 daily `amp;` requests — those all hit ordinary product and listing pages, where core's filtering already holds. This closes the gap before it is found, not after.

## The change

The raw-args loop stays — it exists so a repeated `attribute_value` does not collapse to its last value the way `**kwargs` would — but it now iterates a fixed allowlist mirroring core's:

```python
_KEPT_QUERY_PARAMS = ("search", "order", "min_price", "max_price", "tags", "attribute_value")
```

`category` is deliberately absent: the templates pass `category=0` to keep it out of these URLs.

## Test

`test_children_endpoint_drops_unknown_query_params` asserts that `order=name+asc` survives while `amp;order=…` and `utm_source=x` do not.

Verified through `.venv/bin/python`:

- with the fix: **8/8 passing**
- with the old loop restored: **1 failed**

The second run is what makes the test worth having.

## To port

19.0 carries the same code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)