### PR TITLE
[FIX] deltatech_website_sale_portal: replace deprecated odoo.osv.expression

### DIFF
--- a/deltatech_website_sale_portal/__manifest__.py
+++ b/deltatech_website_sale_portal/__manifest__.py
@@ -7,7 +7,7 @@
     "name": "eCommerce Portal",
     "category": "Website",
     "summary": "eCommerce Portal extension",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_sale_portal/controllers/portal.py
+++ b/deltatech_website_sale_portal/controllers/portal.py
@@ -3,8 +3,8 @@
 # See README.rst file on addons root folder for license details
 
 from odoo import _, http
+from odoo.fields import Domain
 from odoo.http import request
-from odoo.osv import expression
 
 from odoo.addons.sale.controllers import portal
 
@@ -37,11 +37,11 @@ class CustomerPortal(portal.CustomerPortal):
                 search_in = request.params.get("search_in", "all")
 
                 if search_in == "name":
-                    domain = expression.AND([domain, [("name", "ilike", search)]])
+                    domain = Domain.AND([domain, [("name", "ilike", search)]])
                 if search_in == "client_order_ref":
-                    domain = expression.AND([domain, [("client_order_ref", "ilike", search)]])
+                    domain = Domain.AND([domain, [("client_order_ref", "ilike", search)]])
                 if search_in == "all":
-                    domain = expression.AND(
+                    domain = Domain.AND(
                         [domain, ["|", ("name", "ilike", search), ("client_order_ref", "ilike", search)]]
                     )
         return domain

--- a/deltatech_website_sale_portal/readme/HISTORY.md
+++ b/deltatech_website_sale_portal/readme/HISTORY.md
@@ -1,0 +1,5 @@
+## 19.0.1.0.1 (2026-07-30)
+
+- Fix: replaced the deprecated `odoo.osv.expression` import with `odoo.fields.Domain`
+  (`expression.AND` → `Domain.AND`). Since 19.0 `odoo.osv` emits a `DeprecationWarning`
+  at import time and is scheduled for removal.


### PR DESCRIPTION
## Problem

Loading the module emits a `DeprecationWarning` at import time:

```
DeprecationWarning: Since 19.0, odoo.osv is deprecated use odoo.fields.Domain
  File ".../deltatech_website_sale_portal/controllers/portal.py", line 7, in <module>
    from odoo.osv import expression
```

`odoo.osv` is deprecated since 19.0 and scheduled for removal, so the import will eventually break, not just warn.

## Fix

Use `odoo.fields.Domain` instead: `expression.AND` → `Domain.AND` in `_prepare_domain_search`.

## Compatibility

Verified the replacement is functionally equivalent, not just syntactically:

- `Domain.AND` returns the same normalized domain (`['&', '&', ..., '|', ...]`) as the old `expression.AND`.
- `_prepare_quotations_domain` / `_prepare_orders_domain` now return a `Domain` object. The standard `sale` portal controller then does `domain += [('create_date', '>', date_begin), ...]`; `Domain.__add__` accepts list concatenation and returns a list, so the date-range filter on `/my/quotes` and `/my/orders` keeps working.
- `search()` / `search_count()` accept a `Domain` directly.

Pre-commit passes (ruff, ruff-format, pylint_odoo, Odoo module checks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)