### PR TITLE
[FIX] deltatech_sale_payment: _search_payment_status pentru domeniile normalizate din Odoo 19

### DIFF
--- a/deltatech_sale_payment/__manifest__.py
+++ b/deltatech_sale_payment/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Payment",
     "summary": "Payment button in sale order",
-    "version": "19.0.1.1.3",
+    "version": "19.0.1.1.4",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_payment/models/sale.py
+++ b/deltatech_sale_payment/models/sale.py
@@ -2,6 +2,7 @@
 # See README.rst file on addons root folder for license details
 
 from odoo import api, fields, models
+from odoo.fields import Domain
 
 
 class SaleOrder(models.Model):
@@ -96,13 +97,44 @@ class SaleOrder(models.Model):
             order.provider_id = provider
 
     def _search_payment_status(self, operator, value):
-        if operator == "=":
-            if value == "without":
-                return [("transaction_ids", "=", False)]
-            if value == "initiated":
-                return [("transaction_ids.state", "!=", "done")]
-            if value == "authorized":
-                return [("transaction_ids.state", "=", "authorized")]
-            if value == "done":
-                return [("transaction_ids.state", "=", "done")]
-        return []
+        # Odoo 19 rescrie `=` / `!=` in `in` / `not in` peste o colectie de valori
+        # (_operator_equal_as_in din odoo/orm/domains.py), la nivel BASIC, inaintea
+        # expandarii metodei `search`: metoda nu primeste niciodata operatorul `=`
+        if operator not in ("in", "not in"):
+            return NotImplemented
+        if operator == "in":
+            return Domain.OR(self._get_payment_status_domain(status) for status in value)
+        return Domain.AND(~self._get_payment_status_domain(status) for status in value)
+
+    def _get_payment_status_domain(self, status):
+        """Domeniul comenzilor cu statusul de plata dat.
+
+        Statusurile se exclud reciproc, in aceeasi ordine de prioritate ca in
+        `_compute_payment`. Ca si inainte, cautarea ia in calcul doar tranzactiile
+        de plata: sumele incasate direct pe facturi nu se pot exprima in domeniu.
+        """
+        has_transaction = Domain("transaction_ids", "!=", False)
+        has_done = Domain("transaction_ids.state", "in", ["done"])
+        has_authorized = Domain("transaction_ids.state", "in", ["authorized"])
+        has_cancelled = Domain("transaction_ids.state", "in", ["cancel"])
+        if status == "without":
+            return ~has_transaction
+        if status == "initiated":
+            return has_transaction & ~has_done & ~has_authorized & ~has_cancelled
+        if status == "authorized":
+            return has_authorized & ~has_done
+        if status == "cancelled":
+            return has_cancelled & ~has_authorized & ~has_done
+        if status in ("partial", "done"):
+            return Domain("id", "in", self._get_paid_order_ids(status))
+        return Domain.FALSE
+
+    def _get_paid_order_ids(self, status):
+        """Comenzile `partial` / `done`, evaluate in Python.
+
+        Diferenta dintre `partial` si `done` este suma incasata comparata cu totalul
+        comenzii, care nu se poate exprima in domeniu; restrangem la comenzile cu
+        tranzactii confirmate si evaluam statusul pe ele (ca `account.account._search_used`).
+        """
+        orders = self.search([("transaction_ids.state", "in", ["done"])])
+        return orders.filtered(lambda order: order.payment_status == status).ids

--- a/deltatech_sale_payment/tests/test_sale.py
+++ b/deltatech_sale_payment/tests/test_sale.py
@@ -342,10 +342,92 @@ class TestSaleOrderPayment(TransactionCase):
         orders = self.env["sale.order"].search([("id", "=", self.sale_order.id), ("payment_status", "=", "authorized")])
         self.assertIn(self.sale_order, orders)
 
-        # Create a done transaction
-        self._create_transaction(amount=30.0, state="done")
+        # Create a done transaction, below the order total -> partial, not done
+        half_total = self.sale_order.amount_total / 2
+        self._create_transaction(amount=half_total, state="done")
+        orders = self.env["sale.order"].search([("id", "=", self.sale_order.id), ("payment_status", "=", "partial")])
+        self.assertIn(self.sale_order, orders)
+
+        # Capture the rest of the order total -> done
+        self._create_transaction(amount=half_total, state="done")
         orders = self.env["sale.order"].search([("id", "=", self.sale_order.id), ("payment_status", "=", "done")])
         self.assertIn(self.sale_order, orders)
