### PR TITLE
[FIX] deltatech_stock_negative: nu mai blochează vizualizarea stocului și ajustamentele de inventar

### DIFF
--- a/deltatech_stock_negative/__manifest__.py
+++ b/deltatech_stock_negative/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "No Negative Stock",
     "summary": "Negative stocks are not allowed",
-    "version": "19.0.2.0.6",
+    "version": "19.0.2.0.7",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Generic Modules/Stock",

--- a/deltatech_stock_negative/models/__init__.py
+++ b/deltatech_stock_negative/models/__init__.py
@@ -4,3 +4,5 @@
 from . import res_config
 from . import stock
 from . import stock_location
+
+# StockMoveLine override lives in stock.py alongside StockQuant

--- a/deltatech_stock_negative/models/stock.py
+++ b/deltatech_stock_negative/models/stock.py
@@ -12,6 +12,10 @@ class StockQuant(models.Model):
     def _get_available_quantity(
         self, product_id, location_id, lot_id=None, package_id=None, owner_id=None, strict=False, allow_negative=False
     ):
+        # This is a plain read/compute helper called from many places (forecast
+        # availability on lists/kanban, reservation math, inventory adjustments...).
+        # It must stay side-effect free: the "no negative stock" rule is enforced
+        # only at actual move validation time, in StockMoveLine._action_done().
         if (
             location_id
             and not location_id.allow_negative_stock
@@ -19,7 +23,7 @@ class StockQuant(models.Model):
             and product_id.tracking == "serial"
         ):
             lot_id = None
-        res = super()._get_available_quantity(
+        return super()._get_available_quantity(
             product_id=product_id,
             location_id=location_id,
             lot_id=lot_id,
@@ -28,24 +32,57 @@ class StockQuant(models.Model):
             strict=strict,
             allow_negative=allow_negative,
         )
-        company = self.mapped("company_id") or self.env.company
-        if len(company) > 1:
-            raise UserError(_("You cannot search for available quantity across several companies."))
-        if not company.no_negative_stock:
-            return res
-        # check if reception. Sometimes at reception, _get_available_quantity returns
-        # a negative quantity for newly created quants, so the check should be skipped
-        if self.env.context.get("restricted_picking_type_code") == "incoming":
-            return res
-        if location_id and not location_id.allow_negative_stock and res < 0.0 and location_id.usage == "internal":
-            err = _(
-                "You have chosen to avoid negative stock. %(lot_qty)s pieces of %(product_name)s"
-                " are remaining in location %(location_name)s. "
-                "Please adjust your quantities or correct your stock with an inventory adjustment."
-            ) % {
-                "lot_qty": res,
-                "product_name": product_id.name,
-                "location_name": location_id.name,
-            }
-            raise UserError(err)
-        return res
+
+
+class StockMoveLine(models.Model):
+    _inherit = "stock.move.line"
+
+    def _action_done(self):
+        self._check_no_negative_stock()
+        return super()._action_done()
+
+    def _check_no_negative_stock(self):
+        """Block only the actual validation of a move, not the browsing of
+        stock or the correction of an existing deviation via an inventory
+        adjustment (that flow does not go through here).
+
+        Checked against the raw physical `quantity` on the quant, not the
+        `available_quantity` (quantity minus reserved): this move already
+        holds its own reservation on that quant, so netting reservations out
+        here would count the move's own reservation as competing demand.
+        """
+        Quant = self.env["stock.quant"]
+        for ml in self:
+            location = ml.location_id
+            if not location or location.usage != "internal" or location.allow_negative_stock:
+                continue
+            company = ml.company_id or self.env.company
+            if not company.no_negative_stock:
+                continue
+            quantity = ml.product_uom_id._compute_quantity(ml.quantity, ml.product_id.uom_id, rounding_method="HALF-UP")
+            if ml.product_id.uom_id.compare(quantity, 0) <= 0:
+                continue
+            lot_id = ml.lot_id
+            if ml.product_id.tracking == "serial" and not location.check_serial_no:
+                lot_id = None
+            domain = [
+                ("product_id", "=", ml.product_id.id),
+                ("location_id", "=", location.id),
+                ("lot_id", "=", lot_id.id if lot_id else False),
+                ("package_id", "=", ml.package_id.id if ml.package_id else False),
+                ("owner_id", "=", ml.owner_id.id if ml.owner_id else False),
+            ]
+            physical_qty = sum(Quant.sudo().search(domain).mapped("quantity"))
+            if ml.product_id.uom_id.compare(physical_qty - quantity, 0) < 0:
+                raise UserError(
+                    _(
+                        "You have chosen to avoid negative stock. %(lot_qty)s pieces of %(product_name)s"
+                        " are remaining in location %(location_name)s. "
+                        "Please adjust your quantities or correct your stock with an inventory adjustment."
+                    )
+                    % {
+                        "lot_qty": physical_qty - quantity,
+                        "product_name": ml.product_id.name,
+                        "location_name": location.name,
+                    }
+                )

--- a/deltatech_stock_negative/tests/test_negative.py
+++ b/deltatech_stock_negative/tests/test_negative.py
@@ -49,6 +49,7 @@ class TestNegative(TransactionCase):
             }
         )
         move._action_confirm()
+        move.picked = True
         move_line = self.env["stock.move.line"].create(move._prepare_move_line_vals())
         move_line.quantity = 10.0
         move._action_done()
@@ -67,6 +68,7 @@ class TestNegative(TransactionCase):
             }
         )
         move._action_confirm()
+        move.picked = True
         move_line = self.env["stock.move.line"].create(move._prepare_move_line_vals())
 
         with self.assertRaises(UserError) as cm:
