### PR TITLE
[19.0][FIX] deltatech_account_analytic: include out_receipt in team_i…

### DIFF
--- a/deltatech_account_analytic/__manifest__.py
+++ b/deltatech_account_analytic/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech Account Analytic",
     "summary": "Analytic lines enhancements",
-    "version": "19.0.0.0.5",
+    "version": "19.0.0.0.6",
     "author": "Terrabit, Dan Stoica",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_account_analytic/models/account_analytic.py
+++ b/deltatech_account_analytic/models/account_analytic.py
@@ -22,6 +22,6 @@ class AccountAnalyticLine(models.Model):
                     picking_id = stock_move_id.picking_id
                     if picking_id and picking_id.sale_id:
                         vals["team_id"] = picking_id.sale_id.team_id.id
-                elif move_line_id.move_id.move_type in ["out_invoice", "out_refund"]:
+                elif move_line_id.move_id.move_type in ["out_invoice", "out_refund", "out_receipt"]:
                     vals["team_id"] = move_line_id.move_id.team_id.id
         return super().create(vals_list)

--- a/deltatech_account_analytic/readme/HISTORY.md
+++ b/deltatech_account_analytic/readme/HISTORY.md
@@ -1,0 +1,21 @@
+# Changelog
+
+## 19.0.0.0.6 (2026-07-31)
+
+- Fix: analytic lines generated from `out_receipt` (Sales Receipt) invoices
+  kept `team_id` empty on `account.analytic.line`, even though
+  `analytic_distribution` on the source `account.move.line` was already
+  correct (fixed in 19.0.0.0.5). `AccountAnalyticLine.create()` copies
+  `team_id` from `move_id.team_id` only for `out_invoice`/`out_refund` —
+  `out_receipt` was missing from that list, unlike the equivalent list in
+  `account_move.py`. Added `out_receipt` so both stay consistent.
+
+## 19.0.0.0.5 (2026-07-27)
+
+- Fix: `_compute_analytic_distribution` looked up the distribution model by
+  `move_id.team_id` but never declared it as a dependency, so lines kept
+  their stale (often empty) analytic distribution whenever the sales team
+  changed on an existing invoice, instead of only at creation time.
+- Fix: `out_receipt` (Sales Receipt) invoices were excluded from the
+  team-based analytic matching, so their revenue lines never got an
+  analytic account, unlike `out_invoice`/`out_refund` lines.

--- a/deltatech_account_analytic/tests/__init__.py
+++ b/deltatech_account_analytic/tests/__init__.py
@@ -2,4 +2,5 @@
 # See README.rst file on addons root folder for license details
 
 
+from . import test_account_analytic_team
 from . import test_split

--- a/deltatech_account_analytic/tests/test_account_analytic_team.py
+++ b/deltatech_account_analytic/tests/test_account_analytic_team.py
@@ -1,6 +1,7 @@
 # ©  2023-now Terrabit
 # See README.rst file on addons root folder for license details
 
+from odoo import Command
 from odoo.tests import tagged
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
@@ -44,3 +45,34 @@ class TestAccountAnalyticTeam(AccountTestInvoicingCommon):
         analytic_lines = self._post_invoice_with_team("out_receipt")
         self.assertTrue(analytic_lines)
         self.assertEqual(analytic_lines.team_id, self.sale_team)
+
+    def test_entry_analytic_line_no_team_id(self):
+        """A manual journal entry is not team-based: its analytic line must not get team_id."""
+        move = self.env["account.move"].create(
+            {
+                "move_type": "entry",
+                "journal_id": self.company_data["default_journal_misc"].id,
+                "team_id": self.sale_team.id,
+                "line_ids": [
+                    Command.create(
+                        {
+                            "account_id": self.company_data["default_account_revenue"].id,
+                            "analytic_distribution": {str(self.analytic_account.id): 100},
+                            "debit": 0.0,
+                            "credit": 100.0,
+                        }
+                    ),
+                    Command.create(
+                        {
+                            "account_id": self.company_data["default_account_expense"].id,
+                            "debit": 100.0,
+                            "credit": 0.0,
+                        }
+                    ),
+                ],
+            }
+        )
+        move.action_post()
+        analytic_lines = self.env["account.analytic.line"].search([("move_line_id.move_id", "=", move.id)])
+        self.assertTrue(analytic_lines)
+        self.assertFalse(analytic_lines.team_id)