+
+    def _create_order(self, price_unit=100.0):
+        return self.env["sale.order"].create(
+            {
+                "partner_id": self.partner.id,
+                "order_line": [
+                    (
+                        0,
+                        0,
+                        {
+                            "product_id": self.product.id,
+                            "product_uom_qty": 1.0,
+                            "price_unit": price_unit,
+                        },
+                    )
+                ],
+            }
+        )
+
+    def _orders_by_payment_status(self):
+        """One order per payment status, so the search can be checked for exclusivity."""
+        orders = {"without": self._create_order()}
+
+        orders["initiated"] = self._create_order()
+        self._create_transaction_for_order(orders["initiated"], amount=10.0, state="pending")
+
+        orders["authorized"] = self._create_order()
+        self._create_transaction_for_order(orders["authorized"], amount=20.0, state="authorized")
+
+        orders["cancelled"] = self._create_order()
+        self._create_transaction_for_order(orders["cancelled"], amount=30.0, state="cancel")
+
+        orders["partial"] = self._create_order()
+        self._create_transaction_for_order(orders["partial"], amount=orders["partial"].amount_total / 2, state="done")
+
+        orders["done"] = self._create_order()
+        self._create_transaction_for_order(orders["done"], amount=orders["done"].amount_total, state="done")
+
+        return orders
+
+    def test_search_payment_status_returns_only_matching_orders(self):
+        # Regression: in Odoo 19 the search method receives 'in' / 'not in' (never '='),
+        # so an unhandled operator used to fall through to an empty (TRUE) domain and the
+        # filter silently returned every order
+        orders = self._orders_by_payment_status()
+        all_orders = self.env["sale.order"].browse([order.id for order in orders.values()])
+
+        for status, order in orders.items():
+            self.assertEqual(order.payment_status, status, f"Computed status for the '{status}' order")
+
+        for status, order in orders.items():
+            found = self.env["sale.order"].search([("id", "in", all_orders.ids), ("payment_status", "=", status)])
+            self.assertEqual(found, order, f"Only the '{status}' order must match payment_status = {status}")
+
+            found = self.env["sale.order"].search([("id", "in", all_orders.ids), ("payment_status", "!=", status)])
+            self.assertEqual(found, all_orders - order, f"Every other order must match payment_status != {status}")
+
+    def test_search_payment_status_multiple_values(self):
+        orders = self._orders_by_payment_status()
+        all_orders = self.env["sale.order"].browse([order.id for order in orders.values()])
+
+        found = self.env["sale.order"].search(
+            [("id", "in", all_orders.ids), ("payment_status", "in", ["partial", "done"])]
+        )
+        self.assertEqual(found, orders["partial"] | orders["done"])
+
+        found = self.env["sale.order"].search(
+            [("id", "in", all_orders.ids), ("payment_status", "not in", ["partial", "done"])]
+        )
+        self.assertEqual(found, all_orders - orders["partial"] - orders["done"])
+
+    def test_search_payment_status_unknown_value(self):
+        # An unknown value must match nothing, not everything
+        order = self._create_order()
+        found = self.env["sale.order"].search([("id", "=", order.id), ("payment_status", "=", "no_such_status")])
+        self.assertFalse(found)
 
     def test_wizard_onchange_provider(self):
         wizard = (


### PR DESCRIPTION
## Problema

`sale.order._search_payment_status` trata doar operatorul `=`:

```python
def _search_payment_status(self, operator, value):
    if operator == "=":
        ...
    return []
```

În Odoo 19 metoda nu primește niciodată `=`: `_operator_equal_as_in` (`odoo/orm/domains.py`) rescrie orice `=` / `!=` în `in` / `not in` peste un `OrderedSet`, la nivel BASIC, înaintea expandării metodei `search` (care se face la nivel FULL). Deci `("payment_status", "=", "done")` ajunge în metodă ca `("payment_status", "in", {"done"})`.

Consecință: condiția era mereu falsă, se ajungea la `return []`, iar un domeniu gol este TRUE — **filtrul dispărea complet și acțiunea afișa toate comenzile**, silent, fără excepție. Afecta filtrul `payment_initiated` din `views/sale_view.xml` și orice domeniu pe `payment_status`. Modulul e în `depends` la `terrabit_rsy`, `terrabit_insignis`, `terrabit_flodel`, `terrabit_datus` și `deltatech_ptc`, deci bug-ul era activ pe bazele clienților.

Aceeași clasă de bug ca [563dfd2a5](https://github.com/dhongu/deltatech/commit/563dfd2a5) (`deltatech_invoice_picking`).

## Corecția

Urmează idiomul din core 19 (`account.account._search_used`):

- tratează `in` / `not in` peste colecția de valori, întoarce `NotImplemented` pentru restul operatorilor;
- compune domeniile per valoare cu `Domain.OR` / `Domain.AND` (`from odoo.fields import Domain`);
- statusurile se exclud acum reciproc, în aceeași ordine de prioritate ca `_compute_payment` (înainte `authorized` intra și în `initiated`, iar `partial` și `cancelled` nu erau tratate deloc → tot domeniu TRUE);
- `partial` / `done` depind de suma încasată comparată cu totalul comenzii, care nu se poate exprima în domeniu: se restrânge la comenzile cu tranzacții confirmate și se evaluează statusul în Python;
- o valoare necunoscută întoarce `Domain.FALSE`, nu TRUE.

Limitare păstrată din implementarea anterioară, documentată în docstring: căutarea ia în calcul doar tranzacțiile de plată, nu sumele încasate direct pe facturi.

## Teste

3 teste noi: fiecare valoare a selecției întoarce **doar** comenzile corespunzătoare, plus complementul pentru `!=` / `not in`, plus valoarea necunoscută. Toate trei cad pe implementarea veche și trec pe cea nouă.

`test_search_payment_status` (existent) verifică acum `partial` pentru o tranzacție sub totalul comenzii — asertarea `done` de dinainte trecea doar pentru că domeniul era TRUE.

```
0 failed, 0 error(s) of 14 tests   # bază curată, test19_dsp
3 failed, 0 error(s) of 14 tests   # cu _search_payment_status vechi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)