### PR TITLE
[FIX] deltatech_invoice_picking: _search_invoiced pe domeniu SQL

### DIFF
--- a/deltatech_invoice_picking/__manifest__.py
+++ b/deltatech_invoice_picking/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Invoice Pickings",
-    "version": "18.0.1.0.9",
+    "version": "18.0.1.0.10",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Facturare livrari",

--- a/deltatech_invoice_picking/models/stock_picking_batch.py
+++ b/deltatech_invoice_picking/models/stock_picking_batch.py
@@ -20,8 +20,15 @@ class StockPickingBatch(models.Model):
             batch.invoiced = invoiced
 
     def _search_invoiced(self, operator, value):
-        batches = self.search([]).filtered(lambda x: x.invoiced == value)
-        return [("id", operator, [x.id for x in batches] if batches else False)]
+        if operator in ("=", "!="):
+            searched_value = bool(value) == (operator == "=")
+        elif operator in ("in", "not in") and isinstance(value, list | tuple | set) and set(value) == {True}:
+            searched_value = operator == "in"
+        else:
+            raise UserError(_("Unsupported operator %s on field invoiced") % operator)
+        # lot facturat = nu are nicio livrare fara factura
+        not_invoiced = [("picking_ids.account_move_id", "=", False)]
+        return ["!"] + not_invoiced if searched_value else not_invoiced
 
     def action_create_invoice(self):
         for batch in self:
@@ -33,17 +40,13 @@ class StockPickingBatch(models.Model):
                 for picking in pickings:
                     if picking.account_move_id:
                         pickings -= picking
-                result = pickings.action_create_invoice()
-                self.invoiced = True
-                return result
+                return pickings.action_create_invoice()
             elif batch.picking_type_id.code == "incoming":
                 # check if pickings are already invoiced and remove invoiced pickings from list
                 pickings = batch.picking_ids
                 for picking in pickings:
                     if picking.account_move_id:
                         pickings -= picking
-                result = pickings.action_create_supplier_invoice()
-                self.invoiced = True
-                return result
+                return pickings.action_create_supplier_invoice()
             else:
                 raise UserError(_("You cannot invoice this type of batches: (%s)") % batch.picking_type_id.code)

--- a/deltatech_invoice_picking/tests/test_invoice_picking.py
+++ b/deltatech_invoice_picking/tests/test_invoice_picking.py
@@ -88,6 +88,51 @@ class TestStockAccountCustom(common.TransactionCase):
     def test_action_create_invoice(self):
         self.picking_out.action_create_invoice()
 
+    def test_search_invoiced(self):
+        Batch = self.env["stock.picking.batch"]
+        # lotul se formeaza inainte de validare: _sanity_check refuza livrarile done
+        purchase_order = self.PurchaseOrder.create(
+            {
+                "partner_id": self.partner.id,
+                "date_order": fields.Date.today(),
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "name": self.product.name,
+                            "product_id": self.product.id,
+                            "product_qty": 5.0,
+                            "product_uom": self.product.uom_id.id,
+                            "price_unit": self.product.list_price,
+                            "date_planned": fields.Date.today(),
+                        },
+                    )
+                ],
+            }
+        )
+        purchase_order.button_confirm()
+        picking = purchase_order.picking_ids[0]
+        batch = Batch.create({"picking_ids": [(6, 0, picking.ids)]})
+
+        self.assertFalse(batch.invoiced)
+        self.assertIn(batch, Batch.search([("invoiced", "=", False)]))
+        self.assertNotIn(batch, Batch.search([("invoiced", "=", True)]))
+        # operatorii inversi trebuie sa dea acelasi rezultat
+        self.assertIn(batch, Batch.search([("invoiced", "!=", True)]))
+        self.assertNotIn(batch, Batch.search([("invoiced", "!=", False)]))
+
+        picking.move_line_ids[0].quantity = 5
+        picking.button_validate()
+        picking.write({"supplier_invoice_number": "INV/2023/002"})
+        picking.action_create_supplier_invoice()
+        self.assertTrue(picking.account_move_id)
+
+        batch.invalidate_recordset(["invoiced"])
+        self.assertTrue(batch.invoiced)
+        self.assertIn(batch, Batch.search([("invoiced", "=", True)]))
+        self.assertNotIn(batch, Batch.search([("invoiced", "=", False)]))
+
     def test_sale_invoice_creation(self):
         invoice = self.sale_order._create_invoices()
         self.assertTrue(invoice, "Invoice was not created for Sale Order")


### PR DESCRIPTION
## Context

`stock.picking.batch.invoiced` este un câmp calculat nestocat, căutabil prin `_search_invoiced`. Metoda încărca și calcula toate loturile în Python la fiecare filtrare, apoi întorcea `("id", operator, ids)`.

Problema a apărut la un upgrade 18 → 19 pe o bază de client: pe 19 varianta veche întoarce **tăcut** un rezultat greșit. Odoo 19 rescrie condițiile pe boolean înainte de a chema metoda `search` — `("invoiced", "=", False)` devine `("invoiced", "not in", [True])` prin `_operator_equal_as_in` + `_optimize_boolean_in` din `odoo/orm/domains.py`. Comparația `x.invoiced == value` devine bool vs listă, deci mereu falsă → recordset gol → `("id", "not in", False)` → `_optimize_in_set` transformă un `not in` gol în domeniu TRUE. Filtrul dispare complet și acțiunile „Batches to invoice" afișează toate loturile în starea done, inclusiv cele deja facturate.

## Modificare

`_search_invoiced` întoarce acum echivalentul direct pe câmpuri stocate — *lot facturat = nu are nicio livrare fără factură* — deci filtrarea devine o singură interogare SQL, fără `search([])` peste toate loturile. Operatorii nesuportați ridică `UserError` în loc să producă un domeniu ghicit.

Semantica e păstrată identic, inclusiv pentru loturile fără livrări (`all([])` = True ⟺ „nu are nicio livrare fără factură").

Eliminate și atribuirile `self.invoiced = True` din `action_create_invoice`: scriau pe tot recordset-ul din interiorul buclei `for batch in self` și oricum doar în cache, valoarea rezultând din compute după setarea `account_move_id`.

## Note

- Varianta echivalentă pentru 19.0 e deja pe branch (commit `563dfd2a5`); nu e un cherry-pick, fiindcă pe 19 se folosește clasa `Domain` și `NotImplemented`, care nu există în 18
- Verificat sintactic și prin citirea optimizatorului de domenii din core; nu a fost rulat pe o bază de test

🤖 Generated with [Claude Code](https://claude.com/claude-code)