--- a/deltatech_account_analytic/tests/test_account_analytic_team.py
+++ b/deltatech_account_analytic/tests/test_account_analytic_team.py
@@ -11,6 +11,9 @@ class TestAccountAnalyticTeam(AccountTestInvoicingCommon):
     def setUpClass(cls):
         super().setUpClass()
         cls.sale_team = cls.env["crm.team"].sudo().create({"name": "Test Team"})
+        # Some installs (e.g. l10n_ro_efactura_enhancement) refuse to post out_invoice/out_refund
+        # for a partner without a country, so give the test partner one regardless of the install.
+        cls.partner_a.write({"country_id": cls.env.ref("base.us").id})
         cls.analytic_plan = cls.env["account.analytic.plan"].create({"name": "Test Plan"})
         cls.analytic_account = cls.env["account.analytic.account"].create(
             {"name": "Test Analytic Account", "plan_id": cls.analytic_plan.id}

--- a/deltatech_account_analytic/tests/test_account_analytic_team.py
+++ b/deltatech_account_analytic/tests/test_account_analytic_team.py
@@ -1,0 +1,42 @@
+# ©  2023-now Terrabit
+# See README.rst file on addons root folder for license details
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged("post_install", "-at_install")
+class TestAccountAnalyticTeam(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.sale_team = cls.env["crm.team"].sudo().create({"name": "Test Team"})
+        cls.analytic_plan = cls.env["account.analytic.plan"].create({"name": "Test Plan"})
+        cls.analytic_account = cls.env["account.analytic.account"].create(
+            {"name": "Test Analytic Account", "plan_id": cls.analytic_plan.id}
+        )
+
+    def _post_invoice_with_team(self, move_type):
+        invoice = self._create_invoice(
+            move_type=move_type,
+            team_id=self.sale_team.id,
+            invoice_line_ids=[
+                self._prepare_invoice_line(
+                    product_id=self.product_a,
+                    analytic_distribution={str(self.analytic_account.id): 100},
+                ),
+            ],
+        )
+        invoice.action_post()
+        return self.env["account.analytic.line"].search([("move_line_id.move_id", "=", invoice.id)])
+
+    def test_out_invoice_analytic_line_team_id(self):
+        analytic_lines = self._post_invoice_with_team("out_invoice")
+        self.assertTrue(analytic_lines)
+        self.assertEqual(analytic_lines.team_id, self.sale_team)
+
+    def test_out_receipt_analytic_line_team_id(self):
+        """Analytic lines generated from out_receipt must get team_id, same as out_invoice."""
+        analytic_lines = self._post_invoice_with_team("out_receipt")
+        self.assertTrue(analytic_lines)
+        self.assertEqual(analytic_lines.team_id, self.sale_team)

--- a/deltatech_account_analytic/tests/test_account_analytic_team.py
+++ b/deltatech_account_analytic/tests/test_account_analytic_team.py
@@ -1,8 +1,9 @@
 # ©  2023-now Terrabit
 # See README.rst file on addons root folder for license details
 
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
+
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged("post_install", "-at_install")


### PR DESCRIPTION
…d matching for analytic lines

_compute_analytic_distribution on account.move.line already includes out_receipt in team-based analytic matching, but the separate team_id assignment in AccountAnalyticLine.create() still used the old ["out_invoice", "out_refund"] list, so analytic lines generated from sales receipts kept team_id empty even though their analytic distribution was correct.