@@ -91,6 +93,7 @@ class TestNegative(TransactionCase):
             }
         )
         move._action_confirm()
+        move.picked = True
         move_line = self.env["stock.move.line"].create(move._prepare_move_line_vals())
         move_line.lot_id = self.lot
         move_line.quantity = 10.0
@@ -113,6 +116,7 @@ class TestNegative(TransactionCase):
             }
         )
         move._action_confirm()
+        move.picked = True
         move_line = self.env["stock.move.line"].create(move._prepare_move_line_vals())
         move_line.lot_id = self.lot
 
@@ -138,6 +142,7 @@ class TestNegative(TransactionCase):
                 "product_uom_qty": 10.0,
             }
         )
+        move.picked = True
         move_line = self.env["stock.move.line"].create(move._prepare_move_line_vals())
         move_line.package_id = package
         move_line.quantity = 10.0
@@ -160,9 +165,43 @@ class TestNegative(TransactionCase):
                 "product_uom_qty": 10.0,
             }
         )
+        move.picked = True
         move_line = self.env["stock.move.line"].create(move._prepare_move_line_vals())
 
         with self.assertRaises(UserError) as cm:
             move_line.quantity = 10.0
             move._action_done()
         self.assertRegex(cm.exception.args[0], "avoid negative stock")
+
+    def test_view_and_adjust_existing_deviation(self):
+        # Simulate a pre-existing negative deviation on the location (e.g. from
+        # before the rule was enabled), bypassing validation the same way a
+        # direct quant write would (this call does not go through
+        # StockMoveLine._action_done()).
+        self.env["stock.quant"]._update_available_quantity(
+            product_id=self.product, location_id=self.stock_location, quantity=-5.0
+        )
+        quant = self.env["stock.quant"].search(
+            [("product_id", "=", self.product.id), ("location_id", "=", self.stock_location.id)]
+        )
+        self.assertEqual(quant.quantity, -5.0)
+
+        # Reading a compute that goes through _get_available_quantity (e.g. a
+        # draft move's forecast/availability, as rendered in transfer lists)
+        # must not raise.
+        move = self.env["stock.move"].create(
+            {
+                "location_id": self.stock_location.id,
+                "location_dest_id": self.pack_location.id,
+                "product_id": self.product.id,
+                "product_uom": self.uom_unit.id,
+                "product_uom_qty": 1.0,
+            }
+        )
+        self.assertEqual(move.availability, 0.0)
+
+        # Correcting the deviation via an inventory adjustment must not raise,
+        # even while it stays negative.
+        quant.write({"inventory_quantity": -2.0})
+        quant.action_apply_inventory()
+        self.assertEqual(quant.quantity, -2.0)


### PR DESCRIPTION
## Context / de ce

Cu „No negative stock" activat, modulul bloca și simpla vizualizare a stocului
sau salvarea unui ajustament de inventar de câte ori exista deja o abatere
(cantitate negativă) pe o locație — un blocaj tip cerc vicios: nu puteai
corecta abaterea pentru că salvarea corecției declanșa aceeași eroare.

Cauza: `StockQuant._get_available_quantity()` este un getter generic de
citire, apelat din foarte multe locuri din core (afișarea disponibilității pe
listele/kanban-urile de transferuri, calculul de rezervare, aplicarea unui
ajustament de inventar). Suprascrierea ridica `UserError` direct din acest
getter, indiferent de context — deci și la simpla citire, nu doar la
validarea efectivă a unei mișcări.

## Ce s-a schimbat

- `models/stock.py`:
  - `StockQuant._get_available_quantity()` a rămas un getter curat, fără
    efecte secundare (a păstrat doar logica preexistentă pentru
    serie/`check_serial_no`).
  - Restricția „no negative stock" s-a mutat în `StockMoveLine._action_done()`
    (noua metodă `_check_no_negative_stock()`), verificând doar la validarea
    efectivă a mișcării, pe locația sursă internă, cantitatea fizică brută a
    quant-ului (`quantity`), nu cea disponibilă netă de rezervări
    (`available_quantity` — mișcarea validată deja își rezervase propria
    cantitate, așa că nu trebuie contabilizată ca „cerere concurentă").
- `models/__init__.py`: fără schimbare funcțională.
- `tests/test_negative.py`:
  - testele existente primesc `move.picked = True` înainte de
    `_action_done()` — fără acest flag, Odoo 19 anulează mișcarea în loc s-o
    proceseze, iar testele vechi „treceau" din întâmplare (blocajul se
    declanșa la rezervare, nu la validare, cum se intenționa).
  - test nou, `test_view_and_adjust_existing_deviation`: simulează o abatere
    negativă preexistentă și verifică că (a) citirea disponibilității unei
    mișcări nu mai ridică eroare și (b) corectarea parțială printr-un
    ajustament de inventar (care rămâne tot negativ) se salvează.
- `__manifest__.py`: bump versiune `19.0.2.0.6` → `19.0.2.0.7`.

## Testare

Rulat local, pe bază demo-free (`--without-demo=all`):

```
python3 odoo-bin -d test_negstock --without-demo=all -i deltatech_stock_negative \
    --test-enable --test-tags /deltatech_stock_negative --stop-after-init
```

Rezultat: `0 failed, 0 error(s) of 7 tests`.

## Note / riscuri

- Comportamentul de „no negative stock" rămâne activ exact ca înainte pentru
  cazul real vizat (validarea unei mișcări care ar duce stocul sub zero pe o
  locație internă fără `allow_negative_stock`) — doar punctul de verificare
  s-a mutat de la citire la validare.
- Nu am modificat comportamentul pentru locații/produse care permit deja
  stoc negativ (`allow_negative_stock`, serie fără `check_serial_no`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)