### PR TITLE
[IMP] deltatech_purchase_create_bill_button: traducere RO

### DIFF
--- a/deltatech_purchase_create_bill_button/i18n/ro.po
+++ b/deltatech_purchase_create_bill_button/i18n/ro.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_create_bill_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-30 00:00+0000\n"
+"PO-Revision-Date: 2026-07-30 00:00+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_create_bill_button
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_create_bill_button.purchase_order_form
+msgid "Create Bill"
+msgstr "Creare factură"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_purchase_create_bill_button` — modulul nu avea folder `i18n`.

## Termeni

| msgid | msgstr |
|---|---|
| Create Bill | Creare factură |

Traducerea e preluată din `purchase/i18n/ro.po` (intrarea oficială Odoo, marcată acum obsoletă acolo), consistentă cu „Create Bills" → „Creați facturi".

Modulul are un singur termen traductibil: butonul din `views/purchase_view.xml`. `models/purchase_order.py` nu conține stringuri, iar `name`/`summary` din manifest se traduc prin `base`, nu prin `.po`-ul modulului.

## Verificare

- `msgfmt --check` — 1 mesaj tradus, fără erori
- pre-commit (`oca-checks-po`) — trecut

🤖 Generated with [Claude Code](https://claude.com/claude-code)