### PR TITLE
[IMP] i18n: fișiere .pot pentru toate modulele

### DIFF
--- a/deltatech/i18n/deltatech.pot
+++ b/deltatech/i18n/deltatech.pot
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech
+#: model:ir.model.fields,field_description:deltatech.field_ir_rule__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech
+#: model:ir.model.fields,field_description:deltatech.field_ir_rule__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech
+#: model:ir.model.fields,field_description:deltatech.field_ir_rule__model_name
+msgid "Model Name"
+msgstr ""
+
+#. module: deltatech
+#: model:ir.model,name:deltatech.model_ir_rule
+msgid "Record Rule"
+msgstr ""

--- a/deltatech_account/i18n/deltatech_account.pot
+++ b/deltatech_account/i18n/deltatech_account.pot
@@ -1,0 +1,46 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_account
+#: model_terms:ir.ui.view,arch_db:deltatech_account.res_config_settings_view_form
+msgid "Accounting"
+msgstr ""
+
+#. module: deltatech_account
+#: model:ir.model.fields,field_description:deltatech_account.field_res_config_settings__use_anglo_saxon
+msgid "Anglo-Saxon Accounting"
+msgstr ""
+
+#. module: deltatech_account
+#: model:ir.model,name:deltatech_account.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_account
+#: model:ir.model.fields,field_description:deltatech_account.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_account
+#: model:ir.model.fields,field_description:deltatech_account.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_account
+#: model_terms:ir.ui.view,arch_db:deltatech_account.res_config_settings_view_form
+msgid "Record cost of goods sold in your journal entries"
+msgstr ""

--- a/deltatech_account_analytic/i18n/deltatech_account_analytic.pot
+++ b/deltatech_account_analytic/i18n/deltatech_account_analytic.pot
@@ -1,0 +1,286 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_account_analytic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__amount
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__amount
+#: model:ir.model.fields.selection,name:deltatech_account_analytic.selection__account_analytic_split__split_type__amount
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#. odoo-python
+#: code:addons/deltatech_account_analytic/models/account_analytic_split.py:0
+msgid "Amount must be non-zero"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:res.groups,name:deltatech_account_analytic.group_analytic_split
+msgid "Analitic split user"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__analytic_id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__analytic_id
+msgid "Analytic"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_account_analytic_distribution_model
+msgid "Analytic Distribution Model"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_account_analytic_line
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__analytic_line_id
+msgid "Analytic Line"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.actions.act_window,name:deltatech_account_analytic.action_analytic_split
+#: model:ir.model,name:deltatech_account_analytic.model_account_analytic_split
+msgid "Analytic split"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_account_analytic_split_line
+msgid "Analytic split line"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_account_analytic_split_template
+msgid "Analytic split template"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_account_analytic_split_template_line
+msgid "Analytic split template line"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.actions.act_window,name:deltatech_account_analytic.action_analytic_split_template
+#: model:ir.ui.menu,name:deltatech_account_analytic.menu_analytic_split_template
+msgid "Analytic split templates"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.ui.menu,name:deltatech_account_analytic.menu_analytic_split
+msgid "Analytic splits"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_form
+msgid "Compute"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_form
+msgid "Confirm"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields.selection,name:deltatech_account_analytic.selection__account_analytic_split__state__confirmed
+msgid "Confirmed"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__create_uid
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__create_uid
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__create_uid
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__create_date
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__create_date
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__create_date
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__date
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_distribution_model__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_line__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields.selection,name:deltatech_account_analytic.selection__account_analytic_split__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_distribution_model__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_line__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_move_line__id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#. odoo-python
+#: code:addons/deltatech_account_analytic/models/account_analytic_split.py:0
+msgid "Invalid template. Sum of percents must be 100"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model,name:deltatech_account_analytic.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__write_uid
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__write_uid
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__write_uid
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__write_date
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__write_date
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__write_date
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields.selection,name:deltatech_account_analytic.selection__account_analytic_split__split_type__line
+msgid "Line"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__line_to_split
+msgid "Line To Split"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_form
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_t_form
+msgid "Lines templates"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__name
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__percent
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__percent
+msgid "Percent %"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_line__product_category_id
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_line_filter
+msgid "Product category"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_form
+msgid "Reset"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_distribution_model__team_id
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_line_filter
+msgid "Sale team"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__sequence
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_line__split_id
+msgid "Split"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__split_template_id
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template_line__split_template_id
+msgid "Split Template"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__split_type
+msgid "Split Type"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__line_ids
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split_template__line_ids
+msgid "Split lines"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_split__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model:ir.model.fields,field_description:deltatech_account_analytic.field_account_analytic_line__team_id
+msgid "Team"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#. odoo-python
+#: code:addons/deltatech_account_analytic/models/account_analytic_split.py:0
+msgid "This operation is not permitted for this type of split (Line)"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#. odoo-python
+#: code:addons/deltatech_account_analytic/models/account_analytic_split.py:0
+msgid "You must select a split template"
+msgstr ""
+
+#. module: deltatech_account_analytic
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_form
+#: model_terms:ir.ui.view,arch_db:deltatech_account_analytic.view_account_analytic_split_t_form
+msgid "percent"
+msgstr ""

--- a/deltatech_account_edi_ubl_advice/i18n/deltatech_account_edi_ubl_advice.pot
+++ b/deltatech_account_edi_ubl_advice/i18n/deltatech_account_edi_ubl_advice.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_account_edi_ubl_advice
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_account_edi_ubl_advice
+#: model:ir.model.fields,field_description:deltatech_account_edi_ubl_advice.field_account_edi_xml_ubl_bis3__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_account_edi_ubl_advice
+#: model:ir.model.fields,field_description:deltatech_account_edi_ubl_advice.field_account_edi_xml_ubl_bis3__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_account_edi_ubl_advice
+#: model:ir.model,name:deltatech_account_edi_ubl_advice.model_account_edi_xml_ubl_bis3
+msgid "UBL BIS Billing 3.0.12"
+msgstr ""

--- a/deltatech_account_edit_currency_rate/i18n/deltatech_account_edit_currency_rate.pot
+++ b/deltatech_account_edit_currency_rate/i18n/deltatech_account_edit_currency_rate.pot
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_account_edit_currency_rate
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_account_edit_currency_rate
+#: model:ir.model,name:deltatech_account_edit_currency_rate.model_res_currency
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_account_edit_currency_rate
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_account_bank_statement_line__currency_rate_custom
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_account_move__currency_rate_custom
+msgid "Currency Rate Custom"
+msgstr ""
+
+#. module: deltatech_account_edit_currency_rate
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_account_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_res_currency__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_account_edit_currency_rate
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_account_move_line__id
+#: model:ir.model.fields,field_description:deltatech_account_edit_currency_rate.field_res_currency__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_account_edit_currency_rate
+#: model:ir.model,name:deltatech_account_edit_currency_rate.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_account_edit_currency_rate
+#: model:ir.model,name:deltatech_account_edit_currency_rate.model_account_move_line
+msgid "Journal Item"
+msgstr ""

--- a/deltatech_actions/i18n/deltatech_actions.pot
+++ b/deltatech_actions/i18n/deltatech_actions.pot
@@ -1,0 +1,146 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_actions
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,website_form_label:deltatech_actions.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_create_missing_reordering_rules_ir_actions_server
+msgid "Create missing reordering rules (0/0)"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/product.py:0
+msgid "Created %s missing rules"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_partner.py:0
+msgid "Cron job: Au fost normalizate %s nume de companii"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_xml_attachments_ir_actions_server
+msgid "Delete duplicate xml attachments"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_mail_messages_ir_actions_server
+msgid "Delete mail messages"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_pdf_attachments_invoice_ir_actions_server
+msgid "Delete pdf invoice attachments"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_pdf_attachments_stock_picking_ir_actions_server
+msgid "Delete pdf pickings attachments"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_pdf_attachments_sale_order_ir_actions_server
+msgid "Delete pdf sale order attachments"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_mail_message__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_partner__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_partner.py:0
+msgid "EROARE - Normalizare companii - Cron Job"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_partner.py:0
+msgid "Eroare în normalizarea companiilor: %s"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_mail_message__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_partner__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_merge_companies_ir_actions_server
+msgid "Merge duplicate companies by VAT"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.ir_cron_merge_contacts_ir_actions_server
+msgid "Merge duplicate contacts by email"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_mail_message
+msgid "Message"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_partner.py:0
+msgid "Normalizare companii - Cron Job"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.actions.server,name:deltatech_actions.cron_normalize_company_names_ir_actions_server
+msgid "Normalize company names"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_agreement_management/i18n/deltatech_agreement_management.pot
+++ b/deltatech_agreement_management/i18n/deltatech_agreement_management.pot
@@ -1,0 +1,399 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_agreement_management
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#. odoo-python
+#: code:addons/deltatech_agreement_management/models/res_partner.py:0
+#: model:ir.ui.menu,name:deltatech_agreement_management.menu_general_agr
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "Agreement"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__date_agreement
+msgid "Agreement Date"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.ui.menu,name:deltatech_agreement_management.menu_general_agreement_config_type
+msgid "Agreement types"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_res_partner__agreement_count
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_res_users__agreement_count
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_partner_form_agreement
+msgid "Agreements"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "Close Contract"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__company_currency_id
+msgid "Company Currency"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.ui.menu,name:deltatech_agreement_management.menu_general_agreement_config
+msgid "Configuration"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model,name:deltatech_agreement_management.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model,website_form_label:deltatech_agreement_management.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__create_uid
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__create_date
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__description
+msgid "Description"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__display_name
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__display_name
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields.selection,name:deltatech_agreement_management.selection__general_agreement__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__final_date
+msgid "Final Date"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model,name:deltatech_agreement_management.model_general_agreement
+msgid "General Agreement"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model,name:deltatech_agreement_management.model_general_agreement_type
+msgid "General Agreement Type"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "Get number"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__id
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__id
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_res_partner__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__message_has_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields.selection,name:deltatech_agreement_management.selection__general_agreement__state__open
+msgid "In Progress"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__write_uid
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__write_date
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__print_template_id
+msgid "Layout"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:res.groups,name:deltatech_agreement_management.group_agreement_manager
+msgid "Manager"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "Print"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__name
+msgid "Reference"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__sequence_id
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "Set Draft"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "Set In Progress"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__state
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields.selection,name:deltatech_agreement_management.selection__general_agreement__state__closed
+msgid "Terminated"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement__type_id
+#: model:ir.model.fields,field_description:deltatech_agreement_management.field_general_agreement_type__name
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.model.fields,help:deltatech_agreement_management.field_general_agreement__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:res.groups,name:deltatech_agreement_management.group_agreement_user
+msgid "User"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_partner_search_agreement
+msgid "With agreement"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#. odoo-python
+#: code:addons/deltatech_agreement_management/models/general_agreement.py:0
+msgid "You cannot delete a service agreement which is not draft."
+msgstr ""
+
+#. module: deltatech_agreement_management
+#. odoo-python
+#: code:addons/deltatech_agreement_management/models/general_agreement.py:0
+msgid "You must provide a type and a type report template"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#. odoo-python
+#: code:addons/deltatech_agreement_management/models/general_agreement.py:0
+msgid "You must provide a type and a type sequence"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model_terms:ir.ui.view,arch_db:deltatech_agreement_management.view_agreement_form
+msgid "general Agreement"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.actions.act_window,name:deltatech_agreement_management.action_general_agreement_type
+msgid "generals Agreement Types"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#: model:ir.actions.act_window,name:deltatech_agreement_management.action_general_agreement
+#: model:ir.ui.menu,name:deltatech_agreement_management.menu_general_agreement
+msgid "generals Agreements"
+msgstr ""
+
+#. module: deltatech_agreement_management
+#. odoo-python
+#: code:addons/deltatech_agreement_management/models/res_partner.py:0
+msgid "partner_id"
+msgstr ""

--- a/deltatech_alternative/i18n/deltatech_alternative.pot
+++ b/deltatech_alternative/i18n/deltatech_alternative.pot
@@ -1,0 +1,194 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_alternative
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.product_template_form_view
+msgid "Alternative"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_product__alternative_code
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_template__alternative_code
+#: model:ir.model.fields,field_description:deltatech_alternative.field_purchase_order_line__alternative_code
+#: model:ir.model.fields,field_description:deltatech_alternative.field_sale_order_line__alternative_code
+#: model:ir.model.fields,field_description:deltatech_alternative.field_stock_move__alternative_code
+#: model:ir.model.fields,field_description:deltatech_alternative.field_stock_move_line__alternative_code
+msgid "Alternative Code"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.view_order_form
+msgid "Alternative Code:"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_res_config_settings__alternative_limit
+msgid "Alternative Limit"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_res_config_settings__alternative_search
+msgid "Alternative Search"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_product__alternative_ids
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_template__alternative_ids
+msgid "Alternatives"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__name
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_purchase_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_sale_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_stock_move__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative.field_stock_move_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.res_config_settings_view_form
+msgid ""
+"Enable searching for alternative products by searching in product name."
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__hide
+msgid "Hide"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_purchase_order_line__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_sale_order_line__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_stock_move__id
+#: model:ir.model.fields,field_description:deltatech_alternative.field_stock_move_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_res_config_settings__alternative_length_min
+msgid "Mimim Length"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.product_alternative_form_view
+msgid "Product Alternatives"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__product_tmpl_id
+msgid "Product Template"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_product_alternative
+msgid "Product alternative"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.res_config_settings_view_form
+msgid "Search limit"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.res_config_settings_view_form
+msgid "Search minim length code"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model,name:deltatech_alternative.model_stock_move
+msgid "Stock Move"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_product__used_for
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_template__used_for
+msgid "Used For"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.product_alternative_search_form_view
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative.product_product_alternative_search_form_view
+msgid "Vendor Code"
+msgstr ""
+
+#. module: deltatech_alternative
+#: model:ir.model.fields,field_description:deltatech_alternative.field_product_alternative__sequence
+msgid "sequence"
+msgstr ""

--- a/deltatech_alternative_website/i18n/deltatech_alternative_website.pot
+++ b/deltatech_alternative_website/i18n/deltatech_alternative_website.pot
@@ -1,0 +1,48 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_alternative_website
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_alternative_website
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative_website.product_alternative_code
+msgid "<span>Alternative code:</span>"
+msgstr ""
+
+#. module: deltatech_alternative_website
+#: model_terms:ir.ui.view,arch_db:deltatech_alternative_website.product_used_for
+msgid "<span>User for:</span>"
+msgstr ""
+
+#. module: deltatech_alternative_website
+#: model:ir.model.fields,field_description:deltatech_alternative_website.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_alternative_website.field_website_searchable_mixin__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_alternative_website
+#: model:ir.model.fields,field_description:deltatech_alternative_website.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_alternative_website.field_website_searchable_mixin__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_alternative_website
+#: model:ir.model,name:deltatech_alternative_website.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_alternative_website
+#: model:ir.model,name:deltatech_alternative_website.model_website_searchable_mixin
+msgid "Website Searchable Mixin"
+msgstr ""

--- a/deltatech_analytic_distribution/i18n/deltatech_analytic_distribution.pot
+++ b/deltatech_analytic_distribution/i18n/deltatech_analytic_distribution.pot
@@ -1,0 +1,95 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_analytic_distribution
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_analytic_distribution
+#: model_terms:ir.ui.view,arch_db:deltatech_analytic_distribution.view_res_config_settings_analytic_distribution
+msgid ""
+"Activating this will enforce that the bills have 100% analytic distribution."
+" This field is company specific!"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#. odoo-python
+#: code:addons/deltatech_analytic_distribution/models/account_move.py:0
+msgid "Analytic distribution is required for all invoice lines."
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model,name:deltatech_analytic_distribution.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model,name:deltatech_analytic_distribution.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_res_company__display_name
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_res_company__analytic_distribution_validation_enabled
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_res_config_settings__analytic_distribution_validation_enabled
+msgid "Enable Analytic Distribution Validation"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model.fields,help:deltatech_analytic_distribution.field_res_config_settings__analytic_distribution_validation_enabled
+msgid "Enable or disable analytic distribution enforcement for this company."
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model.fields,help:deltatech_analytic_distribution.field_res_company__analytic_distribution_validation_enabled
+msgid "Enforce that analytic lines have 100% distribution for this company."
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_res_company__id
+#: model:ir.model.fields,field_description:deltatech_analytic_distribution.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#. odoo-python
+#: code:addons/deltatech_analytic_distribution/models/account_move.py:0
+msgid ""
+"Invalid distribution, all distribution lines need to have: Location, "
+"Department and Line of Business."
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#. odoo-python
+#: code:addons/deltatech_analytic_distribution/models/account_move.py:0
+msgid "Invalid value in analytic distribution: %s. It must be a number."
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#: model:ir.model,name:deltatech_analytic_distribution.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_analytic_distribution
+#. odoo-python
+#: code:addons/deltatech_analytic_distribution/models/account_move.py:0
+msgid ""
+"The total percentage in analytic distribution must add up to 100. Found: %s."
+msgstr ""

--- a/deltatech_auto_reorder_rule/i18n/deltatech_auto_reorder_rule.pot
+++ b/deltatech_auto_reorder_rule/i18n/deltatech_auto_reorder_rule.pot
@@ -1,0 +1,148 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_auto_reorder_rule
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields.selection,name:deltatech_auto_reorder_rule.selection__order_rules_details_wizard__trigger__auto
+msgid "Automatic"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model_terms:ir.ui.view,arch_db:deltatech_auto_reorder_rule.view_order_rules_details_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model_terms:ir.ui.view,arch_db:deltatech_auto_reorder_rule.view_order_rules_details_wizard_form
+msgid "Create Rules"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.actions.server,name:deltatech_auto_reorder_rule.product_action_create_rule
+msgid "Create rule"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__display_name
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_stock_route__display_name
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_stock_warehouse__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_stock_warehouse__generate_reorder_rules
+msgid "Generate Reorder Rules"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__id
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_stock_route__id
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_stock_warehouse__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model,name:deltatech_auto_reorder_rule.model_stock_route
+msgid "Inventory Routes"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields.selection,name:deltatech_auto_reorder_rule.selection__order_rules_details_wizard__trigger__manual
+msgid "Manual"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__max_quantity
+msgid "Maximum Quantity"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__min_quantity
+msgid "Minimum Quantity"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.actions.server,name:deltatech_auto_reorder_rule.product_action_create_variant_rule
+msgid "Open Rules Wizard"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.actions.act_window,name:deltatech_auto_reorder_rule.action_order_rules_details_wizard
+#: model_terms:ir.ui.view,arch_db:deltatech_auto_reorder_rule.view_order_rules_details_wizard_form
+msgid "Order Rules Details"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model,name:deltatech_auto_reorder_rule.model_order_rules_details_wizard
+msgid "Order Rules Details Wizard"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model,name:deltatech_auto_reorder_rule.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,help:deltatech_auto_reorder_rule.field_order_rules_details_wizard__stock_location_ids
+msgid "Select stock locations for the order rules."
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__stock_location_ids
+msgid "Stock Locations"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_order_rules_details_wizard__trigger
+msgid "Trigger"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,field_description:deltatech_auto_reorder_rule.field_stock_route__use_this_for_auto_rules
+msgid "Use This for Auto Rules"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model,name:deltatech_auto_reorder_rule.model_stock_warehouse
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_auto_reorder_rule
+#: model:ir.model.fields,help:deltatech_auto_reorder_rule.field_stock_route__use_this_for_auto_rules
+msgid "You should only have one route with this option"
+msgstr ""

--- a/deltatech_average_payment_period/i18n/deltatech_average_payment_period.pot
+++ b/deltatech_average_payment_period/i18n/deltatech_average_payment_period.pot
@@ -1,0 +1,120 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_average_payment_period
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__account_id
+msgid "Account"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__account_code
+msgid "Account Code"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__move_id
+msgid "Account Move"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__amount
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.actions.act_window,name:deltatech_average_payment_period.action_account_average_payment_report
+#: model:ir.model,name:deltatech_average_payment_period.model_account_average_payment_report
+#: model:ir.ui.menu,name:deltatech_average_payment_period.menu_account_average_payment_report
+msgid "Average Payment Period"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__balance
+msgid "Balance"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__credit
+msgid "Credit"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__date
+#: model_terms:ir.ui.view,arch_db:deltatech_average_payment_period.view_account_average_payment_report_search
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__debit
+msgid "Debit"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__display_name
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_move_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__id
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_move_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model,name:deltatech_average_payment_period.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__partner_id
+#: model_terms:ir.ui.view,arch_db:deltatech_average_payment_period.view_account_average_payment_report_search
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__payment_date
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_move_line__payment_date
+msgid "Payment Date"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__payment_days
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_move_line__payment_days
+msgid "Payment Days"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__payment_days_simple
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_move_line__payment_days_simple
+msgid "Plain payment days"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__ref
+msgid "Reference"
+msgstr ""
+
+#. module: deltatech_average_payment_period
+#: model:ir.model.fields,field_description:deltatech_average_payment_period.field_account_average_payment_report__weight
+msgid "Weight"
+msgstr ""

--- a/deltatech_backup_attachment/i18n/deltatech_backup_attachment.pot
+++ b/deltatech_backup_attachment/i18n/deltatech_backup_attachment.pot
@@ -1,0 +1,109 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_backup_attachment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_backup_attachment
+#: model_terms:ir.ui.view,arch_db:deltatech_backup_attachment.view_export_attachment_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model_terms:ir.ui.view,arch_db:deltatech_backup_attachment.view_export_attachment_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__domain
+msgid "Domain"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model_terms:ir.ui.view,arch_db:deltatech_backup_attachment.view_export_attachment_form
+msgid "Export"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model_terms:ir.ui.view,arch_db:deltatech_backup_attachment.view_export_attachment_form
+msgid "Export Complete"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.actions.act_window,name:deltatech_backup_attachment.action_export_attachment
+#: model:ir.model,name:deltatech_backup_attachment.model_export_attachment
+#: model:ir.ui.menu,name:deltatech_backup_attachment.menu_export_attachment
+#: model_terms:ir.ui.view,arch_db:deltatech_backup_attachment.view_export_attachment_form
+msgid "Export attachment"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__data_file
+msgid "File"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__name
+msgid "File Name"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields,field_description:deltatech_backup_attachment.field_export_attachment__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields.selection,name:deltatech_backup_attachment.selection__export_attachment__state__choose
+msgid "choose"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model:ir.model.fields.selection,name:deltatech_backup_attachment.selection__export_attachment__state__get
+msgid "get"
+msgstr ""
+
+#. module: deltatech_backup_attachment
+#: model_terms:ir.ui.view,arch_db:deltatech_backup_attachment.view_export_attachment_form
+msgid "or"
+msgstr ""

--- a/deltatech_batch_transfer/i18n/deltatech_batch_transfer.pot
+++ b/deltatech_batch_transfer/i18n/deltatech_batch_transfer.pot
@@ -1,0 +1,231 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_batch_transfer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_batch_transfer
+#: model_terms:ir.ui.view,arch_db:deltatech_batch_transfer.stock_prepare_batch_form
+msgid "Add pickings to"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model_terms:ir.ui.view,arch_db:deltatech_batch_transfer.view_picking_form
+msgid "Add to batch"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__additional_quantity
+msgid "Additional Quantity"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model,name:deltatech_batch_transfer.model_stock_picking_batch
+msgid "Batch Transfer"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model_terms:ir.ui.view,arch_db:deltatech_batch_transfer.stock_prepare_batch_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model_terms:ir.ui.view,arch_db:deltatech_batch_transfer.stock_prepare_batch_form
+msgid "Confirm"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__create_uid
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__create_date
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.actions.report,name:deltatech_batch_transfer.delivery_batch_print
+msgid "Deliveries"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking_batch__direction
+msgid "Direction"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking_batch__display_name
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__display_name
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking_batch__id
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__id
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields.selection,name:deltatech_batch_transfer.selection__stock_picking_batch__direction__incoming
+msgid "Incoming"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__write_uid
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__write_date
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__line_ids
+msgid "Line"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__mode
+#: model_terms:ir.ui.view,arch_db:deltatech_batch_transfer.stock_prepare_batch_form
+msgid "Mode"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#. odoo-python
+#: code:addons/deltatech_batch_transfer/models/stock_picking.py:0
+msgid "No effective quantities set"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking_batch__note
+msgid "Note"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields.selection,name:deltatech_batch_transfer.selection__stock_picking_batch__direction__outgoing
+msgid "Outgoing"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,help:deltatech_batch_transfer.field_stock_prepare_batch__user_id
+msgid "Person responsible for this batch transfer"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#. odoo-python
+#: code:addons/deltatech_batch_transfer/wizard/stock_prepare_batch.py:0
+msgid "Please select orders for the same customer."
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model,name:deltatech_batch_transfer.model_stock_prepare_batch
+msgid "Prepare Batch"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model,name:deltatech_batch_transfer.model_stock_prepare_batch_line
+msgid "Prepare Batch Line"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.actions.act_window,name:deltatech_batch_transfer.action_prepare_batch
+#: model:ir.actions.act_window,name:deltatech_batch_transfer.action_prepare_batch_sale_order
+#: model:ir.ui.menu,name:deltatech_batch_transfer.menu_action_prepare_batch
+msgid "Prepare batch"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__product_id
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields.selection,name:deltatech_batch_transfer.selection__stock_prepare_batch__mode__purchase
+msgid "Purchase"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__quantity
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model_terms:ir.ui.view,arch_db:deltatech_batch_transfer.batch_form_view_selected_lines
+msgid "Received"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking_batch__reference
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__reference
+msgid "Reference"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__user_id
+msgid "Responsible"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields.selection,name:deltatech_batch_transfer.selection__stock_prepare_batch__mode__sale
+msgid "Sale"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_picking_batch__received_move_line_ids
+msgid "Selected move lines"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch__set_done_qty
+msgid "Set Done Qty"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#. odoo-python
+#: code:addons/deltatech_batch_transfer/wizard/stock_prepare_batch.py:0
+msgid ""
+"The product [%(product_code)s]%(product_name)s was not found for this "
+"partner."
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#. odoo-python
+#: code:addons/deltatech_batch_transfer/models/stock_picking.py:0
+msgid "This picking is already in a batch"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model,name:deltatech_batch_transfer.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_batch_transfer
+#: model:ir.model.fields,field_description:deltatech_batch_transfer.field_stock_prepare_batch_line__wizard_id
+msgid "Wizard"
+msgstr ""

--- a/deltatech_business_process/i18n/deltatech_business_process.pot
+++ b/deltatech_business_process/i18n/deltatech_business_process.pot
@@ -1,0 +1,2779 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_business_process
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_business_process
+#: model:mail.template,body_html:deltatech_business_process.email_template_development_approved
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p>\n"
+"                    Dear&nbsp;<t t-out=\"object.project_id.project_manager_id.name\"/>,\n"
+"                    <br/>\n"
+"                    The development\n"
+"                    <t t-out=\"object.name\"/>\n"
+"                    of\n"
+"                    <t t-out=\"object.project_id.name\"/>\n"
+"                    has been approved on\n"
+"                    <t t-esc=\"datetime.date.today().strftime('%d-%m-%Y')\"/>\n"
+"                    with the required time of <t t-out=\"object.development_duration\"/>.\n"
+"\n"
+"                    <br/>\n"
+"                    Please check and inform colleagues of the current development.\n"
+"\n"
+"\n"
+"                </p>\n"
+"            </div>\n"
+"        "
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:mail.template,body_html:deltatech_business_process.email_template_issue_submitted
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p>\n"
+"                    Dear&nbsp;<t t-out=\"object.project_id.project_manager_id.name\"/>,\n"
+"                    <br/>\n"
+"                    The issue\n"
+"                    <t t-out=\"object.name\"/>\n"
+"                    of\n"
+"                    <t t-out=\"object.project_id.name\"/>\n"
+"                    has submitted by\n"
+"                    <t t-out=\"object.create_uid.name\"/>\n"
+"                    on\n"
+"                    <t t-esc=\"datetime.date.today().strftime('%d-%m-%Y')\"/>.\n"
+"                    <br/>\n"
+"                    Please check and inform colleagues of the current issue.\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    Description:\n"
+"                    <br/>\n"
+"                    </p><div style=\"border: 1px solid #000; padding: 10px;\">\n"
+"                        <t t-out=\"object.description\"/>\n"
+"                    </div>\n"
+"                \n"
+"            </div>\n"
+"        "
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_kanban
+msgid "<span class=\"fa fa-clock-o mr-2\" title=\"Dates\"/>"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_kanban
+msgid "<span class=\"o_label\">Steps</span>"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_kanban
+msgid "<span class=\"o_label\">Tests</span>"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Abandon"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__state__abandoned
+msgid "Abandoned"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_needaction
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_needaction
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_needaction
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_needaction
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_needaction
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_exception_decoration
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_exception_decoration
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_exception_decoration
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_exception_decoration
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_exception_decoration
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_type_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_type_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_type_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_type_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_type_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__allocated
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__allocated
+msgid "Allocated"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__approved
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__approved__approved
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+msgid "Approved"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__approved_id
+msgid "Approved by"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__area_id
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_area
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business__process_report_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_line_search
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_transaction_filter
+msgid "Area"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_kanban
+msgid "Arrow"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_kanban
+msgid "Arrow icon"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_attachment_count
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_attachment_count
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_attachment_count
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_attachment_count
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_attachment_count
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process.py:0
+#: code:addons/deltatech_business_process/models/business_process_test.py:0
+#: code:addons/deltatech_business_process/models/business_project.py:0
+msgid "Attachments"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__attachment_ids
+msgid "Attachments that don't come from a message."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__approved__awaiting_approval
+msgid "Awaiting Approval"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "Back"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:res.groups,name:deltatech_business_process.group_business_process_manager
+msgid "Business Admin"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_area
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__area_id
+msgid "Business Area"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Business Blueprint"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_development
+msgid "Business Development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_development_type
+msgid "Business Development Type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_issue
+msgid "Business Issue"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_open_issue
+msgid "Business Open Issue"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Business Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_export
+msgid "Business Process Export"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_group
+msgid "Business Process Group"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_implementation_stage
+msgid "Business Process Implementation Stage"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_import
+msgid "Business Process Import"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business__process_report_pivot
+msgid "Business Process Report"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_step_test
+msgid "Business Process Step Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_step
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_step
+msgid "Business Process Steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.business_process_test_action_form
+msgid "Business Process Test Form"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_report
+msgid "Business Processes"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_report
+msgid "Business Processes Report"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_role
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_role
+msgid "Business Role"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_test_report
+msgid "Business Tests"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_area
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__area_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__area_id
+msgid "Business area"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_development
+msgid "Business development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_development_type
+msgid "Business development type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__process_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__process_id
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_app
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_main
+#: model:res.groups.privilege,name:deltatech_business_process.groups_privilege_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Business process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_test
+msgid "Business process Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__process_group_ids
+msgid "Business process groups"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_report
+msgid "Business process report"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_step
+msgid "Business process step"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_test_report
+#: model:ir.model,name:deltatech_business_process.model_business_process_test_report
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business__process_test_report_pivot
+msgid "Business process test report"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_project
+#: model:ir.model,name:deltatech_business_process.model_business_project
+msgid "Business project"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_role
+msgid "Business role"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_transaction
+#: model:ir.model,name:deltatech_business_process.model_business_transaction
+msgid "Business transaction"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_options_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__category
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__category
+msgid "Category"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__category__change_request
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__category__change_request
+msgid "Change Request"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "Choose the JSON file you exported earlier, then click Import."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Choose what information to include in the exported file."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_options_form
+msgid ""
+"Choose whether to import the exported effort estimates, then pick the "
+"processes."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "Close"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__closed
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__closed
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__state__closed
+msgid "Closed"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__closed_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__closed_date
+msgid "Closed Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__closed_by_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__closed_by_id
+msgid "Closed by"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__code
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__code
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid ""
+"Comma-separated git URLs cloned/pulled automatically. Example: "
+"https://github.com/terrabit-ro/procese"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_res_config_settings__process_library_git_repos
+msgid ""
+"Comma-separated list of git URLs. Each repo is cloned/pulled into the Odoo "
+"data directory and scanned for process.json files. Example: "
+"https://github.com/terrabit-ro/procese"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_res_config_settings__process_library_whitelist
+msgid ""
+"Comma-separated list of modules. When set, the sources are restricted to "
+"exactly the listed modules (ignores auto-discovery)."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid ""
+"Comma-separated list of modules. When set, the sources are restricted to "
+"exactly the listed modules."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__company_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__completion_bbp
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__completion_bbp
+msgid "Completion"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__completion_dev
+msgid "Completion Dev"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__completion_fs
+msgid "Completion FS"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__completion_test
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__completion_test
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__completion_test
+msgid "Completion Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__completion_bbp
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_report__completion_bbp
+msgid "Completion business blueprint"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__completion_dev
+msgid "Completion development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__completion_fs
+msgid "Completion of functional specification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__completion_test
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__completion_test
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test_report__completion_test
+msgid "Completion test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_config
+msgid "Configuration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__configuration_duration
+msgid "Configuration duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__responsible_id
+msgid "Consultant"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Contacts"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_options_form
+msgid "Continue"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__severity__cosmetic
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__severity__cosmetic
+msgid "Cosmetic"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__count_acceptance_tests
+msgid "Count Acceptance Tests"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__count_developments
+msgid "Count Developments"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__doc_count
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__doc_count
+msgid "Count Documents"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__count_issues
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__count_issues
+msgid "Count Issues"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__count_processes
+msgid "Count Processes"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__count_steps
+msgid "Count Steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__count_tests
+msgid "Count Tests"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__create_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__create_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__severity__critical
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__severity__critical
+msgid "Critical"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__module_type__custom
+msgid "Custom"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__customer_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__customer_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__customer_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__customer_id
+msgid "Customer"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__customer_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__customer_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__customer_id
+msgid "Customer Responsible"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+msgid "Data"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__data_migration_duration
+msgid "Data migration duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__data_result
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__data_result
+msgid "Data result"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__data_used
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__data_used
+msgid "Data used"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__date_end_dev
+msgid "Date End Dev"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__date_end_test
+msgid "Date End Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__date_start_dev
+msgid "Date Start Dev"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__date_start_test
+msgid "Date Start Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__date_end
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__date_end
+msgid "Date end"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__date_end
+msgid "Date end test"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_development.py:0
+#: code:addons/deltatech_business_process/models/business_issue.py:0
+msgid "Date of approval: {today}"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__date_start
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__date_start
+msgid "Date start"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__date_start
+msgid "Date start test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Dates"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__category__defect
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__category__defect
+msgid "Defect"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__state__deployment
+msgid "Deployment"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__description
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__description
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__description
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__description
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__description
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__description
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Description"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__state__design
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__state__design
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_bp__design
+msgid "Design"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__destination_process_ids
+msgid "Destination Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Destination process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__details
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+msgid "Details"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__developer_id
+msgid "Developer"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__state__development
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_form
+msgid "Development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:mail.template,name:deltatech_business_process.email_template_development_approved
+#: model:mail.template,subject:deltatech_business_process.email_template_development_approved
+msgid "Development Approved"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_development_type
+msgid "Development Type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__development_duration
+msgid "Development duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__development_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__development_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__count_developments
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_development
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Developments"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__process_library_autodiscover
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Discover processes from all modules"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Documents"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_migration__status__done
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_integration_test__done
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_internal_test__done
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_user_acceptance_test__done
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__state__done
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_test__done
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.action_download_excel_report
+msgid "Download Excel Report"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__approved__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_step_test__feedback_state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_step_test__result__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__state__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__result__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_bp__draft
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_test__draft
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Duration of process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__effort_dev
+msgid "Effort Dev"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__effort_fs
+msgid "Effort FS"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__effort_test
+msgid "Effort Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__effort_dev
+msgid "Effort for development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__effort_fs
+msgid "Effort for functional specification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__effort_test
+msgid "Effort for test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__date_end_bbp
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__date_end_bbp
+msgid "End BBP"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__date_end
+msgid "End Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__date_end_fs
+msgid "End FS"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "End Testing"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:res.groups,name:deltatech_business_process.group_business_end_user
+msgid "End User"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__date_end_bbp
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_report__date_end_bbp
+msgid "End date business blueprint"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__date_end_dev
+msgid "End date development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__date_end_fs
+msgid "End date functional specification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__date_end_test
+msgid "End date test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__date_estimated
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__date_estimated
+msgid "Estimated Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__state__exploration
+msgid "Exploration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Export"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_export
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Export Business Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Export Complete"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Export selected business processes"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__transaction_type__ex
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__transaction_type__ex
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_transaction__transaction_type__ex
+msgid "Extern"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_step_test__result__failed
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__result__failed
+msgid "Failed"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__feedback_text
+msgid "Feedback"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__feedback_by_id
+msgid "Feedback By"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__feedback_date
+msgid "Feedback date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__feedback_state
+msgid "Feedback state"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__data_file
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__data_file
+msgid "File"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__name
+msgid "File Name"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "File Selected"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:business.process.implementation.stage,name:deltatech_business_process.implementation_stage_first
+msgid "First stage"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__folder
+msgid "Folder"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_follower_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_follower_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_follower_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_follower_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_follower_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_partner_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_partner_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_partner_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_partner_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_partner_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__activity_type_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__activity_type_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__activity_type_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__activity_type_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__activity_type_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "General"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Get Duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__process_library_git_repos
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Git repositories"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__process_library_git_token
+msgid "Git token / password"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__process_library_git_user
+msgid "Git username"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Go live"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__date_go_live
+msgid "Go live date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__has_message
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__has_message
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__has_message
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__has_message
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__has_message
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_exception_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_exception_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_exception_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_exception_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_exception_icon
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__activity_exception_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__activity_exception_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__activity_exception_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__activity_exception_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__activity_exception_icon
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Identification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__message_needaction
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__message_needaction
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__message_needaction
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__message_needaction
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__message_needaction
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__message_has_error
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__message_has_error
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__message_has_error
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__message_has_error
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__message_has_error
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__message_has_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__allowed_user_ids
+msgid ""
+"If set, only these users and business admins can see this process, its "
+"steps, tests and issues. Leave empty to keep it visible to everyone."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Implementation"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__responsible_id
+msgid "Implementation Responsible"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_implementation_stage
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_implementation_stage
+msgid "Implementation Stage"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__implementation_stage_id
+msgid "Implementation stage"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_filter
+msgid "Implementation state"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__module_type__implementor
+msgid "Implementor"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "Import"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "Import Business Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "Import business processes from a file"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_from_process_import
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_from_project_import
+msgid "Import from file (JSON)"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.action_open_process_library_from_process
+#: model:ir.actions.server,name:deltatech_business_process.action_open_process_library_from_project
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_options_form
+msgid "Import from library"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_options_form
+msgid "Import processes from the library"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_line_list
+msgid "Import selected"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_library_import_options__include_durations
+msgid ""
+"Import the configuration / instructing / testing / data-migration durations "
+"exported with each process. Untick to import every selected process without "
+"its effort estimates (all-or-nothing)."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__category__improvement
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__category__improvement
+msgid "Improvement"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__in_test
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__in_test
+msgid "In Test Business"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_integration_test__in_progress
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_internal_test__in_progress
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_user_acceptance_test__in_progress
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "In progress"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "In test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_approved_by
+msgid "Include Approved By?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_customer_responsible
+msgid "Include Customer Responsible?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_developments
+msgid "Include Developments?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_durations
+msgid "Include Durations?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_issues
+msgid "Include Issues?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_modules
+msgid "Include Modules?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_process_state
+msgid "Include Process State?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_responsible
+msgid "Include Responsible?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_support
+msgid "Include Support?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__include_tests
+msgid "Include Tests in Export?"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__include_durations
+msgid "Include durations"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.action_install_modules_for_selected
+msgid "Install Modules for Selected Processes"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__instructing_duration
+msgid "Instructing duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__scope__integration
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__scope__integration
+msgid "Integration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__scope__internal
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__scope__internal
+msgid "Internal"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process.py:0
+msgid "Internal Test %s"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_is_follower
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_is_follower
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_is_follower
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_is_follower
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_is_follower
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Issue"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:mail.template,name:deltatech_business_process.email_template_issue_submitted
+#: model:mail.template,subject:deltatech_business_process.email_template_issue_submitted
+msgid "Issue Submitted"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_issue
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_issue_report
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__issue_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__count_issues
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__issue_ids
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_issue
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_issue_report
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_pivot
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Issues"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__write_uid
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_options__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__write_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_library_import_line
+msgid "Library process selection line"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__project_type__local
+msgid "Local"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__logo
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_kanban
+msgid "Logo"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__attachment_ids
+msgid "Main Attachments"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__severity__major
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__severity__major
+msgid "Major"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__transaction_type__md
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__transaction_type__md
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_transaction__transaction_type__md
+msgid "Master Data"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_has_error
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_has_error
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_has_error
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_has_error
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_has_error
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_migration__status__migrate
+msgid "Migrate"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__migrate_date
+msgid "Migrate Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__migration_id
+msgid "Migration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__migration_steps
+msgid "Migration Steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__migration_tool
+msgid "Migration Tool"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_migration
+msgid "Migration data"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_migration_test
+msgid "Migration test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__severity__minor
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__severity__minor
+msgid "Minor"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__module_type
+msgid "Module type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__module_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__modules
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Modules"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__my_activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__my_activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__my_activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__my_activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__my_activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development_type__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_group__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_role__name
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__name
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_date_deadline
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_summary
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_summary
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_summary
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_summary
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_summary
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_type_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_type_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_type_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_type_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_type_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_project.py:0
+msgid "No active project found."
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/res_config_settings.py:0
+msgid "No git repositories configured or sync failed."
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/wizard/import_business_process.py:0
+msgid "No project selected!"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_step_test__feedback_state__not_ok
+msgid "Not ok"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_integration_test__not_started
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_internal_test__not_started
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__status_user_acceptance_test__not_started
+msgid "Not started"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__note
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_form
+msgid "Note"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_needaction_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_needaction_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_needaction_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_needaction_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_needaction_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__doc_count
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__doc_count
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__doc_count
+msgid "Number of documents attached"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__message_has_error_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__message_has_error_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__message_has_error_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__message_has_error_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__message_has_error_counter
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__message_needaction_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__message_needaction_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__message_needaction_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__message_needaction_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__message_needaction_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__message_has_error_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__message_has_error_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__message_has_error_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__message_has_error_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__message_has_error_counter
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__observation
+msgid "Observation"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_step_test__feedback_state__ok
+msgid "Ok"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process.py:0
+msgid "Only local projects can install modules"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__open
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__open
+msgid "Open"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__open_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__open_date
+msgid "Open Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__category__open_issue
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__category__open_issue
+msgid "Open Issue"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__category__operation
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__category__operation
+msgid "Operation"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Options"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__category__other
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__category__other
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__scope__other
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__scope__other
+msgid "Other"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_overview
+msgid "Overview"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_step_test__result__passed
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__result__passed
+msgid "Passed"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__approved__pending
+msgid "Pending"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_res_config_settings__process_library_git_token
+msgid ""
+"Personal access token (or password) for private HTTPS repositories. It is "
+"sent as an HTTP Basic Authorization header on each git command and is never "
+"written into the cloned repo's on-disk config. SSH (git@…) URLs and URLs "
+"that already embed credentials ignore this and use their own auth."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__state__preparation
+msgid "Preparation"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_migration__status__prepare
+msgid "Prepare"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__prepare_date
+msgid "Prepare Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Private repository credentials"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__process_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__process_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__process_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__process_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__process_id
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business__process_report_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_calendar
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__process_group_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__process_group_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__process_group_id
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_filter
+msgid "Process Group"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_config_settings
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_config_settings
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Process Library"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_library
+msgid "Process Library (engine)"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/wizard/import_business_process.py:0
+msgid "Process Library — %s"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/res_config_settings.py:0
+msgid "Process Library — Git Sync"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:res.groups,name:deltatech_business_process.group_business_process_responsible
+msgid "Process Responsible"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__process_step_test_id
+msgid "Process Step Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__process_test_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__process_test_id
+msgid "Process Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_test
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_process_test
+msgid "Process Tests"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model,name:deltatech_business_process.model_business_process_library_import_options
+msgid "Process library import options"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.act_window,name:deltatech_business_process.action_business_process_step_test
+msgid "Process step test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Process steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_calendar
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_calendar
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_graph
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_pivot
+msgid "Process test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__process_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Processes"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__state__production
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__state__production
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__state__production
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_bp__production
+msgid "Production"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__project_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__project_id
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_calendar
+msgid "Project"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__project_manager_id
+msgid "Project Manager"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__project_type
+msgid "Project Type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_project
+msgid "Projects"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__raise_by_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__raise_by_id
+msgid "Raise by"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__state__ready
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__state__ready
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_bp__ready
+msgid "Ready"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__state__realization
+msgid "Realization"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__scope__regression
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__scope__regression
+msgid "Regression"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__approved__rejected
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+msgid "Rejected"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__project_type__remote
+msgid "Remote"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "Reopen"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__reopened
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__reopened
+msgid "Reopened"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__transaction_type__rp
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__transaction_type__rp
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_transaction__transaction_type__rp
+msgid "Report"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_report
+msgid "Reports"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Reset to Draft"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_area__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__responsible_id
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+msgid "Responsible"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Responsible Parties"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__responsible_id
+msgid "Responsible Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__responsible_step_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__responsible_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__responsible_step_id
+msgid "Responsible Step"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__activity_user_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__activity_user_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__activity_user_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__activity_user_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__activity_user_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Restrict to modules"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_res_config_settings__process_library_whitelist
+msgid "Restrict to modules (list)"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__result
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__result
+msgid "Result"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__role_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__role_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__role_id
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+msgid "Role"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__state__run
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_test__run
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Run"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_project__state__running
+msgid "Running"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_res_config_settings__process_library_autodiscover
+msgid ""
+"Scan every installed module that ships a `processes/` folder. Disabled = "
+"only the modules listed below."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid ""
+"Scan every installed module that ships a processes/ folder. Disabled = only "
+"the modules listed below."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__scope
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__scope
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Scope"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__has_screenshots
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_line_list
+msgid "Screenshots"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:business.process.implementation.stage,name:deltatech_business_process.implementation_stage_second
+msgid "Second stage"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/wizard/import_business_process.py:0
+msgid "Select at least one process from the library."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "Send"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_implementation_stage__sequence
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__sequence
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__sequence
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__sequence
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "Set Draft"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.set_internal_to_draft
+msgid "Set Internal Draft"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.set_user_acceptance_to_draft
+msgid "Set User Accept. Draft"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__severity
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__severity
+msgid "Severity"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__solution
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__solution
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "Solution"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__solution_date
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__solution_date
+msgid "Solution Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_issue__state__solved
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_open_issue__state__solved
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "Solved"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_library_import_line__source_module
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_line_list
+msgid "Source (module)"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__source_process_ids
+msgid "Source Process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_line_search
+msgid "Source module"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Source process"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Sources  & Destinations"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__state__specification
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_form
+msgid "Specification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__module_type__standard
+msgid "Standard"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:business.process.implementation.stage,name:deltatech_business_process.implementation_stage_start
+msgid "Start"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__date_start_bbp
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__date_start_bbp
+msgid "Start BBP"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration_test__date_start
+msgid "Start Date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Start Design"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__date_start_fs
+msgid "Start FS"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.action_start_integration_test
+msgid "Start Integration Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.action_start_internal_test
+msgid "Start Internal Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Start Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.actions.server,name:deltatech_business_process.action_start_user_acceptance_test
+msgid "Start User Acceptance Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__date_start
+msgid "Start date"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__date_start_bbp
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_report__date_start_bbp
+msgid "Start date business blueprint"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__date_start_dev
+msgid "Start date development"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__date_start_fs
+msgid "Start date functional specification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__date_start_test
+msgid "Start date test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_export__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_import__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__state
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__state_bp
+msgid "State BP"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__state_test
+msgid "State Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_migration__status
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__activity_state
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__activity_state
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__activity_state
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__activity_state
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__activity_state
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__status_integration_test
+msgid "Status integration test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__status_internal_test
+msgid "Status internal test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__status_user_acceptance_test
+msgid "Status user acceptance test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__step_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__step_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__step_id
+msgid "Step"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_issue__step_test_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_open_issue__step_test_id
+msgid "Step Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__step_ids
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__count_steps
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__count_steps
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_project_form
+msgid "Steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process.py:0
+msgid "Success"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__support_id
+msgid "Support"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Sync now"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/res_config_settings.py:0
+msgid "Synced: %s"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__team_member_ids
+msgid "Team members"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_development__state__test
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process__state__test
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__state__test
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_bp__test
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_development_form
+msgid "Test"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process.py:0
+msgid "Test %s #%s"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Test Steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__test_started
+msgid "Test started"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__test_step_ids
+msgid "Test steps"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__tester_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test__tester_id
+msgid "Tester"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process_test.py:0
+msgid "Testing %s"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__testing_duration
+msgid "Testing duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__test_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Tests"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_issue.py:0
+msgid ""
+"The field Closed Date is required, please complete it to change status to "
+"Closed"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_issue.py:0
+msgid ""
+"The field Solution Date is required, please complete it to change status to "
+"Solved"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_issue.py:0
+msgid ""
+"The field Solution is required, please complete it to change status to "
+"Solved"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+msgid "The selected file will be processed:"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_issue.py:0
+msgid "This test is completed."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Token / password"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid ""
+"Token used for private HTTPS repositories. Sent as an HTTP Basic header per "
+"git command; not stored in the cloned repo's config. SSH URLs use their own "
+"keys."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__duration_for_completion
+msgid "Total duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_project__total_project_duration
+msgid "Total project duration"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__transaction_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__transaction_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step_test__transaction_id
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__transaction_id
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_report__transaction_type__tr
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__transaction_type__tr
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_transaction__transaction_type__tr
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+msgid "Transaction"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_report__transaction_type
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_step__transaction_type
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process_test_report__transaction_type
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_transaction__transaction_type
+msgid "Transaction Type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.ui.menu,name:deltatech_business_process.menu_business_transaction
+msgid "Transactions"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_development__type_id
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_issue_form
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_business_development__activity_exception_decoration
+#: model:ir.model.fields,help:deltatech_business_process.field_business_issue__activity_exception_decoration
+#: model:ir.model.fields,help:deltatech_business_process.field_business_open_issue__activity_exception_decoration
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process__activity_exception_decoration
+#: model:ir.model.fields,help:deltatech_business_process.field_business_process_test__activity_exception_decoration
+#: model:ir.model.fields,help:deltatech_business_process.field_business_project__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__scope__user_acceptance
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__scope__user_acceptance
+msgid "User Acceptance"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "Username"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,help:deltatech_business_process.field_res_config_settings__process_library_git_user
+msgid ""
+"Username for private HTTPS repositories. Leave empty to use 'x-access-token'"
+" (works for GitHub personal access tokens). For GitLab use 'oauth2'."
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_step_test_from
+msgid "Verification"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_migration__status__verify
+msgid "Verify"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_form
+msgid "Visibility"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields,field_description:deltatech_business_process.field_business_process__allowed_user_ids
+msgid "Visible only to"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_form
+msgid "Wait"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test__state__wait
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_test_report__state_test__wait
+msgid "Waiting"
+msgstr ""
+
+#. module: deltatech_business_process
+#. odoo-python
+#: code:addons/deltatech_business_process/models/business_process.py:0
+msgid "Warning"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_line_search
+msgid "With screenshots"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+msgid "Your file is ready. Click to download:"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_export__state__choose
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_import__state__choose
+msgid "choose"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "e.g. l10n_ro_process_library, other_processes_module"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_export__state__get
+#: model:ir.model.fields.selection,name:deltatech_business_process.selection__business_process_import__state__get
+msgid "get"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "https://github.com/terrabit-ro/procese"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_export_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_import_form
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_library_import_options_form
+msgid "or"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "personal access token"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_filter
+msgid "scope"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.view_business_process_test_filter
+msgid "state"
+msgstr ""
+
+#. module: deltatech_business_process
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process.res_config_settings_view_form
+msgid "x-access-token (GitHub) / oauth2 (GitLab)"
+msgstr ""

--- a/deltatech_business_process_handover_document/i18n/deltatech_business_process_handover_document.pot
+++ b/deltatech_business_process_handover_document/i18n/deltatech_business_process_handover_document.pot
@@ -1,0 +1,352 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_business_process_handover_document
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.actions.report,print_report_name:deltatech_business_process_handover_document.action_report_verbal_process
+msgid "'Handover Document'"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+", the Odoo system handover process took place. The details of the process "
+"are as follows:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"<br/>\n"
+"                    <br/>\n"
+"\n"
+"                    By our signatures, we confirm that the Odoo system handover process has been completed as per this\n"
+"                    document and both parties agree with the details recorded above.\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    <span style=\"font-weight: bold;\">Signatures:</span>"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"<br/>\n"
+"                    <span>Attendees:</span>\n"
+"                    <br/>\n"
+"                    <br/>"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"<br/>\n"
+"            <br/>\n"
+"            <span style=\"font-weight: bold;\">Signatures:</span>"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "<span>0</span>"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "<span>N/A</span>"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "According to the previously agreed terms between the parties, today,"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Accounts and Access:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Annex 1."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"Any issues or anomalies identified during the tests were resolved in "
+"advance."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"Any specific access requirements have been noted and implemented according to\n"
+"                                    specifications."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Area"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model,name:deltatech_business_process_handover_document.model_business_area
+msgid "Business Area"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model,name:deltatech_business_process_handover_document.model_business_project
+msgid "Business project"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"Complete system documentation, including user manuals and technical\n"
+"                                    specifications, have been provided and are available for use."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Custom Developments"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Date:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__development_ids
+msgid "Developments"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,help:deltatech_business_process_handover_document.field_business_project__handover_development_ids
+msgid ""
+"Developments included in the handover document. When a stage filter is set, "
+"only developments attached to the filtered processes' steps are listed; "
+"otherwise all project developments are listed (unchanged behaviour)."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_area__display_name
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Documentation and Resources:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Duration"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"Functionality tests were carried out to verify the proper functioning of the system,\n"
+"                                    as detailed in Annex 1."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_area__handover_checked
+msgid "Handover Checked"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__handover_development_ids
+msgid "Handover Developments"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.actions.report,name:deltatech_business_process_handover_document.action_report_verbal_process
+msgid "Handover Document"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.view_business_project_form_inherit
+msgid "Handover Options"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__handover_process_ids
+msgid "Handover Processes"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Handover Report for the Odoo System"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__handover_stage_id
+msgid "Handover Stage Filter"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Handover Subject: Odoo System"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_area__id
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,help:deltatech_business_process_handover_document.field_business_project__handover_stage_id
+msgid ""
+"If set, the handover document only includes processes (and their tests) in "
+"this implementation stage. Leave empty to include all processes."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"Internal\n"
+"                            (steps)"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Process"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,help:deltatech_business_process_handover_document.field_business_project__handover_process_ids
+msgid ""
+"Processes included in the handover document, after applying the stage "
+"filter."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__provider_company
+msgid "Provider Company"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.view_business_project_form_inherit
+msgid "Provider Information"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__provider_representative
+msgid "Provider Representative"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__provider_testers
+msgid "Provider Testers"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__recipient_company
+msgid "Recipient Company"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.view_business_project_form_inherit
+msgid "Recipient Information"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__recipient_representative
+msgid "Recipient Representative"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model:ir.model.fields,field_description:deltatech_business_process_handover_document.field_business_project__recipient_testers
+msgid "Recipient Testers"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"Required modules and specific functionalities have been implemented as per\n"
+"                                    the established requirements."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Subsequent Responsibilities:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "System Status:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "Tests and Verifications:"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "The Odoo system was checked and is in an optimal working condition."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"The necessary resources for system administration and maintenance have been\n"
+"                                    handed over and are available to the responsible team."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"The parties have discussed and clarified the subsequent responsibilities regarding\n"
+"                                    system administration, maintenance, and updates."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"User Acceptance\n"
+"                            (steps)"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid ""
+"User accounts and system access have been configured in accordance with security\n"
+"                                    policies and are functional."
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "and testing representative"
+msgstr ""
+
+#. module: deltatech_business_process_handover_document
+#: model_terms:ir.ui.view,arch_db:deltatech_business_process_handover_document.report_bp_document
+msgid "represented by"
+msgstr ""

--- a/deltatech_cash_statement/i18n/deltatech_cash_statement.pot
+++ b/deltatech_cash_statement/i18n/deltatech_cash_statement.pot
@@ -1,0 +1,83 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_cash_statement
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_cash_statement
+#: model:ir.model,name:deltatech_cash_statement.model_account_cash_update_balances
+msgid "Account Cash Update Balances"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model_terms:ir.ui.view,arch_db:deltatech_cash_statement.view_account_cash_update_balances_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model_terms:ir.ui.view,arch_db:deltatech_cash_statement.view_account_cash_update_balances_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.actions.act_window,name:deltatech_cash_statement.action_account_cash_update_balances
+#: model_terms:ir.ui.view,arch_db:deltatech_cash_statement.view_account_cash_update_balances_form
+msgid "Cash Update Balances"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#. odoo-python
+#: code:addons/deltatech_cash_statement/wizard/account_cash_update_balances.py:0
+msgid "Please select only Open or Posted statements"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model:ir.model.fields,field_description:deltatech_cash_statement.field_account_cash_update_balances__balance_start
+msgid "Starting Balance"
+msgstr ""
+
+#. module: deltatech_cash_statement
+#: model_terms:ir.ui.view,arch_db:deltatech_cash_statement.view_account_cash_update_balances_form
+msgid "or"
+msgstr ""

--- a/deltatech_category_group/i18n/deltatech_category_group.pot
+++ b/deltatech_category_group/i18n/deltatech_category_group.pot
@@ -1,0 +1,150 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_category_group
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_account_invoice_report__category_class
+#: model_terms:ir.ui.view,arch_db:deltatech_category_group.category_group_search
+msgid "Category Class"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_account_invoice_report__category_type
+#: model_terms:ir.ui.view,arch_db:deltatech_category_group.category_group_search
+msgid "Category Type"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_product_category__category_group_class
+#: model:ir.model.fields,field_description:deltatech_category_group.field_sale_margin_report__category_class
+#: model:ir.model.fields,field_description:deltatech_category_group.field_stock_quant__category_group_class
+#: model_terms:ir.ui.view,arch_db:deltatech_category_group.view_category_class_form
+msgid "Category class"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.actions.act_window,name:deltatech_category_group.action_category_class
+#: model:ir.ui.menu,name:deltatech_category_group.menu_category_class
+#: model_terms:ir.ui.view,arch_db:deltatech_category_group.view_category_class_tree
+msgid "Category classes"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model,name:deltatech_category_group.model_category_group_class
+msgid "Category group class"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model,name:deltatech_category_group.model_category_group_type
+msgid "Category group type"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.ui.menu,name:deltatech_category_group.menu_category_type_options
+msgid "Category options"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_product_category__category_group_type
+#: model:ir.model.fields,field_description:deltatech_category_group.field_sale_margin_report__category_type
+#: model:ir.model.fields,field_description:deltatech_category_group.field_stock_quant__category_group_type
+#: model_terms:ir.ui.view,arch_db:deltatech_category_group.view_category_type_form
+msgid "Category type"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.actions.act_window,name:deltatech_category_group.action_category_type
+#: model:ir.ui.menu,name:deltatech_category_group.menu_category_type
+#: model_terms:ir.ui.view,arch_db:deltatech_category_group.view_category_type_tree
+msgid "Category types"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__create_uid
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__create_date
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_account_invoice_report__display_name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__display_name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__display_name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_sale_margin_report__display_name
+#: model:ir.model.fields,field_description:deltatech_category_group.field_stock_quant__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_account_invoice_report__id
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__id
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__id
+#: model:ir.model.fields,field_description:deltatech_category_group.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_category_group.field_sale_margin_report__id
+#: model:ir.model.fields,field_description:deltatech_category_group.field_stock_quant__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model,name:deltatech_category_group.model_account_invoice_report
+msgid "Invoices Statistics"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__write_uid
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__write_date
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:res.groups,name:deltatech_category_group.category_group_manager
+msgid "Manage category groups"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model,name:deltatech_category_group.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model,name:deltatech_category_group.model_stock_quant
+msgid "Quants"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model,name:deltatech_category_group.model_sale_margin_report
+msgid "Sale Margin Report"
+msgstr ""
+
+#. module: deltatech_category_group
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_class__sequence
+#: model:ir.model.fields,field_description:deltatech_category_group.field_category_group_type__sequence
+msgid "Sequence"
+msgstr ""

--- a/deltatech_competitors_price/i18n/deltatech_competitors_price.pot
+++ b/deltatech_competitors_price/i18n/deltatech_competitors_price.pot
@@ -1,0 +1,146 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_competitors_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__auto_fetch
+msgid "Auto Fetch"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.view_deltatech_competitor_price_form
+msgid "Close"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__competitor_name
+msgid "Competitor"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.view_deltatech_competitor_price_form
+msgid "Competitor Price"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model,name:deltatech_competitors_price.model_deltatech_competitor_price
+msgid "Competitor Price Tracking"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_product_product__competitor_price_ids
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_product_template__competitor_price_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.product_template_form_inherit_competitor_prices
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.view_deltatech_competitor_price_tree
+msgid "Competitor Prices"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__display_name
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.product_template_form_inherit_competitor_prices
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.view_deltatech_competitor_price_tree
+msgid "Fetch"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model_terms:ir.ui.view,arch_db:deltatech_competitors_price.view_deltatech_competitor_price_form
+msgid "Fetch Now"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__fetch_status
+msgid "Fetch Status"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__id
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,help:deltatech_competitors_price.field_deltatech_competitor_price__auto_fetch
+msgid "Include in scheduled fetch"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__last_fetch
+msgid "Last Fetch"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__last_price
+msgid "Last Price"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#. odoo-python
+#: code:addons/deltatech_competitors_price/models/competitor_price.py:0
+msgid "No product URL on competitor line."
+msgstr ""
+
+#. module: deltatech_competitors_price
+#. odoo-python
+#: code:addons/deltatech_competitors_price/models/competitor_price.py:0
+msgid "OK"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#. odoo-python
+#: code:addons/deltatech_competitors_price/models/competitor_price.py:0
+msgid "Price not found on page"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model,name:deltatech_competitors_price.model_product_template
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__product_tmpl_id
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_competitors_price
+#: model:ir.model.fields,field_description:deltatech_competitors_price.field_deltatech_competitor_price__product_url
+msgid "Product URL"
+msgstr ""

--- a/deltatech_contact/i18n/deltatech_contact.pot
+++ b/deltatech_contact/i18n/deltatech_contact.pot
@@ -1,0 +1,175 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_contact
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__birthdate
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__birthdate
+msgid "Birthdate"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__cnp
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__cnp
+msgid "CNP"
+msgstr ""
+
+#. module: deltatech_contact
+#. odoo-python
+#: code:addons/deltatech_contact/models/res_partner.py:0
+msgid "CNP invalid"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_simple_form
+msgid "Card ID Issued"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_simple_form
+msgid "Card ID Number"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model,name:deltatech_contact.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model,website_form_label:deltatech_contact.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_res_partner_filter
+msgid "Delivery"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_simple_form
+msgid "Ex: 01.01.2000"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields.selection,name:deltatech_contact.selection__res_partner__gender__female
+msgid "Female"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__gender
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__gender
+msgid "Gender"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__id_issued_at
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__id_issued_at
+msgid "ID Issued at"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__id_issued_by
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__id_issued_by
+msgid "ID Issued by"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__id_nr
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__id_nr
+msgid "ID Nr"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__id_series
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__id_series
+msgid "ID series"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+msgid "Identity Card"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_res_partner_filter
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__is_department
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__is_department
+msgid "Is Department"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields.selection,name:deltatech_contact.selection__res_partner__gender__male
+msgid "Male"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_partner__mean_transp
+#: model:ir.model.fields,field_description:deltatech_contact.field_res_users__mean_transp
+msgid "Mean Transport"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+msgid "Number"
+msgstr ""
+
+#. module: deltatech_contact
+#: model:ir.model.fields.selection,name:deltatech_contact.selection__res_partner__gender__other
+msgid "Other"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+msgid "Other Information"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+msgid "Personal Data"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_simple_form
+msgid "SPCLEP .."
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+msgid "Series"
+msgstr ""
+
+#. module: deltatech_contact
+#: model_terms:ir.ui.view,arch_db:deltatech_contact.view_partner_form
+msgid "XX"
+msgstr ""

--- a/deltatech_credentials/i18n/deltatech_credentials.pot
+++ b/deltatech_credentials/i18n/deltatech_credentials.pot
@@ -1,0 +1,114 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_credentials
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__access_token
+msgid "Access Token"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__access_type
+msgid "Access Type"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields.selection,name:deltatech_credentials.selection__access_credentials__access_type__token
+msgid "Access token"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__client_id
+msgid "Client Id"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__client_secret
+msgid "Client Secret / API key"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields.selection,name:deltatech_credentials.selection__access_credentials__access_type__client
+msgid "Client_id and client_secret"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__code
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.actions.act_window,name:deltatech_credentials.action_access_credentials
+#: model:ir.model,name:deltatech_credentials.model_access_credentials
+#: model:ir.ui.menu,name:deltatech_credentials.menu_access_credentials
+#: model_terms:ir.ui.view,arch_db:deltatech_credentials.view_access_credentials_form
+msgid "Credentials"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__password
+msgid "Password"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model_terms:ir.ui.view,arch_db:deltatech_credentials.view_access_credentials_filter
+msgid "Search"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields.selection,name:deltatech_credentials.selection__access_credentials__access_type__user
+msgid "User and password"
+msgstr ""
+
+#. module: deltatech_credentials
+#: model:ir.model.fields,field_description:deltatech_credentials.field_access_credentials__username
+msgid "Username"
+msgstr ""

--- a/deltatech_cron_monitor_webhook/i18n/deltatech_cron_monitor_webhook.pot
+++ b/deltatech_cron_monitor_webhook/i18n/deltatech_cron_monitor_webhook.pot
@@ -1,0 +1,173 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_cron_monitor_webhook
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Authentication Options (choose ONE):</strong>"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"<strong>Body (POST only):</strong> Send a JSON with token (requires "
+"<code>Content-Type: application/json</code>)"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Header:</strong> Add <code>X-Access-Token: YOUR_TOKEN</code>"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Method:</strong> POST or GET"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Schedule:</strong> Your desired interval"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"<strong>URL Parameter:</strong> Append <code>?token=YOUR_TOKEN</code> to the"
+" URL"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"<strong>URL:</strong> Copy from the Cron Job (Webhook Configuration tab)\n"
+"                                                <br/>\n"
+"                                                <small class=\"text-muted\">Or use the global token: <code>https://your-domain.com/cron/webhook/YOUR_CODE?token=GLOBAL_TOKEN</code></small>"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model,name:deltatech_cron_monitor_webhook.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Create a free account on"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Create a new cron job with these settings:"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Cron Monitor"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Cron Monitoring Settings"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__display_name
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__enable_webhook
+msgid "Enable Webhook"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Example Body for POST:"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Generate Token"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_res_config_settings__cron_webhook_token
+msgid "Global Webhook Token"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Global webhook security settings"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__id
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model,name:deltatech_cron_monitor_webhook.model_ir_cron
+msgid "Scheduled Actions"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,help:deltatech_cron_monitor_webhook.field_ir_cron__webhook_code
+msgid "Unique code for this webhook"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__webhook_code
+msgid "Webhook Code"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.constraint,message:deltatech_cron_monitor_webhook.constraint_ir_cron_webhook_code_unique
+msgid "Webhook Code must be unique!"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.ir_cron_view_form_inherit_monitoring
+msgid "Webhook Configuration"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Webhook Security"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__webhook_url
+msgid "Webhook URL"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "cron-job.org"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"{\n"
+"    \"token\": \"YOUR_TOKEN_HERE\"\n"
+"}"
+msgstr ""
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "🚀 External Cron Setup (cron-job.org)"
+msgstr ""

--- a/deltatech_data_sheet/i18n/deltatech_data_sheet.pot
+++ b/deltatech_data_sheet/i18n/deltatech_data_sheet.pot
@@ -1,0 +1,48 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_data_sheet
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_data_sheet
+#: model_terms:ir.ui.view,arch_db:deltatech_data_sheet.product_template_form_view
+msgid "Data Sheet"
+msgstr ""
+
+#. module: deltatech_data_sheet
+#: model:ir.model.fields,field_description:deltatech_data_sheet.field_product_product__data_sheet_id
+#: model:ir.model.fields,field_description:deltatech_data_sheet.field_product_template__data_sheet_id
+msgid "Data Sheet Attachment"
+msgstr ""
+
+#. module: deltatech_data_sheet
+#: model:ir.model.fields,field_description:deltatech_data_sheet.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_data_sheet
+#: model:ir.model.fields,field_description:deltatech_data_sheet.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_data_sheet
+#: model:ir.model,name:deltatech_data_sheet.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_data_sheet
+#: model:ir.model.fields,field_description:deltatech_data_sheet.field_product_product__safety_data_sheet_id
+#: model:ir.model.fields,field_description:deltatech_data_sheet.field_product_template__safety_data_sheet_id
+msgid "Safety Data Sheet"
+msgstr ""

--- a/deltatech_data_sheet_website/i18n/deltatech_data_sheet_website.pot
+++ b/deltatech_data_sheet_website/i18n/deltatech_data_sheet_website.pot
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_data_sheet_website
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_data_sheet_website
+#: model_terms:ir.ui.view,arch_db:deltatech_data_sheet_website.product_data_sheet
+msgid "Show Data Sheet"
+msgstr ""
+
+#. module: deltatech_data_sheet_website
+#: model_terms:ir.ui.view,arch_db:deltatech_data_sheet_website.product_data_sheet
+msgid "Show Safety Data Sheet"
+msgstr ""

--- a/deltatech_dc/i18n/deltatech_dc.pot
+++ b/deltatech_dc/i18n/deltatech_dc.pot
@@ -1,0 +1,417 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_dc
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ", NRC:"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ""
+", do not endanger the life, health and safety of consumers and comply with\n"
+"                    the\n"
+"                    internal technical specifications of the products and with the sanitary-veterinary legislation and\n"
+"                    for food safety in force. We guarantee the quality of the products provided that the storage and\n"
+"                    transport parameters specified in the table and on the packaging are respected."
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ", with headquarters in"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ""
+"; we declare, ensure and guarantee on our\n"
+"                    own\n"
+"                    responsibility that the products delivered to the customer, according to the invoice/notice no."
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ""
+"<br/>\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <span>\n"
+"                    Registration Nr.\n"
+"                </span>\n"
+"                <br/>\n"
+"                <br/>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_warranty_certificate
+msgid ""
+"<br/>\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"\n"
+"                <br/>\n"
+"                We,"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ""
+"<br/>\n"
+"                <br/>\n"
+"                <span>\n"
+"                    <strong>Responsible Person:</strong>\n"
+"                    <br/>\n"
+"                    <br/>\n"
+"                    <strong>Signature:</strong>\n"
+"                </span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>, declare that the product:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>, with dates the tax identification</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>, with its headquarters in</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "<span>Declaration of Conformity:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>Standard of Company #:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>Standards:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>Technical Data Sheet #:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>Technical Specification #:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_warranty_certificate
+msgid "<span>Warranty Certificate</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>We,</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>and controlled according to Quality Control Plan dated in</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>is made in accordance with:</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>street</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>with expiration date</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "<span>with lot number</span>"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_warranty_certificate
+msgid "Annex of invoice:"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__data_sheet
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_product__data_sheet
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_template__data_sheet
+msgid "Data Sheet"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__date
+msgid "Date of Declaration"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.actions.act_window,name:deltatech_dc.action_deltatech_dc
+#: model:ir.actions.report,name:deltatech_dc.action_report_dc
+#: model:ir.actions.report,name:deltatech_dc.action_report_dc_invoice
+#: model:ir.actions.report,name:deltatech_dc.action_report_dc_lot
+#: model:ir.actions.report,name:deltatech_dc.action_report_dc_picking
+#: model:ir.model,name:deltatech_dc.model_deltatech_dc
+#: model:ir.ui.menu,name:deltatech_dc.menu_deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.view_deltatech_dc_type_form
+msgid "Declaration of Conformity"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.actions.report,name:deltatech_dc.action_report_dc_picking_form_2
+msgid "Declaration of Conformity 2"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__display_name
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc__display_name
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc_invoice__display_name
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc_lot__display_name
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_dc.field_stock_lot__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Expiration Date"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "F(PP 7.5/4.4.6-01)03"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__id
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc__id
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc_invoice__id
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc_lot__id
+#: model:ir.model.fields,field_description:deltatech_dc.field_report_deltatech_dc_report_dc_picking__id
+#: model:ir.model.fields,field_description:deltatech_dc.field_stock_lot__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__lot_id
+msgid "Lot"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Lot Number"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model,name:deltatech_dc.model_stock_lot
+msgid "Lot/Serial"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Name of products and services"
+msgstr ""
+
+#. module: deltatech_dc
+#. odoo-python
+#: code:addons/deltatech_dc/models/deltatech_dc.py:0
+msgid "New"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Nr."
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__name
+msgid "Number"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model,name:deltatech_dc.model_product_template
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__product_id
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_warranty_certificate
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_stock_lot__production_date
+msgid "Production Date"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.product_template_form_view
+msgid "Quality Control"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model,name:deltatech_dc.model_report_deltatech_dc_report_dc
+#: model:ir.model,name:deltatech_dc.model_report_deltatech_dc_report_dc_invoice
+#: model:ir.model,name:deltatech_dc.model_report_deltatech_dc_report_dc_lot
+#: model:ir.model,name:deltatech_dc.model_report_deltatech_dc_report_dc_picking
+msgid "ReportDCPrint"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Sale Order:"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid "Signature,"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__company_standard
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_product__company_standard
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_template__company_standard
+msgid "Standard of Company"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__standards
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_product__standards
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_template__standards
+msgid "Standards"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "Storage Conditions"
+msgstr ""
+
+#. module: deltatech_dc
+#: model:ir.model.fields,field_description:deltatech_dc.field_deltatech_dc__technical_specification
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_product__technical_specification
+#: model:ir.model.fields,field_description:deltatech_dc.field_product_template__technical_specification
+msgid "Technical Specification"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "The document belongs to the"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_warranty_certificate
+msgid "Warranty Period(months)"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc
+msgid ""
+"We hereby certify that the above mentioned materials has been inspected by ourselves and\n"
+"                                meets our manufacturing specification and the\n"
+"                                requirements of your order. Final physical properties and compliance with any finished\n"
+"                                product specification depends on satisfactory\n"
+"                                processing by yourselves."
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "We,"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid ""
+"and cannot be made\n"
+"                        public without the council's approval."
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "county, VAT:"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "county, work point located in"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_form_2
+msgid "from"
+msgstr ""
+
+#. module: deltatech_dc
+#: model_terms:ir.ui.view,arch_db:deltatech_dc.report_dc_warranty_certificate
+msgid ""
+"with registration certificate (number), Unique\n"
+"                Registration Code (number), as a distributor, we provide a warranty for the following products:"
+msgstr ""

--- a/deltatech_delivery_status/i18n/deltatech_delivery_status.pot
+++ b/deltatech_delivery_status/i18n/deltatech_delivery_status.pot
@@ -1,0 +1,203 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_delivery_status
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__available_state__available
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_picking_internal_search
+msgid "Available"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking__available_state
+msgid "Available State"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__delivered
+msgid "Delivered"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking__delivery_state
+msgid "Delivery State"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_picking_internal_search
+msgid "Delivery Status"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_crm_team__display_name
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_payment_provider__display_name
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_payment_transaction__display_name
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_crm_team__id
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_payment_provider__id
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_payment_transaction__id
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,help:deltatech_delivery_status.field_payment_provider__postponed_delivery
+msgid ""
+"If enabled, the delivery will be postponed until the payment is confirmed."
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__in_warehouse
+msgid "In Carrier Warehouse"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__in_transit
+msgid "In Transit"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__in_delivery
+msgid "In delivery"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__available_state__partially
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_picking_internal_search
+msgid "Partially available"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model,name:deltatech_delivery_status.model_payment_provider
+msgid "Payment Provider"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model,name:deltatech_delivery_status.model_payment_transaction
+msgid "Payment Transaction"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model,name:deltatech_delivery_status.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_order_form
+msgid "Postpone"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.actions.server,name:deltatech_delivery_status.action_postpone_delivery
+msgid "Postpone Delivery"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_crm_team__postpone_payment_transfer
+msgid "Postpone delivery for transfer payment"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_order_form
+msgid "Postpone the delivery of the products"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking__postponed
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_stock_picking_type__postponed
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_picking_form
+msgid "Postponed"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_payment_provider__postponed_delivery
+msgid "Postponed Delivery"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields,field_description:deltatech_delivery_status.field_sale_order__postponed_delivery
+msgid "Postponed delivery"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__pre_advice
+msgid "Pre advice"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__ready_in_warehouse
+msgid "Ready in warehouse"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__delivery_state__refused
+msgid "Refused"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_order_form
+msgid "Release"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.actions.server,name:deltatech_delivery_status.action_release_delivery
+msgid "Release Delivery"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_order_form
+msgid "Release the postponed delivery of the products"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model,name:deltatech_delivery_status.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model,name:deltatech_delivery_status.model_crm_team
+msgid "Sales Team"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#. odoo-python
+#: code:addons/deltatech_delivery_status/models/stock_picking.py:0
+msgid "The transfer %s is postponed"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model,name:deltatech_delivery_status.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_delivery_status
+#: model:ir.model.fields.selection,name:deltatech_delivery_status.selection__stock_picking__available_state__unavailable
+#: model_terms:ir.ui.view,arch_db:deltatech_delivery_status.view_picking_internal_search
+msgid "Unavailable"
+msgstr ""

--- a/deltatech_discount_policy/i18n/deltatech_discount_policy.pot
+++ b/deltatech_discount_policy/i18n/deltatech_discount_policy.pot
@@ -1,0 +1,60 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_discount_policy
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist__discount_policy
+msgid "Discount Policy"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields.selection,name:deltatech_discount_policy.selection__product_pricelist__discount_policy__with_discount
+msgid "Discount included in the price"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist__display_name
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist_item__display_name
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist__id
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist_item__id
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model,name:deltatech_discount_policy.model_product_pricelist
+msgid "Pricelist"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model,name:deltatech_discount_policy.model_product_pricelist_item
+msgid "Pricelist Rule"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model,name:deltatech_discount_policy.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields.selection,name:deltatech_discount_policy.selection__product_pricelist__discount_policy__without_discount
+msgid "Show public price & discount to the customer"
+msgstr ""

--- a/deltatech_download/i18n/deltatech_download.pot
+++ b/deltatech_download/i18n/deltatech_download.pot
@@ -1,0 +1,73 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_download
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_ir_actions_report__direct_download
+msgid "Direct Download"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_ir_actions_report__display_name
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model,name:deltatech_download.model_wizard_download_file
+msgid "Download Wizard"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__data_file
+msgid "File"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__file_name
+msgid "File Name"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_ir_actions_report__id
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_download
+#: model:ir.model,name:deltatech_download.model_ir_actions_report
+msgid "Report Action"
+msgstr ""

--- a/deltatech_dropshipping/i18n/deltatech_dropshipping.pot
+++ b/deltatech_dropshipping/i18n/deltatech_dropshipping.pot
@@ -1,0 +1,62 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_dropshipping
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_dropshipping
+#. odoo-python
+#: code:addons/deltatech_dropshipping/models/purchase_order.py:0
+msgid ""
+"<li><strong>%(product)s</strong>: Purchase %(purchase)s > Sale %(sale)s "
+"(Diff: %(diff)s)</li>"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model:ir.model.fields,field_description:deltatech_dropshipping.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_dropshipping.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model:ir.model.fields,field_description:deltatech_dropshipping.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_dropshipping.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model:ir.model,name:deltatech_dropshipping.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model:ir.model.fields,field_description:deltatech_dropshipping.field_purchase_order__purchase_price_warning
+msgid "Purchase Price Warning"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model:ir.model.fields,field_description:deltatech_dropshipping.field_stock_picking__partner_shipping_id
+msgid "Shipping address"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model_terms:ir.ui.view,arch_db:deltatech_dropshipping.purchase_order_form
+msgid ""
+"The following products have a purchase price higher than the sale price:"
+msgstr ""
+
+#. module: deltatech_dropshipping
+#: model:ir.model,name:deltatech_dropshipping.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_expenses/i18n/deltatech_expenses.pot
+++ b/deltatech_expenses/i18n/deltatech_expenses.pot
@@ -1,0 +1,865 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_expenses
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__state
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction_line__state
+msgid ""
+" * The 'Draft' status is used when a user is encoding a new and unconfirmed expenses deduction.             \n"
+"* The 'Done' status is set automatically when the expenses deduction is confirm.              \n"
+"* The 'Cancelled' status is used when user cancel expenses deduction."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "<span class=\"o_form_label\">Expenses Deduction</span>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid ""
+"<span invisible=\"state != 'draft' or number != '/'\">Draft\n"
+"                            </span>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<span> având funcția de</span>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<span>Decont cheltuieli:</span>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<span>Subsemnatul</span>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<strong>Date</strong>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<strong>Document</strong>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<strong>Suma</strong>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "<strong>TVA</strong>"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__account_diem_id
+msgid "Account"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__move_id
+msgid "Account Entry"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.hr_expense_view_form_deduction
+msgid "Această cheltuială este preluată într-un"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.actions.act_window,name:deltatech_expenses.action_add_expenses_to_deduction
+msgid "Adaugă în decont de cheltuieli"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__advance
+#: model:ir.model.fields.selection,name:deltatech_expenses.selection__deltatech_expenses_deduction__state__advance
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Advance"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__date_advance
+msgid "Advance Date"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__analytic_distribution
+msgid "Analytic Distribution"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__analytic_precision
+msgid "Analytic Precision"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:res.groups,name:deltatech_expenses.group_expenses_user
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_expenses_import_hr_form
+msgid "Angajat"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__approved_by_id
+msgid "Aprobat de"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:res.groups,name:deltatech_expenses.group_expenses_approver
+msgid "Aprobator"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Avans"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "Avans primit in data"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields.selection,name:deltatech_expenses.selection__deltatech_expenses_deduction__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Cannot delete Expenses Deduction(s) which are already done."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__journal_id
+msgid "Cash Journal"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "Chelt. conf. borderou de mai jos"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction_line__hr_expense_id
+msgid "Cheltuiala hr.expense din care a fost preluată această linie."
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid ""
+"Cheltuielile pot fi preluate doar într-un decont în starea Draft sau "
+"Advance."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.actions.act_window,help:deltatech_expenses.action_deltatech_expenses_deduction
+msgid "Click to create a Expenses Deduction."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:res.groups,name:deltatech_expenses.group_expenses_accounting
+msgid "Contabil"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__accounted_by_id
+msgid "Contabilizat de"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__create_uid
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__create_uid
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__create_date
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__create_date
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__currency_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "DEC/2021/00001"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_hr_expense__expenses_deduction_id
+msgid ""
+"Dacă este completat, cheltuiala este decontată prin acest Decont de "
+"cheltuieli (deltatech_expenses), iar notele contabile NU se generează din "
+"modulul standard, pentru a evita dublarea cheltuielilor."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__date
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__days
+msgid "Days"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.module.category,name:deltatech_expenses.module_category_expenses_deduction
+#: model:res.groups.privilege,name:deltatech_expenses.res_groups_privilege_expenses_deduction
+msgid "Decont Cheltuieli"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_expenses_import_hr_form
+msgid "Decont de cheltuieli"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Decontare avans"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Decontul %s nu poate fi invalidat: nu este în starea Finalizat."
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid ""
+"Decontul %s nu poate fi validat ca avans: nu mai este în starea Ciornă (a "
+"fost deja validat sau invalidat)."
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid ""
+"Decontul %s nu poate fi validat: nu este în starea Avans (a fost deja "
+"finalizat sau nu are un avans validat)."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_employee_form_deduction
+msgid "Deconturi"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__expense_account_id
+msgid "Default Expense Account"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Deferenta Avans"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Description"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__diem
+msgid "Diem"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__journal_diem_id
+msgid "Diem Journal"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "Diferenţă"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__difference
+msgid "Difference"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "Din care diurna"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_journal__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_payment__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_hr_employee__display_name
+#: model:ir.model.fields,field_description:deltatech_expenses.field_hr_expense__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__distribution_analytic_account_ids
+msgid "Distribution Analytic Account"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Diurna"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields.selection,name:deltatech_expenses.selection__deltatech_expenses_deduction__state__done
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields.selection,name:deltatech_expenses.selection__deltatech_expenses_deduction__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_hr_employee
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__employee_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__employee_id
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_filter
+msgid "Employee"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__partner_id
+msgid "Employee Partner"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_hr_expense
+msgid "Expense"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__date_expense
+msgid "Expense Date"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__expense_journal_id
+msgid "Expense Journal"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__expenses_line_ids
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__expense_ids
+#: model:ir.model.fields.selection,name:deltatech_expenses.selection__deltatech_expenses_deduction_line__type__expenses
+msgid "Expenses"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.actions.act_window,name:deltatech_expenses.action_deltatech_expenses_deduction
+#: model:ir.model,name:deltatech_expenses.model_deltatech_expenses_deduction
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_bank_statement_line__expenses_deduction_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_move__expenses_deduction_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_payment__expenses_deduction_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__expenses_deduction_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__expenses_deduction_id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_hr_expense__expenses_deduction_id
+#: model:ir.ui.menu,name:deltatech_expenses.menu_deltatech_expenses_deduction
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_filter
+msgid "Expenses Deduction"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_deltatech_expenses_deduction_line
+msgid "Expenses Deduction Line"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/hr_employee.py:0
+#: model:ir.model.fields,field_description:deltatech_expenses.field_hr_employee__expenses_deduction_count
+msgid "Expenses Deductions"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Expenses Sheet"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Free Notes"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid ""
+"Furnizorul %s nu are un cont de datorii (401) configurat; completați 'Cont "
+"de plătit' pe partener înainte de decontare."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__hr_expense_id
+msgid "HR Expense"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_journal__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_account_payment__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_hr_employee__id
+#: model:ir.model.fields,field_description:deltatech_expenses.field_hr_expense__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__message_has_error
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_deltatech_expenses_import_hr
+msgid "Import HR Expenses into Expenses Deduction"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Invalidate"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__move_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Journal Items"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__write_uid
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__write_uid
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__write_date
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__write_date
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_import_hr__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_filter
+msgid "Month"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_filter
+msgid "My Expenses"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_filter
+msgid "New"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_filter
+msgid "New Expenses Deduction"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__note
+msgid "Note"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Notes"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "Nu aveți rolul necesar pentru a %s decontul de cheltuieli."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__number
+msgid "Number"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction_line__tax_ids
+msgid "Only for tax excluded from price"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Other information"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__partner_id
+msgid ""
+"Partenerul asociat angajatului (work_contact_id), folosit pentru notele "
+"contabile."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model,name:deltatech_expenses.model_account_payment
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__payment_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Payments"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_expenses_import_hr_form
+msgid "Preia"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_expenses_import_hr_form
+msgid "Preia cheltuieli HR"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__price_subtotal
+msgid "Price Subtotal"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.actions.report,name:deltatech_expenses.action_report_deltatech_expenses_deduction
+msgid "Print Expenses Deduction"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__rating_ids
+msgid "Ratings"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__name
+msgid "Reference"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_expenses_import_hr_form
+msgid "Renunță"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid ""
+"Se certifica îndeplinirea obiectivului delegației\n"
+"                                        <br/>\n"
+"                                        Șef compartiment"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/wizard/expenses_import_hr.py:0
+msgid "Selectați cheltuieli ale aceluiași angajat."
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/wizard/expenses_import_hr.py:0
+msgid "Selectați decontul de cheltuieli în care se preiau cheltuielile."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "Semnătură titular"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__state
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__state
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Supplier"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields.selection,name:deltatech_expenses.selection__deltatech_expenses_deduction_line__type__supplier_payment
+msgid "Supplier Payment"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__tax_ids
+msgid "Tax"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__tax_amount
+msgid "Tax Amount"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__amount
+msgid "Total"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__amount
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_tree
+msgid "Total Amount"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__total_diem
+msgid "Total Diem"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Total Tax"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Traseu aprobare"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__travel_order
+msgid "Travel Order"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction_line__type
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid ""
+"Următoarele cheltuieli nu pot fi preluate în acest decont (angajat/companie "
+"diferite, stare neeligibilă sau deja contabilizate): %s"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__accounted_by_id
+msgid "Utilizatorul care a finalizat/contabilizat decontul (rol Contabil)."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__approved_by_id
+msgid "Utilizatorul care a validat avansul (rol Aprobator)."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.view_deltatech_expenses_deduction_form
+msgid "Validate"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__voucher_ids
+msgid "Vouchers"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__amount_vouchers
+msgid "Vouchers Amount"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,field_description:deltatech_expenses.field_deltatech_expenses_deduction__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model:ir.model.fields,help:deltatech_expenses.field_deltatech_expenses_deduction__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/deltatech_expenses_deduction.py:0
+msgid "You must select a supplier for all lines."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "acte justificative specificate"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "anexez prezentului"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "de primit"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "de restituit"
+msgstr ""
+
+#. module: deltatech_expenses
+#. odoo-python
+#: code:addons/deltatech_expenses/models/hr_employee.py:0
+msgid "employee_id"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "un act justificativ specificat"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "în baza ordinului de deplasare nr."
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid ""
+"în borderoul de mai jos pentru justificarea avansului primit la data de"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.report_deltatech_expenses_deduction
+msgid "Șef contabil"
+msgstr ""
+
+#. module: deltatech_expenses
+#: model_terms:ir.ui.view,arch_db:deltatech_expenses.hr_expense_view_form_deduction
+msgid "și se contabilizează acolo; postarea standard este dezactivată."
+msgstr ""

--- a/deltatech_fast_purchase/i18n/deltatech_fast_purchase.pot
+++ b/deltatech_fast_purchase/i18n/deltatech_fast_purchase.pot
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_fast_purchase
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_fast_purchase
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_purchase.purchase_order_form
+msgid ""
+"Are you sure you want to make the automatic receipt with the quantities and "
+"price from the purchase order?"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_purchase.purchase_order_form
+msgid "Confirm, Receipt and Bill"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model:ir.model.fields,field_description:deltatech_fast_purchase.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_fast_purchase.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model:ir.model.fields,field_description:deltatech_fast_purchase.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_fast_purchase.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_purchase.view_picking_form
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model:ir.model.fields,field_description:deltatech_fast_purchase.field_stock_picking__notice
+msgid "Notice"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model:ir.model,name:deltatech_fast_purchase.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_purchase.purchase_order_form
+msgid "Receipt Notice"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_purchase.purchase_order_form
+msgid "Receipt and Bill"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#. odoo-python
+#: code:addons/deltatech_fast_purchase/models/purchase.py:0
+msgid "The stock transfer cannot be validated!"
+msgstr ""
+
+#. module: deltatech_fast_purchase
+#: model:ir.model,name:deltatech_fast_purchase.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_fast_sale/i18n/deltatech_fast_sale.pot
+++ b/deltatech_fast_sale/i18n/deltatech_fast_sale.pot
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_fast_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_fast_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_sale.view_order_form
+msgid ""
+"Are you sure you want to make the automatic delivery with the quantities and"
+" price from the sale order?"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_sale.view_order_form
+msgid "Confirm, Deliver and Invoice"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_sale.view_order_form
+msgid "Deliver Notice"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_sale.view_order_form
+msgid "Deliver and Invoice"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model:ir.model.fields,field_description:deltatech_fast_sale.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_fast_sale.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model:ir.model.fields,field_description:deltatech_fast_sale.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_fast_sale.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_fast_sale.view_picking_form
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#. odoo-python
+#: code:addons/deltatech_fast_sale/models/sale.py:0
+msgid "Not all products are available."
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model:ir.model.fields,field_description:deltatech_fast_sale.field_stock_picking__notice
+msgid "Notice"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model:ir.model,name:deltatech_fast_sale.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_fast_sale
+#: model:ir.model,name:deltatech_fast_sale.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_followup/i18n/deltatech_followup.pot
+++ b/deltatech_followup/i18n/deltatech_followup.pot
@@ -1,0 +1,420 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_followup
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__with_refunds
+msgid "Also get refund invoices"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__amount_margin
+msgid "Amount margin"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__amount_margin
+msgid ""
+"Amount margin. If total due debit is lower than this margin, the followup "
+"will be skipped"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__code
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__code
+msgid "Code. Can be used in cron job to run only selected followups"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__match
+msgid "Comparator"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__match
+msgid ""
+"Comparator operator. If equal, only the invoices with the exact date will be"
+" processed. If greater or equal, all theinvoices with date grater or equal "
+"with the computed datewill be processed"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model,name:deltatech_followup.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model,website_form_label:deltatech_followup.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__create_uid
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__create_date
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__date_field
+msgid "Date field to use"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__relative_days
+msgid "Days from"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__display_name
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__display_name
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__date_field__due_date
+msgid "Due date"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__match__=
+msgid "Equal"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model,name:deltatech_followup.model_followup_send_wizard
+msgid "Followup Send Wizard"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:res.groups,name:deltatech_followup.group_manage_followups
+msgid "Followup manager"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.ui.menu,name:deltatech_followup.menu_invoice_followup
+msgid "Followups"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__match__>=
+msgid "Greater or equal"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__id
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__id
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_partner__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_has_error
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__use_customer_currency
+msgid ""
+"If checked, the currency of the customer will be used, otherwise the "
+"currency of the company"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.actions.act_window,name:deltatech_followup.action_invoice_followup
+#: model:ir.model,name:deltatech_followup.model_account_invoice_followup
+#: model_terms:ir.ui.view,arch_db:deltatech_followup.view_followups_form
+msgid "Invoice Followup"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__date_field__invoice_date
+msgid "Invoice date"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__invoice_html
+msgid "Invoices placeholder"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__write_uid
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__write_date
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__mail_template
+msgid "Mail Template"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__mail_template
+msgid "Mail template to use. You have to use a Partner model template."
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__name
+msgid "Name of the followup"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__only_open
+msgid "Only open (unpaid) invoices will be processed"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__only_open
+msgid "Only open invoices"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__with_refunds
+msgid "Parse refund invoices"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__rating_ids
+msgid "Ratings"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__relative_days
+msgid ""
+"Relative days from date field. Can be negative if you want to send this "
+"followup before the given date"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_partner__send_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_users__send_followup
+msgid "Send followup e-mails"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.actions.server,name:deltatech_followup.action_send_followup
+msgid "Send now"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__date_field
+msgid ""
+"The date field from the invoices from which the send date will be computed"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__invoice_html
+msgid ""
+"This code will be inserted into the mail, replacing the[invoices] key string. The following placeholders canbe used:\n"
+"$number=invoice.number,\n"
+"$payment_term_id=invoice.payment_term_id,\n"
+"$date_invoice=invoice.date_invoice,\n"
+"$date_due=invoice.date_due,\n"
+"$amount_untaxed=invoice.amount_untaxed,\n"
+"$amount_tax=invoice.amount_tax,\n"
+"$amount_total=invoice.amount_total,\n"
+"$amount_due=invoice.residual,\n"
+"$total_debit=total amount to pay,\n"
+"$currency=invoice.currency\n"
+"$total_all_debit=all partner debit\n"
+"$total_due_debit=all due debit"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__use_customer_currency
+msgid "Use customer currency"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__website_message_ids
+msgid "Website communication history"
+msgstr ""

--- a/deltatech_generic_partner_restriction/i18n/deltatech_generic_partner_restriction.pot
+++ b/deltatech_generic_partner_restriction/i18n/deltatech_generic_partner_restriction.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_generic_partner_restriction
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_journal__display_name
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_payment__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_journal__restriction
+msgid "Generic Restriction"
+msgstr ""
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_journal__id
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_payment__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model,name:deltatech_generic_partner_restriction.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model,name:deltatech_generic_partner_restriction.model_account_payment
+msgid "Payments"
+msgstr ""

--- a/deltatech_gln/i18n/deltatech_gln.pot
+++ b/deltatech_gln/i18n/deltatech_gln.pot
@@ -1,0 +1,48 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_gln
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_gln
+#: model:ir.model,name:deltatech_gln.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_gln
+#: model:ir.model,website_form_label:deltatech_gln.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_partner__gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_users__gln
+msgid "GLN"
+msgstr ""
+
+#. module: deltatech_gln
+#: model:ir.model.fields,help:deltatech_gln.field_res_partner__gln
+#: model:ir.model.fields,help:deltatech_gln.field_res_users__gln
+msgid "Global Location Number"
+msgstr ""
+
+#. module: deltatech_gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_partner__id
+msgid "ID"
+msgstr ""

--- a/deltatech_invoice_number/i18n/deltatech_invoice_number.pot
+++ b/deltatech_invoice_number/i18n/deltatech_invoice_number.pot
@@ -1,0 +1,131 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_number
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_number
+#: model:ir.model,name:deltatech_invoice_number.model_account_invoice_change_number
+msgid "Account Invoice Change Number"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:res.groups,name:deltatech_invoice_number.group_change_invoice_number
+msgid "Allow to change invoice number"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_number.view_account_invoice_change_number_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_number.view_account_invoice_change_number_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.actions.act_window,name:deltatech_invoice_number.action_account_invoice_change_number
+#: model:ir.actions.server,name:deltatech_invoice_number.action_account_invoice_change_number_server
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_number.view_account_invoice_change_number_form
+msgid "Change invoice number"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_journal__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__id
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_journal__id
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_move__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__internal_number
+msgid "Invoice Number"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_number.journal_restrict_date_form
+msgid "Invoice numbering"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model,name:deltatech_invoice_number.model_account_journal
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model,name:deltatech_invoice_number.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_journal__journal_sequence_id
+msgid "Journal Sequence"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_invoice_change_number__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#. odoo-python
+#: code:addons/deltatech_invoice_number/models/account_invoice.py:0
+msgid "Please define a sequence on the journal."
+msgstr ""
+
+#. module: deltatech_invoice_number
+#. odoo-python
+#: code:addons/deltatech_invoice_number/models/account_invoice.py:0
+msgid "Post the invoice with a date on or after %s"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#: model:ir.model.fields,field_description:deltatech_invoice_number.field_account_journal__restrict_date
+msgid "Restrict invoice date"
+msgstr ""
+
+#. module: deltatech_invoice_number
+#. odoo-python
+#: code:addons/deltatech_invoice_number/models/account_invoice.py:0
+msgid "The invoice has no date."
+msgstr ""
+
+#. module: deltatech_invoice_number
+#. odoo-python
+#: code:addons/deltatech_invoice_number/models/account_invoice.py:0
+msgid "Warning"
+msgstr ""

--- a/deltatech_invoice_picking/i18n/deltatech_invoice_picking.pot
+++ b/deltatech_invoice_picking/i18n/deltatech_invoice_picking.pot
@@ -1,0 +1,176 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_picking
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking__account_move_id
+msgid "Account Move"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_stock_picking_batch
+msgid "Batch Transfer"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_picking.view_picking_form
+msgid "Bill"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.actions.server,name:deltatech_invoice_picking.action_picking_supplier_invoice
+msgid "Create Purchase Invoices"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.actions.server,name:deltatech_invoice_picking.action_picking_invoice
+msgid "Create Sale Invoices"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_account_bank_statement_line__from_pickings
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_account_move__from_pickings
+msgid "Created from pickings"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_account_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_purchase_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_advance_payment_inv__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking_batch__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_order__force_invoice_order
+msgid "Force Invoice Order"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_account_move_line__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_purchase_order_line__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_advance_payment_inv__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_sale_order_line__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking_batch__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_picking.view_batch_form_invoice
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_picking.view_picking_form
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking_batch__invoiced
+msgid "Invoiced"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/stock_picking.py:0
+msgid "Please enter supplier invoice number"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_sale_advance_payment_inv
+msgid "Sales Advance Payment Invoice"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking__supplier_invoice_number
+msgid "Supplier Invoice No"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model.fields,field_description:deltatech_invoice_picking.field_stock_picking__to_invoice
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_picking.view_picking_internal_search_inherit_invoice_picking
+msgid "To invoice"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#: model:ir.model,name:deltatech_invoice_picking.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/account_move.py:0
+msgid "You cannot change this line, the move was generated from pickings"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/account_move.py:0
+msgid "You cannot delete lines, the move was generated from pickings"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/stock_picking_batch.py:0
+msgid "You cannot invoice this type of batches: (%s)"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/purchase.py:0
+#: code:addons/deltatech_invoice_picking/models/sale.py:0
+msgid "You cannot invoice this type of transfer: %s"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/stock_picking_batch.py:0
+msgid "You cannot invoice unconfirmed batches (%s)"
+msgstr ""
+
+#. module: deltatech_invoice_picking
+#. odoo-python
+#: code:addons/deltatech_invoice_picking/models/stock_picking.py:0
+msgid "You cannot invoice unconfirmed pickings (%s)"
+msgstr ""

--- a/deltatech_invoice_picking_automatically/i18n/deltatech_invoice_picking_automatically.pot
+++ b/deltatech_invoice_picking_automatically/i18n/deltatech_invoice_picking_automatically.pot
@@ -1,0 +1,73 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_picking_automatically
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking_type__create_invoice_automatically
+msgid "Create Invoice Automatically"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields.selection,name:deltatech_invoice_picking_automatically.selection__stock_picking__invoice_state__failed
+msgid "Failed"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.actions.server,name:deltatech_invoice_picking_automatically.ir_cron_generate_invoices_ir_actions_server
+msgid "Generate Invoices from Pickings"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking__invoice_state
+msgid "Invoice State"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields.selection,name:deltatech_invoice_picking_automatically.selection__stock_picking__invoice_state__invoiced
+msgid "Invoiced"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model,name:deltatech_invoice_picking_automatically.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields,field_description:deltatech_invoice_picking_automatically.field_stock_picking_type__post_invoice_automatically
+msgid "Post Invoice Automatically"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model.fields.selection,name:deltatech_invoice_picking_automatically.selection__stock_picking__invoice_state__to_invoice
+msgid "To Invoice"
+msgstr ""
+
+#. module: deltatech_invoice_picking_automatically
+#: model:ir.model,name:deltatech_invoice_picking_automatically.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_invoice_product_filter/i18n/deltatech_invoice_product_filter.pot
+++ b/deltatech_invoice_product_filter/i18n/deltatech_invoice_product_filter.pot
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_product_filter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_product_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_product_filter.view_account_invoice_filter
+msgid "Product"
+msgstr ""

--- a/deltatech_invoice_receipt/i18n/deltatech_invoice_receipt.pot
+++ b/deltatech_invoice_receipt/i18n/deltatech_invoice_receipt.pot
@@ -1,0 +1,86 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_receipt
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_purchase_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_purchase_order__from_invoice_id
+msgid "Generated from the invoice"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_purchase_order_line__id
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model,name:deltatech_invoice_receipt.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model.fields,field_description:deltatech_invoice_receipt.field_stock_picking__notice
+msgid "Notice"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#. odoo-python
+#: code:addons/deltatech_invoice_receipt/models/account_invoice.py:0
+msgid "Please confirm purchase order before posting invoice"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#. odoo-python
+#: code:addons/deltatech_invoice_receipt/models/account_invoice.py:0
+msgid "Please enter invoice date"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model,name:deltatech_invoice_receipt.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model,name:deltatech_invoice_receipt.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#. odoo-python
+#: code:addons/deltatech_invoice_receipt/models/account_invoice.py:0
+msgid "The purchase order %s was generated."
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#. odoo-python
+#: code:addons/deltatech_invoice_receipt/models/purchase.py:0
+msgid "The stock transfer cannot be validated!"
+msgstr ""
+
+#. module: deltatech_invoice_receipt
+#: model:ir.model,name:deltatech_invoice_receipt.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_invoice_report/i18n/deltatech_invoice_report.pot
+++ b/deltatech_invoice_report/i18n/deltatech_invoice_report.pot
@@ -1,0 +1,142 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_account_invoice_report__supplier_id
+msgid "Default Supplier"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_account_invoice_report__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_report.product_template_form_view
+msgid "History"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_account_invoice_report__id
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__id
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_product__invoice_history
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_template__invoice_history
+msgid "Invoice History"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model,name:deltatech_invoice_report.model_account_invoice_report
+msgid "Invoices Statistics"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_product__last_invoice_history_computed
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_template__last_invoice_history_computed
+msgid "Last Computed Invoice History"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_product__last_sale_date
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_template__last_sale_date
+msgid "Last Sale Date"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model,name:deltatech_invoice_report.model_product_template
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_report.view_account_invoice_report_search
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_account_invoice_report__product_tmpl_id
+msgid "Product Template"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model,name:deltatech_invoice_report.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__qty_in
+msgid "Qty In"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__qty_out
+msgid "Qty Out"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_report.product_template_form_view
+msgid "Refresh"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_account_invoice_report__state_id
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_report.view_account_invoice_report_search
+msgid "Region"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__template_id
+msgid "Template"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.actions.server,name:deltatech_invoice_report.ir_cron_update_product_invoice_history_by_year_ir_actions_server
+msgid "Update Product Invoice History by Year"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model.fields,field_description:deltatech_invoice_report.field_product_invoice_history__year
+msgid "Year"
+msgstr ""
+
+#. module: deltatech_invoice_report
+#: model:ir.model,name:deltatech_invoice_report.model_product_invoice_history
+msgid "product.invoice.history"
+msgstr ""

--- a/deltatech_invoice_to_draft/i18n/deltatech_invoice_to_draft.pot
+++ b/deltatech_invoice_to_draft/i18n/deltatech_invoice_to_draft.pot
@@ -1,0 +1,41 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_to_draft
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_to_draft
+#: model:res.groups,name:deltatech_invoice_to_draft.group_reset_to_draft_account_move
+msgid "Can reset account move to draft"
+msgstr ""
+
+#. module: deltatech_invoice_to_draft
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_to_draft.invoice_form
+msgid "Cancel Entry"
+msgstr ""
+
+#. module: deltatech_invoice_to_draft
+#: model:ir.model.fields,field_description:deltatech_invoice_to_draft.field_account_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_to_draft
+#: model:ir.model.fields,field_description:deltatech_invoice_to_draft.field_account_move__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_to_draft
+#: model:ir.model,name:deltatech_invoice_to_draft.model_account_move
+msgid "Journal Entry"
+msgstr ""

--- a/deltatech_invoice_weight/i18n/deltatech_invoice_weight.pot
+++ b/deltatech_invoice_weight/i18n/deltatech_invoice_weight.pot
@@ -1,0 +1,114 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_invoice_weight
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_invoice_weight
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_weight.report_invoice_document_weight
+msgid ""
+"<br/>\n"
+"                <strong>New weight:</strong>"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_weight.report_invoice_document_weight
+msgid "<strong>Gross weight:</strong>"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_bank_statement_line__weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_move__weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_purchase_order__weight_gross
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_sale_order__weight_gross
+msgid "Gross Weight"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model,name:deltatech_invoice_weight.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_product_product__l10n_ro_net_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_product_template__l10n_ro_net_weight
+msgid "L10N Ro Net Weight"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_bank_statement_line__weight_net
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_move__weight_net
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_purchase_order__weight_net
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_sale_order__weight_net
+msgid "Net Weight"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_bank_statement_line__weight_package
+#: model:ir.model.fields,field_description:deltatech_invoice_weight.field_account_move__weight_package
+msgid "Package Weight"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model,name:deltatech_invoice_weight.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model,name:deltatech_invoice_weight.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model,name:deltatech_invoice_weight.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_account_bank_statement_line__weight
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_account_move__weight
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_purchase_order__weight_gross
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_sale_order__weight_gross
+msgid "The gross weight in Kg."
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_account_bank_statement_line__weight_net
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_account_move__weight_net
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_purchase_order__weight_net
+#: model:ir.model.fields,help:deltatech_invoice_weight.field_sale_order__weight_net
+msgid "The net weight in Kg."
+msgstr ""
+
+#. module: deltatech_invoice_weight
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_weight.view_purchase_form
+#: model_terms:ir.ui.view,arch_db:deltatech_invoice_weight.view_sale_form
+msgid "Weight"
+msgstr ""

--- a/deltatech_kit_price/i18n/deltatech_kit_price.pot
+++ b/deltatech_kit_price/i18n/deltatech_kit_price.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_kit_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_kit_price
+#: model:ir.model.fields,field_description:deltatech_kit_price.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_kit_price
+#: model:ir.model.fields,field_description:deltatech_kit_price.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_kit_price
+#: model:ir.model,name:deltatech_kit_price.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/deltatech_ledger/i18n/deltatech_ledger.pot
+++ b/deltatech_ledger/i18n/deltatech_ledger.pot
@@ -1,0 +1,131 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_ledger
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_ledger
+#: model:ir.model.fields.selection,name:deltatech_ledger.selection__ledger_ledger__state__active
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_search
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields.selection,name:deltatech_ledger.selection__ledger_ledger__state__canceled
+msgid "Canceled"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__contact_id
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_search
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__document_number
+msgid "Document Number"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields.selection,name:deltatech_ledger.selection__ledger_ledger__record_type__entry
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_search
+msgid "Entry"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields.selection,name:deltatech_ledger.selection__ledger_ledger__record_type__exit
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_search
+msgid "Exit"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.actions.act_window,name:deltatech_ledger.action_ledger_model
+#: model:ir.model,name:deltatech_ledger.model_ledger_ledger
+#: model:ir.ui.menu,name:deltatech_ledger.menu_ledger_model
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_form
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_search
+msgid "Ledger"
+msgstr ""
+
+#. module: deltatech_ledger
+#. odoo-python
+#: code:addons/deltatech_ledger/models/ledger.py:0
+msgid "New"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__name
+msgid "Number of Record"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__place_of_origin
+msgid "Place of Origin"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__record_date
+msgid "Record Date"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__record_short_description
+msgid "Record Short Description"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__record_type
+#: model_terms:ir.ui.view,arch_db:deltatech_ledger.view_ledger_search
+msgid "Record Type"
+msgstr ""
+
+#. module: deltatech_ledger
+#: model:ir.model.fields,field_description:deltatech_ledger.field_ledger_ledger__state
+msgid "State"
+msgstr ""

--- a/deltatech_line_counter/i18n/deltatech_line_counter.pot
+++ b/deltatech_line_counter/i18n/deltatech_line_counter.pot
@@ -1,0 +1,78 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_line_counter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_line_counter
+#: model_terms:ir.ui.view,arch_db:deltatech_line_counter.view_line_counter_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model_terms:ir.ui.view,arch_db:deltatech_line_counter.view_line_counter_wizard_form
+msgid "Count Lines"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.actions.act_window,name:deltatech_line_counter.action_line_counter_wizard
+#: model:ir.ui.menu,name:deltatech_line_counter.menu_line_counter_wizard
+#: model_terms:ir.ui.view,arch_db:deltatech_line_counter.view_line_counter_wizard_form
+msgid "Line Counter"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model,name:deltatech_line_counter.model_line_counter_wizard
+msgid "Module Line Counter Wizard"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__module_ids
+msgid "Modules"
+msgstr ""
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__result
+msgid "Result"
+msgstr ""

--- a/deltatech_logistic_docs/i18n/deltatech_logistic_docs.pot
+++ b/deltatech_logistic_docs/i18n/deltatech_logistic_docs.pot
@@ -1,0 +1,97 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_logistic_docs
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_logistic_docs
+#: model:ir.model,name:deltatech_logistic_docs.model_ir_attachment
+msgid "Attachment"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#. odoo-python
+#: code:addons/deltatech_logistic_docs/models/account_invoice.py:0
+#: code:addons/deltatech_logistic_docs/models/purchase_order.py:0
+#: code:addons/deltatech_logistic_docs/models/sale_order.py:0
+#: code:addons/deltatech_logistic_docs/models/stock_picking.py:0
+msgid "Attachments"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_ir_actions_report__display_name
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_ir_attachment__display_name
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model_terms:ir.ui.view,arch_db:deltatech_logistic_docs.purchase_order_form
+#: model_terms:ir.ui.view,arch_db:deltatech_logistic_docs.view_move_form
+#: model_terms:ir.ui.view,arch_db:deltatech_logistic_docs.view_order_form
+#: model_terms:ir.ui.view,arch_db:deltatech_logistic_docs.view_picking_form
+msgid "Documents"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model_terms:ir.ui.view,arch_db:deltatech_logistic_docs.view_document_file_kanban
+msgid "Download"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_ir_actions_report__id
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_ir_attachment__id
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model,name:deltatech_logistic_docs.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_account_bank_statement_line__doc_count
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_account_move__doc_count
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_purchase_order__doc_count
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_sale_order__doc_count
+#: model:ir.model.fields,field_description:deltatech_logistic_docs.field_stock_picking__doc_count
+msgid "Number of documents attached"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model,name:deltatech_logistic_docs.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model,name:deltatech_logistic_docs.model_ir_actions_report
+msgid "Report Action"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model,name:deltatech_logistic_docs.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_logistic_docs
+#: model:ir.model,name:deltatech_logistic_docs.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_lot/i18n/deltatech_lot.pot
+++ b/deltatech_lot/i18n/deltatech_lot.pot
@@ -1,0 +1,50 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_lot
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_lot
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_lot__display_name
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_lot
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_lot__id
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_move_line__id
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_lot
+#: model:ir.model.fields,field_description:deltatech_lot.field_stock_lot__location_id
+msgid "Location"
+msgstr ""
+
+#. module: deltatech_lot
+#: model:ir.model,name:deltatech_lot.model_stock_lot
+msgid "Lot/Serial"
+msgstr ""
+
+#. module: deltatech_lot
+#: model:ir.model,name:deltatech_lot.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr ""
+
+#. module: deltatech_lot
+#: model:ir.model,name:deltatech_lot.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_mail/i18n/deltatech_mail.pot
+++ b/deltatech_mail/i18n/deltatech_mail.pot
@@ -1,0 +1,145 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__body_part
+msgid "Body Part"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.actions.act_window,name:deltatech_mail.action_mail_body_substitution
+#: model:ir.ui.menu,name:deltatech_mail.menu_email_body_substitution
+msgid "Body Substitution"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__create_uid
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__create_date
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__display_name
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_mail__display_name
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_message__display_name
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__display_name
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_thread__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model,name:deltatech_mail.model_mail_thread
+msgid "Email Thread"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__id
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_mail__id
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_message__id
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__id
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_thread__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__write_uid
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__write_date
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model,name:deltatech_mail.model_mail_body_substitution
+msgid "Mail Body Substitution"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model,name:deltatech_mail.model_mail_substitution
+msgid "Mail Substitution"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model,name:deltatech_mail.model_mail_message
+msgid "Message"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model,name:deltatech_mail.model_mail_mail
+msgid "Outgoing Mails"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields.selection,name:deltatech_mail.selection__mail_substitution__type__receiver
+msgid "Receiver"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__name
+msgid "Related Document Model"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model,website_form_label:deltatech_mail.model_mail_mail
+msgid "Send an E-mail"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields.selection,name:deltatech_mail.selection__mail_substitution__type__sender
+msgid "Sender"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.actions.act_window,name:deltatech_mail.action_mail_substitution
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_body_substitution__substitution
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__email
+#: model:ir.ui.menu,name:deltatech_mail.menu_email_substitution
+#: model_terms:ir.ui.view,arch_db:deltatech_mail.mail_substitution_form
+msgid "Substitution"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,help:deltatech_mail.field_mail_substitution__email
+msgid "Substitution with this email"
+msgstr ""
+
+#. module: deltatech_mail
+#: model:ir.model.fields,field_description:deltatech_mail.field_mail_substitution__type
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_mail
+#. odoo-python
+#: code:addons/deltatech_mail/models/mail_mail.py:0
+#: code:addons/deltatech_mail/models/mail_message.py:0
+msgid "Unable to post message, please configure the company's email address."
+msgstr ""

--- a/deltatech_markdown_field/i18n/deltatech_markdown_field.pot
+++ b/deltatech_markdown_field/i18n/deltatech_markdown_field.pot
@@ -1,0 +1,136 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_markdown_field
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.esm.js:0
+msgid "Adresă link (URL):"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Bold"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Bullet list"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Clear formatting"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Code block"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "H1"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "H2"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "H3"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Heading 1"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Heading 2"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Heading 3"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Italic"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Link"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.esm.js:0
+msgid "Markdown"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Markdown toolbar"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.esm.js:0
+msgid "Minimum height"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Numbered list"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Paragraph"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Quote"
+msgstr ""
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Strikethrough"
+msgstr ""

--- a/deltatech_move_negative_stock/i18n/deltatech_move_negative_stock.pot
+++ b/deltatech_move_negative_stock/i18n/deltatech_move_negative_stock.pot
@@ -1,0 +1,88 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_move_negative_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_move_negative_stock
+#: model:mail.template,body_html:deltatech_move_negative_stock.mail_template_negative_stock
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 12px;\">\n"
+"                    Negative quantity products:\n"
+"                </p>\n"
+"                <p>\n"
+"                    <t t-foreach=\"object.get_negative_products()\" t-as=\"product\">\n"
+"                        [<t t-out=\"product.default_code\"/>]<t t-out=\"product.with_context(lang=object.user_id.lang).name\"/>:\n"
+"                        <t t-out=\"product_value\"/>\n"
+"                        <t t-out=\"product.with_context(lang=object.user_id.lang).uom_id.name\"/>\n"
+"                        <br/>\n"
+"                    </t>\n"
+"                </p>\n"
+"            </div>\n"
+"        "
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.model.fields,field_description:deltatech_move_negative_stock.field_stock_location__display_name
+#: model:ir.model.fields,field_description:deltatech_move_negative_stock.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_move_negative_stock.view_picking_form
+msgid "Get negative products"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.model.fields,field_description:deltatech_move_negative_stock.field_stock_location__id
+#: model:ir.model.fields,field_description:deltatech_move_negative_stock.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.model,name:deltatech_move_negative_stock.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:mail.template,name:deltatech_move_negative_stock.mail_template_negative_stock
+msgid "Location: send negative stock"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.model.fields,field_description:deltatech_move_negative_stock.field_stock_location__user_id
+msgid "Manager"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:mail.template,subject:deltatech_move_negative_stock.mail_template_negative_stock
+msgid "Negative stock for location {{object.complete_name}}"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.actions.server,name:deltatech_move_negative_stock.ir_cron_negative_stock_ir_actions_server
+msgid "Send negative stock"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.model,name:deltatech_move_negative_stock.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_move_negative_stock
+#: model:ir.model.fields,help:deltatech_move_negative_stock.field_stock_location__user_id
+msgid ""
+"User notified by the daily cron when this location holds negative stock."
+msgstr ""

--- a/deltatech_mrp/i18n/deltatech_mrp.pot
+++ b/deltatech_mrp/i18n/deltatech_mrp.pot
@@ -1,0 +1,286 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__nbr
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "# of Orders"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__actually_price
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Actually Price"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_cost_detail__amount
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__categ_id
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Category"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__company_id
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_cost_detail__cost_categ
+#: model:ir.model.fields,field_description:deltatech_mrp.field_product_category__cost_categ
+msgid "Cost Category"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model,name:deltatech_mrp.model_deltatech_cost_detail
+#: model:ir.model.fields,field_description:deltatech_mrp.field_mrp_production__cost_detail_ids
+msgid "Cost Detail"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.deltatech_mrp_production_form_view
+msgid "Costs"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Current"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__date
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_cost_detail__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp.field_mrp_production__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp.field_product_category__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__done
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_cost_detail__id
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__id
+#: model:ir.model.fields,field_description:deltatech_mrp.field_mrp_production__id
+#: model:ir.model.fields,field_description:deltatech_mrp.field_product_category__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__in_production
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "In Production"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model,name:deltatech_mrp.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Order Month"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Ordered date of the production order"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_cost_detail__cost_categ__pak
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__product_category__cost_categ__pak
+msgid "Packing Material"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__picking_except
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Picking Exception"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__standard_price
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Price Standard"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__product_id
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model,name:deltatech_mrp.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_graph
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_pivot
+msgid "Production Analysis"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.actions.act_window,name:deltatech_mrp.action_deltatech_mrp_report
+#: model:ir.model,name:deltatech_mrp.model_deltatech_mrp_report
+#: model:ir.ui.menu,name:deltatech_mrp.menu_deltatech_mrp_report_list
+msgid "Production Cost Analysis"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_cost_detail__production_id
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__production_id
+msgid "Production Order"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Production order"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__product_qty_ef
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Qty Efective"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__product_qty
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Qty Plan"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_cost_detail__cost_categ__raw
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__product_category__cost_categ__raw
+msgid "Raw materials"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__ready
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Ready to Produce"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_cost_detail__cost_categ__semi
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__product_category__cost_categ__semi
+msgid "Semi-products"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__state
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "State"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.actions.act_window,help:deltatech_mrp.action_deltatech_mrp_report
+msgid "This reporting allows you to analysis your manufacturing cost."
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__product_uom
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.deltatech_mrp_production_form_view
+msgid "Update"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__consumed_val
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Val Consumed"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__consumed_pak_val
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Val Consumed Packing"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__consumed_raw_val
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Val Consumed Raw"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__consumed_sem_val
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Val Consumed Semifinish"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__product_val_ef
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Val Efective"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__product_val
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Val Plan"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,help:deltatech_mrp.field_deltatech_mrp_report__standard_price
+msgid ""
+"Value of the product (automatically computed in AVCO).\n"
+"        Used to value the product when the purchase cost is not known (e.g. inventory adjustment).\n"
+"        Used to compute margins on sale orders."
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields,field_description:deltatech_mrp.field_deltatech_mrp_report__val_prod
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_list
+msgid "Value production"
+msgstr ""
+
+#. module: deltatech_mrp
+#: model:ir.model.fields.selection,name:deltatech_mrp.selection__deltatech_mrp_report__state__confirmed
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp.view_deltatech_mrp_report_filter
+msgid "Waiting Goods"
+msgstr ""

--- a/deltatech_mrp_bom/i18n/deltatech_mrp_bom.pot
+++ b/deltatech_mrp_bom/i18n/deltatech_mrp_bom.pot
@@ -1,0 +1,104 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_bom
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom_line__bom_product_template_attribute_value_ids
+msgid "Apply on Variants"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#. odoo-python
+#: code:addons/deltatech_mrp_bom/models/mrp_bom.py:0
+msgid "BOM"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_report_mrp_report_bom_structure
+msgid "BOM Overview Report"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,help:deltatech_mrp_bom.field_mrp_bom_line__bom_product_template_attribute_value_ids
+msgid "BOM Product Variants needed to apply this line."
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields.selection,name:deltatech_mrp_bom.selection__mrp_bom__base_type__base
+msgid "Base"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom__base_type
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_production__bom_base_type
+msgid "Base Type"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_mrp_bom
+msgid "Bill of Material"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_mrp_bom_line
+msgid "Bill of Material Line"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_bom.mrp_production_form_view
+msgid "Compute Derived BoM"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields.selection,name:deltatech_mrp_bom.selection__mrp_bom__base_type__derived
+msgid "Derived"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom_line__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_production__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_report_mrp_report_bom_structure__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom__id
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom_line__id
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_production__id
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_report_mrp_report_bom_structure__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields.selection,name:deltatech_mrp_bom.selection__mrp_bom__base_type__normal
+msgid "Normal"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_bom.mrp_bom_form_view
+msgid "Recompute Components"
+msgstr ""
+
+#. module: deltatech_mrp_bom
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_bom.mrp_bom_form_view
+msgid "Show"
+msgstr ""

--- a/deltatech_mrp_concentration/i18n/deltatech_mrp_concentration.pot
+++ b/deltatech_mrp_concentration/i18n/deltatech_mrp_concentration.pot
@@ -1,0 +1,97 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_concentration
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model,name:deltatech_mrp_concentration.model_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__bom_id
+msgid "Bill of Material"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model,name:deltatech_mrp_concentration.model_mrp_bom_line
+msgid "Bill of Material Line"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_production__bom_id
+msgid ""
+"Bills of Materials, also called recipes, are used to autocomplete components"
+" and work order instructions."
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__concentration
+msgid "Concentration"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__concentration_primary
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__concentration_primary
+msgid "Concentration Primary"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_bom__concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_production__concentration
+msgid "Concentration of the final product"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_bom__concentration_primary
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_production__concentration_primary
+msgid "Concentration of the main ingredient"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom_line__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__id
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom_line__id
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom_line__ingredient_type
+msgid "Ingredient Type"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model,name:deltatech_mrp_concentration.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields.selection,name:deltatech_mrp_concentration.selection__mrp_bom_line__ingredient_type__normal
+msgid "Normal"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields.selection,name:deltatech_mrp_concentration.selection__mrp_bom_line__ingredient_type__primary
+msgid "Primary"
+msgstr ""
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields.selection,name:deltatech_mrp_concentration.selection__mrp_bom_line__ingredient_type__secondary
+msgid "Secondary"
+msgstr ""

--- a/deltatech_mrp_cost/i18n/deltatech_mrp_cost.pot
+++ b/deltatech_mrp_cost/i18n/deltatech_mrp_cost.pot
@@ -1,0 +1,164 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_cost
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_production_components
+msgid "<strong>Amount</strong>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid ""
+"<strong>Date:</strong>\n"
+"                <br/>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_production_components
+msgid "<strong>Effective Quantity</strong>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid ""
+"<strong>Net Salary Rate:</strong>\n"
+"                    <br/>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid ""
+"<strong>Overhead Amount:</strong>\n"
+"                    <br/>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_production_components
+msgid "<strong>Price</strong>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid "<strong>Product</strong>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid "<strong>Quantity</strong>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid ""
+"<strong>Salary Contributions:</strong>\n"
+"                    <br/>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid ""
+"<strong>Utility Consumption:</strong>\n"
+"                    <br/>"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model,name:deltatech_mrp_cost.model_mrp_bom
+msgid "Bill of Material"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__calculate_price
+msgid "Calculate Price"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.bom_form_view
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.mrp_production_form_view
+msgid "Costs"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__duration
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__duration_cost
+msgid "Duration"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.report_mrporder
+msgid "Finished Products"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__id
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model,name:deltatech_mrp_cost.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__net_salary_rate
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__net_salary_rate
+msgid "Net Salary Rate"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__overhead_amount
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__overhead_amount
+msgid "Overhead"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__amount
+msgid "Production Amount"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__salary_contributions
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__salary_contributions
+msgid "Salary Contributions"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,help:deltatech_mrp_cost.field_mrp_bom__utility_consumption
+#: model:ir.model.fields,help:deltatech_mrp_cost.field_mrp_production__utility_consumption
+msgid "Utilities consumption per hour"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_bom__utility_consumption
+#: model:ir.model.fields,field_description:deltatech_mrp_cost.field_mrp_production__utility_consumption
+msgid "Utility consumption"
+msgstr ""
+
+#. module: deltatech_mrp_cost
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.bom_form_view
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_cost.mrp_production_form_view
+msgid "hours"
+msgstr ""

--- a/deltatech_mrp_simple/i18n/deltatech_mrp_simple.pot
+++ b/deltatech_mrp_simple/i18n/deltatech_mrp_simple.pot
@@ -1,0 +1,371 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_simple
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "<span class=\"o_stat_text\">Consume</span>"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "<span class=\"o_stat_text\">Receipt</span>"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.multi_add_view_form
+msgid "Add"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/mrp_simple.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.multi_add_view_form
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "Add lines"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model,name:deltatech_mrp_simple.model_add_multi_mrp_lines
+#: model:ir.model,name:deltatech_mrp_simple.model_add_multi_mrp_lines_product
+msgid "Add multiple lines to mrp"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.multi_add_view_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__final_product_category
+msgid "Category for final product"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__partner_id
+msgid "Client"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "Confirm"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/mrp_simple.py:0
+#: model:ir.actions.act_window,name:deltatech_mrp_simple.action_consume
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__consume_id
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "Consume"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__product_out_ids
+msgid "Consumed products"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_sale_order__simple_mrp_count
+msgid "Count MRP Simple"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__auto_create_sale
+msgid "Create product & sale"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__create_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__create_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__create_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__create_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__create_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__create_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__create_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__create_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,help:deltatech_mrp_simple.field_mrp_simple_line_out__stock
+msgid ""
+"Current quantity of products.\n"
+"In a context with a single Stock Location, this includes goods stored at this Location, or any of its children.\n"
+"In a context with a single Warehouse, this includes goods stored in the Stock Location of this Warehouse, or any of its children.\n"
+"stored in the Stock Location of the Warehouse of this Shop, or any of its children.\n"
+"Otherwise, this includes goods stored in any Stock Location with 'internal' type."
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__date
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields.selection,name:deltatech_mrp_simple.selection__mrp_simple__state__done
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields.selection,name:deltatech_mrp_simple.selection__mrp_simple__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/mrp_simple.py:0
+msgid "Error creating final product!"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__final_product_id
+msgid "Final Product"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__final_product_name
+msgid "Final product name"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__write_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__write_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__write_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__write_uid
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__write_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__write_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__write_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__write_date
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model,name:deltatech_mrp_simple.model_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_order_form_inherit_simple_mrp
+msgid "MRP Simple"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model,name:deltatech_mrp_simple.model_mrp_simple_line_in
+msgid "MRP Simple Line IN"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model,name:deltatech_mrp_simple.model_mrp_simple_line_out
+msgid "MRP Simple Line OUT"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__mrp_simple_id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__mrp_simple_id
+msgid "Mrp Simple"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__multi_id
+msgid "Multi"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__picking_type_consume
+msgid "Picking type consume"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__picking_type_receipt_production
+msgid "Picking type receipt"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/mrp_simple.py:0
+msgid "Price 0 for result product!"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines_product__product_ids
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__product_id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__product_id
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__product_lines
+msgid "Products"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__qty
+msgid "Qty"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__final_product_qty
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__quantity
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__quantity
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__stock
+msgid "Quantity On Hand"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/mrp_simple.py:0
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__receipt_id
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "Receipt"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__product_in_ids
+msgid "Received products"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "Recompute prices"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__sale_order_id
+msgid "Sale Order"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:res.groups,name:deltatech_mrp_simple.group_sale_simple_production
+msgid "Sale simple production"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model,name:deltatech_mrp_simple.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_stock_picking__sale_simple_mrp_id
+msgid "Sales Order from MRP"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_sale_order__simple_mrp_picking_ids
+msgid "Simple MRP Transfers"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_add_multi_mrp_lines__simple_mrp_id
+msgid "Simple Mrp"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.actions.act_window,name:deltatech_mrp_simple.action_mrp_simple
+#: model:ir.ui.menu,name:deltatech_mrp_simple.menu_mrp_simple
+msgid "Simple Production"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/sale_order.py:0
+msgid "Simple production"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model,name:deltatech_mrp_simple.model_stock_picking
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_simple.view_mrp_simple_form
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__price_unit
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__price_unit
+msgid "Unit Price"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__final_product_uom_id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__uom_id
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__uom_id
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__validation_consume
+msgid "Validation Consume"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple__validation_receipt
+msgid "Validation Receipt"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_in__value
+#: model:ir.model.fields,field_description:deltatech_mrp_simple.field_mrp_simple_line_out__value
+msgid "Value"
+msgstr ""
+
+#. module: deltatech_mrp_simple
+#. odoo-python
+#: code:addons/deltatech_mrp_simple/models/mrp_simple.py:0
+msgid "You need at least one final product"
+msgstr ""

--- a/deltatech_mrp_simple_barcode/i18n/deltatech_mrp_simple_barcode.pot
+++ b/deltatech_mrp_simple_barcode/i18n/deltatech_mrp_simple_barcode.pot
@@ -1,0 +1,77 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_simple_barcode
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,field_description:deltatech_mrp_simple_barcode.field_mrp_simple___barcode_scanned
+msgid "Barcode Scanned"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,field_description:deltatech_mrp_simple_barcode.field_mrp_simple__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "Error"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,field_description:deltatech_mrp_simple_barcode.field_mrp_simple__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "Info"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model,name:deltatech_mrp_simple_barcode.model_mrp_simple
+msgid "MRP Simple"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "Status does not allow scanning"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "The %(product_name)s product quantity was set to %(product_qty)s"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "The %s product was added"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "There is no product with barcode or internal reference %s"
+msgstr ""
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,help:deltatech_mrp_simple_barcode.field_mrp_simple___barcode_scanned
+msgid "Value of the last barcode scanned."
+msgstr ""

--- a/deltatech_mrp_validation_date/i18n/deltatech_mrp_validation_date.pot
+++ b/deltatech_mrp_validation_date/i18n/deltatech_mrp_validation_date.pot
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_validation_date
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_validation_date
+#: model:ir.model.fields,field_description:deltatech_mrp_validation_date.field_mrp_production__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_mrp_validation_date
+#: model:ir.model.fields,field_description:deltatech_mrp_validation_date.field_mrp_production__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_mrp_validation_date
+#: model:ir.model,name:deltatech_mrp_validation_date.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: deltatech_mrp_validation_date
+#: model:ir.model.fields,field_description:deltatech_mrp_validation_date.field_mrp_production__validation_date
+msgid "Validation Date"
+msgstr ""

--- a/deltatech_notification_sound/i18n/deltatech_notification_sound.pot
+++ b/deltatech_notification_sound/i18n/deltatech_notification_sound.pot
@@ -1,0 +1,50 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_notification_sound
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_notification_sound
+#: model:ir.model.fields,field_description:deltatech_notification_sound.field_ir_http__display_name
+#: model:ir.model.fields,field_description:deltatech_notification_sound.field_res_users__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_notification_sound
+#: model:ir.model.fields,field_description:deltatech_notification_sound.field_res_users__notification_sound_enabled
+msgid "Enable notification sounds"
+msgstr ""
+
+#. module: deltatech_notification_sound
+#: model:ir.model,name:deltatech_notification_sound.model_ir_http
+msgid "HTTP Routing"
+msgstr ""
+
+#. module: deltatech_notification_sound
+#: model:ir.model.fields,field_description:deltatech_notification_sound.field_ir_http__id
+#: model:ir.model.fields,field_description:deltatech_notification_sound.field_res_users__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_notification_sound
+#: model:ir.model.fields,help:deltatech_notification_sound.field_res_users__notification_sound_enabled
+msgid ""
+"If enabled, the backend will play a short sound when a notification is "
+"shown."
+msgstr ""
+
+#. module: deltatech_notification_sound
+#: model:ir.model,name:deltatech_notification_sound.model_res_users
+msgid "User"
+msgstr ""

--- a/deltatech_partner_generic/i18n/deltatech_partner_generic.pot
+++ b/deltatech_partner_generic/i18n/deltatech_partner_generic.pot
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_partner_generic
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_partner_generic
+#: model:ir.model,name:deltatech_partner_generic.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_partner_generic
+#: model:ir.model,name:deltatech_partner_generic.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_partner_generic
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_company__display_name
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_partner_generic
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_company__generic_partner_id
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_config_settings__generic_partner_id
+msgid "Generic Partner"
+msgstr ""
+
+#. module: deltatech_partner_generic
+#: model_terms:ir.ui.view,arch_db:deltatech_partner_generic.res_config_settings_view_form
+msgid "Generic partner"
+msgstr ""
+
+#. module: deltatech_partner_generic
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_company__id
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_partner_generic
+#: model_terms:ir.ui.view,arch_db:deltatech_partner_generic.res_config_settings_view_form
+msgid "Values set here are company-specific."
+msgstr ""

--- a/deltatech_payment_forecast/i18n/deltatech_payment_forecast.pot
+++ b/deltatech_payment_forecast/i18n/deltatech_payment_forecast.pot
@@ -1,0 +1,196 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_payment_forecast
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_wizard_form
+msgid "Compute forecast"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__create_uid
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__create_date
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__days
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_report_search
+msgid "Days"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__display_name
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__date_to
+msgid "End Date"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_report_search
+msgid "Forecast"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.ui.menu,name:deltatech_payment_forecast.menu_payment_forecast_report_wizard
+msgid "Generate payment forecast"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__id
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields.selection,name:deltatech_payment_forecast.selection__payment_forecast__move_type__incoming
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_report_search
+msgid "Incoming"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__move_id
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__move_amount
+msgid "Invoice amount"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__move_amount_residual
+msgid "Invoice amount residual"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__move_date
+msgid "Invoice date"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__move_due_date
+msgid "Invoice due date"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__write_uid
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__write_date
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__move_type
+msgid "Move Type"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_report_search
+msgid "Move type"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields.selection,name:deltatech_payment_forecast.selection__payment_forecast__move_type__outgoing
+msgid "Outgoing"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_report_search
+msgid "Outgoinig"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.actions.act_window,name:deltatech_payment_forecast.action_payment_forecats_report
+msgid "Payment Forecast Report"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.actions.act_window,name:deltatech_payment_forecast.action_payment_forecats_wizard
+msgid "Payment Forecast Wizard"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model.fields,field_description:deltatech_payment_forecast.field_payment_forecast__payment_amount_forecasted
+msgid "Payment amount"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model,name:deltatech_payment_forecast.model_payment_forecast
+#: model:ir.ui.menu,name:deltatech_payment_forecast.menu_payment_forecast
+#: model:res.groups,name:deltatech_payment_forecast.payment_forecast_manager
+msgid "Payment forecast"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.ui.menu,name:deltatech_payment_forecast.menu_payment_forecast_report
+msgid "Payment forecast report"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model:ir.model,name:deltatech_payment_forecast.model_payment_forecast_wizard
+msgid "Payment forecast wizard"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_wizard_form
+msgid "Report Options"
+msgstr ""
+
+#. module: deltatech_payment_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_forecast.view_payment_forecast_wizard_form
+msgid "or"
+msgstr ""

--- a/deltatech_payment_term/i18n/deltatech_payment_term.pot
+++ b/deltatech_payment_term/i18n/deltatech_payment_term.pot
@@ -1,0 +1,179 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_payment_term
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_payment_term
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.invoice_form1
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.view_partner_form
+msgid "<span class=\"o_stat_text\">Rates</span>"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__advance
+msgid "Advance"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.view_account_payment_term_rate_wizard_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.view_account_payment_term_rate_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model,name:deltatech_payment_term.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.view_payment_term_form
+msgid "Create Rate"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model,website_form_label:deltatech_payment_term.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__day_of_the_month
+msgid "Day of the Month"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__display_name
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_res_partner__display_name
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields.selection,name:deltatech_payment_term.selection__account_payment_term_rate_wizard__value__fixed
+msgid "Fixed Amount"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__id
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_res_partner__id
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_bank_statement_line__in_rates
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_move__in_rates
+msgid "In Rates"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model,name:deltatech_payment_term.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__rate
+msgid "Number of rates"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.actions.act_window,name:deltatech_payment_term.action_account_payment_term_rate_wizard
+#: model:ir.actions.act_window,name:deltatech_payment_term.action_sale_payment_term_rate_wizard
+#: model:ir.model,name:deltatech_payment_term.model_account_payment_term_rate_wizard
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.view_account_payment_term_rate_wizard_form
+msgid "Payment Term Rate Wizard"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields.selection,name:deltatech_payment_term.selection__account_payment_term_rate_wizard__value__percent
+msgid "Percent"
+msgstr ""
+
+#. module: deltatech_payment_term
+#. odoo-python
+#: code:addons/deltatech_payment_term/wizard/payment_term.py:0
+msgid "Percentages for Advance must be between 0 and 100."
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__rate_value
+msgid "Rate Value"
+msgstr ""
+
+#. module: deltatech_payment_term
+#. odoo-python
+#: code:addons/deltatech_payment_term/wizard/payment_term.py:0
+msgid "Rate must be greater than 1"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_sale_order__sale_in_rates
+msgid "Sale in Rates"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model,name:deltatech_payment_term.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,help:deltatech_payment_term.field_account_payment_term_rate_wizard__value
+msgid "Select here the kind of valuation related to this payment terms line."
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__term_id
+msgid "Term"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model:ir.model.fields,field_description:deltatech_payment_term.field_account_payment_term_rate_wizard__value
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_payment_term
+#: model_terms:ir.ui.view,arch_db:deltatech_payment_term.view_account_payment_term_rate_wizard_form
+msgid "or"
+msgstr ""

--- a/deltatech_picking_restrict/i18n/deltatech_picking_restrict.pot
+++ b/deltatech_picking_restrict/i18n/deltatech_picking_restrict.pot
@@ -1,0 +1,86 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_picking_restrict
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#. odoo-python
+#: code:addons/deltatech_picking_restrict/models/stock_picking.py:0
+msgid ""
+"Done quantities not equal to reserved for [%(product_code)s] "
+"%(product_name)s"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking_type__validate_group_id
+msgid "Group for validation"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,help:deltatech_picking_restrict.field_stock_picking_type__restrict_quantities
+msgid ""
+"If set, no picking with different reserved quantity and done quantity can be"
+" validated"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,help:deltatech_picking_restrict.field_stock_picking_type__restrict_new_products
+msgid ""
+"If set, no picking with extra products and done quantity can be validated"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model,name:deltatech_picking_restrict.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking_type__restrict_quantities
+msgid "Restrict done quantities to reserved"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model.fields,field_description:deltatech_picking_restrict.field_stock_picking_type__restrict_new_products
+msgid "Restrict new products"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#: model:ir.model,name:deltatech_picking_restrict.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#. odoo-python
+#: code:addons/deltatech_picking_restrict/models/stock_picking.py:0
+msgid "Unrecognized product: [%(product_code)s] %(product_name)s"
+msgstr ""
+
+#. module: deltatech_picking_restrict
+#. odoo-python
+#: code:addons/deltatech_picking_restrict/models/stock_picking.py:0
+msgid "Your user cannot validate this type of transfer"
+msgstr ""

--- a/deltatech_picking_restrict_entry_exit/i18n/deltatech_picking_restrict_entry_exit.pot
+++ b/deltatech_picking_restrict_entry_exit/i18n/deltatech_picking_restrict_entry_exit.pot
@@ -1,0 +1,82 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_picking_restrict_entry_exit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_picking_restrict_entry_exit
+#: model:ir.model.fields,field_description:deltatech_picking_restrict_entry_exit.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#: model:ir.model.fields,field_description:deltatech_picking_restrict_entry_exit.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#: model:res.groups,name:deltatech_picking_restrict_entry_exit.group_picking_restrict_entry_exit
+msgid "Picking create permission"
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#: model:ir.model,name:deltatech_picking_restrict_entry_exit.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#. odoo-python
+#: code:addons/deltatech_picking_restrict_entry_exit/models/stock_picking.py:0
+msgid ""
+"You can't add a line where the quantity done is greater than the quantity "
+"needed"
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#. odoo-python
+#: code:addons/deltatech_picking_restrict_entry_exit/models/stock_picking.py:0
+msgid "You can't manually add moves to an incoming/outgoing picking"
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#. odoo-python
+#: code:addons/deltatech_picking_restrict_entry_exit/models/stock_picking.py:0
+msgid ""
+"You cannot save the picking because the quantity done is greater than the "
+"quantity ordered for the product %s."
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#. odoo-python
+#: code:addons/deltatech_picking_restrict_entry_exit/models/stock_picking.py:0
+msgid ""
+"You cannot validate the picking because the product %s is not linked to a "
+"purchase order line."
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#. odoo-python
+#: code:addons/deltatech_picking_restrict_entry_exit/models/stock_picking.py:0
+msgid ""
+"You cannot validate the picking because the product %s is not linked to a "
+"sale order line."
+msgstr ""
+
+#. module: deltatech_picking_restrict_entry_exit
+#. odoo-python
+#: code:addons/deltatech_picking_restrict_entry_exit/models/stock_picking.py:0
+msgid ""
+"You cannot validate the picking because the quantity done is greater than "
+"the quantity ordered for the product %s."
+msgstr ""

--- a/deltatech_picking_services/i18n/deltatech_picking_services.pot
+++ b/deltatech_picking_services/i18n/deltatech_picking_services.pot
@@ -1,0 +1,126 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_picking_services
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_picking_services
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_services.view_picking_form_services
+msgid "Add a Service"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__allowed_uom_ids
+msgid "Allowed Uom"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__description_picking
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_services.view_picking_form_services
+msgid "Description"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__display_name
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__id
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model,name:deltatech_picking_services.model_picking_service_line
+msgid "Picking Service Line"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__product_uom_qty
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_services.view_picking_form_services
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__product_id
+msgid "Service"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_stock_picking__picking_service_lines
+msgid "Service Lines"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_services.view_picking_form_services
+msgid "Services"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__price_subtotal
+msgid "Subtotal"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_services.view_picking_form_services
+msgid "Total"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model,name:deltatech_picking_services.model_stock_picking
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__picking_id
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__price_unit
+msgid "Unit Price"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_services.view_picking_form_services
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: deltatech_picking_services
+#: model:ir.model.fields,field_description:deltatech_picking_services.field_picking_service_line__product_uom
+msgid "UoM"
+msgstr ""

--- a/deltatech_picking_transit/i18n/deltatech_picking_transit.pot
+++ b/deltatech_picking_transit/i18n/deltatech_picking_transit.pot
@@ -1,0 +1,191 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_picking_transit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_type__auto_second_transfer
+msgid "Auto Second Transfer"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_transit.view_stock_picking_transfer_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_transit.view_stock_picking_transfer_wizard_form
+msgid "Confirm"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__create_second_transfer_automatically
+msgid "Create Second Transfer Automatically"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_transit.view_picking_form_inherit
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_transit.view_stock_picking_transfer_wizard_form
+msgid "Create Transfer"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields.selection,name:deltatech_picking_transit.selection__stock_picking_type__two_step_transfer_use__delivery
+msgid "Delivery"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__display_name
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__id
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,help:deltatech_picking_transit.field_stock_picking__create_second_transfer_automatically
+#: model:ir.model.fields,help:deltatech_picking_transit.field_stock_picking_type__auto_second_transfer
+msgid ""
+"If checked, the system will automatically create a second transfer when the "
+"first transfer is validated, the contact on the transfer will determine the "
+"warehouse for the second transfer."
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__is_transit_transfer
+msgid "Is Transit Transfer"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid "No 2 step reception found for warehouse %s"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid "No warehouse found for partner %s"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_transfer_wizard__operation_id
+msgid "Operation Type"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model,name:deltatech_picking_transit.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model_terms:ir.ui.view,arch_db:deltatech_picking_transit.view_picking_form_inherit
+msgid "Reassign Location"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields.selection,name:deltatech_picking_transit.selection__stock_picking_type__two_step_transfer_use__reception
+msgid "Reception"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__second_transfer_created
+msgid "Second Transfer Created"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid "Second transfer already created."
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__source_transfer_id
+msgid "Source Transfer"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model,name:deltatech_picking_transit.model_stock_picking_transfer_wizard
+msgid "Stock Picking Transfer Wizard"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking__sub_location_existent
+msgid "Sub Location Existent"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid "This transfer was generated from %s."
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model,name:deltatech_picking_transit.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid "Transfer %s was generated."
+msgstr ""
+
+#. module: deltatech_picking_transit
+#: model:ir.model.fields,field_description:deltatech_picking_transit.field_stock_picking_type__two_step_transfer_use
+msgid "Two Step Transfer Use"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid ""
+"You cannot validate the picking because the product %s is not from the "
+"source picking"
+msgstr ""
+
+#. module: deltatech_picking_transit
+#. odoo-python
+#: code:addons/deltatech_picking_transit/models/stock_picking.py:0
+msgid ""
+"You must set a partner before validating the picking when you are using 2 "
+"step picking with auto create on the second transfer."
+msgstr ""

--- a/deltatech_pos_product_filter/i18n/deltatech_pos_product_filter.pot
+++ b/deltatech_pos_product_filter/i18n/deltatech_pos_product_filter.pot
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_pos_product_filter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_pos_product_filter
+#: model_terms:ir.ui.view,arch_db:deltatech_pos_product_filter.view_pos_order_filter
+msgid "Product"
+msgstr ""

--- a/deltatech_price_categ/i18n/deltatech_price_categ.pot
+++ b/deltatech_price_categ/i18n/deltatech_price_categ.pot
@@ -1,0 +1,182 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_price_categ
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_price_categ
+#: model_terms:ir.ui.view,arch_db:deltatech_price_categ.product_template_form_view
+msgid "<span>Please check the sale prices</span>"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__list_price_base
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__list_price_base
+msgid "Base Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,help:deltatech_price_categ.field_product_pricelist_item__base
+msgid ""
+"Base price for computation.\n"
+"Sales Price: The base price will be the Sales Price.\n"
+"Cost Price: The base price will be the cost price.\n"
+"Other Pricelist: Computation of the base price based on another Pricelist."
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_pricelist_item__base
+msgid "Based on"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__percent_bronze
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__percent_bronze
+msgid "Bronze Percent"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__list_price_bronze
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__list_price_bronze
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_pricelist_item__base__list_price_bronze
+msgid "Bronze Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:product.pricelist,name:deltatech_price_categ.list_price_bronze
+msgid "Bronze Pricelist"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__percent_copper
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__percent_copper
+msgid "Copper Percent"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__list_price_copper
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__list_price_copper
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_pricelist_item__base__list_price_copper
+msgid "Copper Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:product.pricelist,name:deltatech_price_categ.list_price_copper
+msgid "Copper Pricelist"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__standard_price
+msgid "Cost"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_template__list_price_base__standard_price
+msgid "Cost Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_pricelist_item__display_name
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__percent_gold
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__percent_gold
+msgid "Gold Percent"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__list_price_gold
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__list_price_gold
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_pricelist_item__base__list_price_gold
+msgid "Gold Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:product.pricelist,name:deltatech_price_categ.list_price_gold
+msgid "Gold Pricelist"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_pricelist_item__id
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_template__list_price_base__last_purchase_price
+msgid "Last Purchase Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_template__list_price_base__list_price
+msgid "List price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__price_issue
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__price_issue
+#: model_terms:ir.ui.view,arch_db:deltatech_price_categ.product_template_search_view
+msgid "Price Issue"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,help:deltatech_price_categ.field_product_product__list_price
+#: model:ir.model.fields,help:deltatech_price_categ.field_product_template__list_price
+msgid "Price at which the product is sold to customers."
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model,name:deltatech_price_categ.model_product_pricelist_item
+msgid "Pricelist Rule"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model,name:deltatech_price_categ.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__list_price
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__list_price
+msgid "Sales Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__percent_silver
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__percent_silver
+msgid "Silver Percent"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_product__list_price_silver
+#: model:ir.model.fields,field_description:deltatech_price_categ.field_product_template__list_price_silver
+#: model:ir.model.fields.selection,name:deltatech_price_categ.selection__product_pricelist_item__base__list_price_silver
+msgid "Silver Price"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:product.pricelist,name:deltatech_price_categ.list_price_silver
+msgid "Silver Pricelist"
+msgstr ""
+
+#. module: deltatech_price_categ
+#: model:ir.model.fields,help:deltatech_price_categ.field_product_template__standard_price
+msgid ""
+"Value of the product (automatically computed in AVCO).\n"
+"        Used to value the product when the purchase cost is not known (e.g. inventory adjustment).\n"
+"        Used to compute margins on sale orders."
+msgstr ""

--- a/deltatech_pricelist/i18n/deltatech_pricelist.pot
+++ b/deltatech_pricelist/i18n/deltatech_pricelist.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_pricelist
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_pricelist
+#: model:ir.model,name:deltatech_pricelist.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_pricelist
+#: model:ir.model.fields,field_description:deltatech_pricelist.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_pricelist.field_res_company__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_pricelist
+#: model:ir.model.fields,field_description:deltatech_pricelist.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_pricelist.field_res_company__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_pricelist
+#: model:ir.model.fields,field_description:deltatech_pricelist.field_res_company__price_currency_id
+msgid "Price List Currency"
+msgstr ""
+
+#. module: deltatech_pricelist
+#: model:ir.model,name:deltatech_pricelist.model_product_template
+msgid "Product"
+msgstr ""

--- a/deltatech_pricelist_line_viewer/i18n/deltatech_pricelist_line_viewer.pot
+++ b/deltatech_pricelist_line_viewer/i18n/deltatech_pricelist_line_viewer.pot
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_pricelist_line_viewer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_pricelist_line_viewer
+#: model_terms:ir.ui.view,arch_db:deltatech_pricelist_line_viewer.product_pricelist_view_inherited
+msgid "<span>Pricelist Lines</span>"
+msgstr ""
+
+#. module: deltatech_pricelist_line_viewer
+#: model:ir.model.fields,field_description:deltatech_pricelist_line_viewer.field_product_pricelist__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_pricelist_line_viewer
+#: model:ir.model.fields,field_description:deltatech_pricelist_line_viewer.field_product_pricelist__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_pricelist_line_viewer
+#: model:res.groups,name:deltatech_pricelist_line_viewer.group_user_permit_prilist_edit_access
+msgid "Permit pricelist editing"
+msgstr ""
+
+#. module: deltatech_pricelist_line_viewer
+#: model_terms:ir.ui.view,arch_db:deltatech_pricelist_line_viewer.product_pricelist_lines_view
+msgid "Price"
+msgstr ""
+
+#. module: deltatech_pricelist_line_viewer
+#: model:ir.model,name:deltatech_pricelist_line_viewer.model_product_pricelist
+msgid "Pricelist"
+msgstr ""
+
+#. module: deltatech_pricelist_line_viewer
+#: model_terms:ir.ui.view,arch_db:deltatech_pricelist_line_viewer.product_pricelist_lines_view
+msgid "Products"
+msgstr ""

--- a/deltatech_product_category_color/i18n/deltatech_product_category_color.pot
+++ b/deltatech_product_category_color/i18n/deltatech_product_category_color.pot
@@ -1,0 +1,48 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_category_color
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_category_color
+#: model:ir.model.fields,field_description:deltatech_product_category_color.field_stock_picking__categ_ids
+msgid "Categ"
+msgstr ""
+
+#. module: deltatech_product_category_color
+#: model:ir.model.fields,field_description:deltatech_product_category_color.field_product_category__color
+msgid "Color Index"
+msgstr ""
+
+#. module: deltatech_product_category_color
+#: model:ir.model.fields,field_description:deltatech_product_category_color.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_product_category_color.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_category_color
+#: model:ir.model.fields,field_description:deltatech_product_category_color.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_product_category_color.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_category_color
+#: model:ir.model,name:deltatech_product_category_color.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_product_category_color
+#: model:ir.model,name:deltatech_product_category_color.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_product_category_group/i18n/deltatech_product_category_group.pot
+++ b/deltatech_product_category_group/i18n/deltatech_product_category_group.pot
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_category_group
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_category_group
+#: model:ir.model.fields,field_description:deltatech_product_category_group.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_product_category_group.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_category_group
+#: model:ir.model.fields,field_description:deltatech_product_category_group.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_product_category_group.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_category_group
+#: model:ir.model,name:deltatech_product_category_group.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_product_category_group
+#: model_terms:ir.ui.view,arch_db:deltatech_product_category_group.vpicktree
+msgid "Responsible"
+msgstr ""
+
+#. module: deltatech_product_category_group
+#: model:ir.model,name:deltatech_product_category_group.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_product_category_group
+#: model:ir.model.fields,field_description:deltatech_product_category_group.field_product_category__user_group_id
+#: model:ir.model.fields,field_description:deltatech_product_category_group.field_stock_picking__user_group_id
+msgid "User Group"
+msgstr ""

--- a/deltatech_product_code/i18n/deltatech_product_code.pot
+++ b/deltatech_product_code/i18n/deltatech_product_code.pot
@@ -1,0 +1,87 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_code
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_code
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_category__barcode_random
+msgid "Barcode Random"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_category__sequence_id
+msgid "Code Sequence"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.actions.server,name:deltatech_product_code.action_find_duplicate
+#: model:ir.actions.server,name:deltatech_product_code.action_find_duplicate_product
+msgid "Find Duplicate"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.actions.server,name:deltatech_product_code.action_force_new_code
+#: model:ir.actions.server,name:deltatech_product_code.action_force_new_code_product
+msgid "Force new internal code"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_category__generate_barcode
+msgid "Generate Barcode"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model.constraint,message:deltatech_product_code.constraint_product_template_name_code_unique
+msgid "Internal Reference already exists !"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model.fields,field_description:deltatech_product_code.field_product_category__prefix_barcode
+msgid "Prefix Barcode"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model,name:deltatech_product_code.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model,name:deltatech_product_code.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model:ir.model,name:deltatech_product_code.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_product_code
+#: model_terms:ir.ui.view,arch_db:deltatech_product_code.product_category_form_view
+msgid "Products"
+msgstr ""

--- a/deltatech_product_dimension/i18n/deltatech_product_dimension.pot
+++ b/deltatech_product_dimension/i18n/deltatech_product_dimension.pot
@@ -1,0 +1,67 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_dimension
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_dimension
+#: model_terms:ir.ui.view,arch_db:deltatech_product_dimension.product_template_form_view
+msgid "Dimension"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_product__product_height
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_template__product_height
+#: model_terms:ir.ui.view,arch_db:deltatech_product_dimension.product_template_form_view
+msgid "Height"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_product__product_length
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_template__product_length
+#: model_terms:ir.ui.view,arch_db:deltatech_product_dimension.product_template_form_view
+msgid "Length"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model:ir.model,name:deltatech_product_dimension.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_product__product_width
+#: model:ir.model.fields,field_description:deltatech_product_dimension.field_product_template__product_width
+#: model_terms:ir.ui.view,arch_db:deltatech_product_dimension.product_template_form_view
+msgid "Width"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model_terms:ir.ui.view,arch_db:deltatech_product_dimension.product_template_form_view
+msgid "cm"
+msgstr ""
+
+#. module: deltatech_product_dimension
+#: model_terms:ir.ui.view,arch_db:deltatech_product_dimension.product_template_form_view
+msgid "x"
+msgstr ""

--- a/deltatech_product_extension/i18n/deltatech_product_extension.pot
+++ b/deltatech_product_extension/i18n/deltatech_product_extension.pot
@@ -1,0 +1,87 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_extension
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_extension
+#: model:ir.model,name:deltatech_product_extension.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model,website_form_label:deltatech_product_extension.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_product__dimensions
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_template__dimensions
+msgid "Dimensions"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_account_invoice_report__display_name
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_res_partner__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_account_invoice_report__id
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_res_partner__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model,name:deltatech_product_extension.model_account_invoice_report
+msgid "Invoices Statistics"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_res_partner__is_manufacturer
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_res_users__is_manufacturer
+msgid "Is manufacturer"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_account_invoice_report__manufacturer
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_product__manufacturer
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_template__manufacturer
+msgid "Manufacturer"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model,name:deltatech_product_extension.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_product__shelf_life
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_template__shelf_life
+msgid "Shelf Life"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_product__uom_shelf_life
+#: model:ir.model.fields,field_description:deltatech_product_extension.field_product_template__uom_shelf_life
+msgid "Unit of Measure Shelf Life"
+msgstr ""
+
+#. module: deltatech_product_extension
+#: model:ir.model.fields,help:deltatech_product_extension.field_product_product__uom_shelf_life
+#: model:ir.model.fields,help:deltatech_product_extension.field_product_template__uom_shelf_life
+msgid "Unit of Measure for Shelf Life"
+msgstr ""

--- a/deltatech_product_labels/i18n/deltatech_product_labels.pot
+++ b/deltatech_product_labels/i18n/deltatech_product_labels.pot
@@ -1,0 +1,188 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_labels
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__auto_generate_lots
+msgid "Auto Generate Lots"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__barcode_image
+msgid "Barcode Image"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__can_generate_lots
+msgid "Can Generate Lots"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model_terms:ir.ui.view,arch_db:deltatech_product_labels.product_product_label_view_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__create_uid
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__create_date
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__customer_id
+msgid "Customer"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__display_name
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__display_name
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__id
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__id
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model_terms:ir.ui.view,arch_db:deltatech_product_labels.product_product_label_view_form
+msgid "Label"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__quantity
+msgid "Label Qty"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__label_lines
+msgid "Labels"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__write_uid
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__write_date
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__layout_id
+msgid "Layout"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__location_id
+msgid "Location"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__lot
+msgid "Lot"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__price
+msgid "Price"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__pricelist_id
+msgid "Price List"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model_terms:ir.ui.view,arch_db:deltatech_product_labels.product_product_label_view_form
+msgid "Print"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__print_only_lots
+msgid "Print lots only"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model,name:deltatech_product_labels.model_product_template
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__product_id
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label_line__label_id
+msgid "Product Label"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.actions.report,name:deltatech_product_labels.report_product_product_label_100x50
+msgid "Product Label - etichete 100x50 PDF"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.actions.report,name:deltatech_product_labels.report_product_product_label
+msgid "Product Label - etichete PDF"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.actions.act_window,name:deltatech_product_labels.action_action_product_product_label
+#: model:ir.actions.act_window,name:deltatech_product_labels.action_action_product_template_label
+#: model:ir.actions.act_window,name:deltatech_product_labels.action_action_sale_order_product_label
+#: model:ir.actions.act_window,name:deltatech_product_labels.action_action_stock_lot_product_label
+#: model:ir.actions.act_window,name:deltatech_product_labels.action_action_stock_picking_product_label
+#: model:ir.actions.act_window,name:deltatech_product_labels.action_action_stock_quant_product_label
+#: model_terms:ir.ui.view,arch_db:deltatech_product_labels.product_product_label_view_form
+msgid "Product Labels"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model,name:deltatech_product_labels.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__use_location
+msgid "Use ptw rules"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model.fields,field_description:deltatech_product_labels.field_product_product_label__warehouse_id
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model,name:deltatech_product_labels.model_product_product_label
+msgid "product.product.label"
+msgstr ""
+
+#. module: deltatech_product_labels
+#: model:ir.model,name:deltatech_product_labels.model_product_product_label_line
+msgid "product.product.label.line"
+msgstr ""

--- a/deltatech_product_list/i18n/deltatech_product_list.pot
+++ b/deltatech_product_list/i18n/deltatech_product_list.pot
@@ -1,0 +1,94 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_list
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model_terms:ir.ui.view,arch_db:deltatech_product_list.view_product_list_form
+msgid "Archived"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model_terms:ir.ui.view,arch_db:deltatech_product_list.view_product_list_form
+msgid "Filter"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__limit
+msgid "Limit"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__name
+#: model_terms:ir.ui.view,arch_db:deltatech_product_list.view_product_list_form
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.actions.act_window,name:deltatech_product_list.action_product_list
+#: model:ir.model,name:deltatech_product_list.model_product_list
+#: model:ir.ui.menu,name:deltatech_product_list.menu_product_list
+msgid "Product List"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model:ir.model.fields,field_description:deltatech_product_list.field_product_list__products_domain
+msgid "Products"
+msgstr ""
+
+#. module: deltatech_product_list
+#: model_terms:ir.ui.view,arch_db:deltatech_product_list.view_product_list_form
+msgid "Select product"
+msgstr ""

--- a/deltatech_product_mpn/i18n/deltatech_product_mpn.pot
+++ b/deltatech_product_mpn/i18n/deltatech_product_mpn.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_mpn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_product__mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_template__mpn
+msgid "MPN"
+msgstr ""
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,help:deltatech_product_mpn.field_product_product__mpn
+#: model:ir.model.fields,help:deltatech_product_mpn.field_product_template__mpn
+msgid "Manufacturer Part Number"
+msgstr ""
+
+#. module: deltatech_product_mpn
+#: model:ir.model,name:deltatech_product_mpn.model_product_template
+msgid "Product"
+msgstr ""

--- a/deltatech_product_trade_markup/i18n/deltatech_product_trade_markup.pot
+++ b/deltatech_product_trade_markup/i18n/deltatech_product_trade_markup.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_trade_markup
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_trade_markup
+#: model:ir.model.fields,field_description:deltatech_product_trade_markup.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_product_trade_markup.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_trade_markup
+#: model:ir.model.fields,field_description:deltatech_product_trade_markup.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_product_trade_markup.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_trade_markup
+#: model:ir.model,name:deltatech_product_trade_markup.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_trade_markup
+#: model:ir.model,name:deltatech_product_trade_markup.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_product_trade_markup
+#: model:ir.model.fields,field_description:deltatech_product_trade_markup.field_product_product__trade_markup
+#: model:ir.model.fields,field_description:deltatech_product_trade_markup.field_product_template__trade_markup
+msgid "Trade Markup"
+msgstr ""

--- a/deltatech_product_unique_code/i18n/deltatech_product_unique_code.pot
+++ b/deltatech_product_unique_code/i18n/deltatech_product_unique_code.pot
@@ -1,0 +1,69 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_unique_code
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_unique_code
+#. odoo-python
+#: code:addons/deltatech_product_unique_code/models/product.py:0
+msgid "- %(label)s '%(val)s' already assigned to: %(records)s"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#: model:res.groups,name:deltatech_product_unique_code.group_product_duplicate_code
+msgid "Allow duplicate product codes"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#. odoo-python
+#: code:addons/deltatech_product_unique_code/models/product.py:0
+msgid "Barcode"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#: model:ir.model.fields,field_description:deltatech_product_unique_code.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_product_unique_code.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#: model:ir.model.fields,field_description:deltatech_product_unique_code.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_product_unique_code.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#. odoo-python
+#: code:addons/deltatech_product_unique_code/models/product.py:0
+msgid "Internal Reference"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#: model:ir.model,name:deltatech_product_unique_code.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#: model:ir.model,name:deltatech_product_unique_code.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_product_unique_code
+#. odoo-python
+#: code:addons/deltatech_product_unique_code/models/product.py:0
+msgid ""
+"The %(label)s must be unique (including archived products):\n"
+"%(msgs)s"
+msgstr ""

--- a/deltatech_product_visibility/i18n/deltatech_product_visibility.pot
+++ b/deltatech_product_visibility/i18n/deltatech_product_visibility.pot
@@ -1,0 +1,236 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_visibility
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__good
+msgid "Bun"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_public_category
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__public_category
+msgid "Categorie publică"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_default_code
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__default_code
+msgid "Cod produs (SKU)"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__code
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.actions.act_window,name:deltatech_product_visibility.visibility_criterion_action
+msgid "Criterii vizibilitate produs"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model,name:deltatech_product_visibility.model_deltatech_product_visibility_criterion
+msgid "Criteriu de vizibilitate a produsului"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_detail
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_detail
+msgid "Defalcare vizibilitate"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.actions.act_window,help:deltatech_product_visibility.visibility_criterion_action
+msgid "Definește criteriile și ponderile scorului de vizibilitate"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_ecommerce_description
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__ecommerce_description
+msgid "Descriere eCommerce (scurtă)"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_website_description
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__website_description
+msgid "Descriere website (amplă)"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__display_name
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_gallery
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__gallery
+msgid "Galerie de imagini (≥ 2)"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__id
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_main_image
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__main_image
+msgid "Imagine principală"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__hidden
+msgid "Invizibil"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_level
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_level
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_search_visibility
+msgid "Nivel vizibilitate"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__optimal
+msgid "Optim"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.actions.act_window,help:deltatech_product_visibility.visibility_criterion_action
+msgid ""
+"Ponderile pot fi ajustate fără cod. După modificare, folosește butonul "
+"„Recalculează scorurile\"."
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_sale_price
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__sale_price
+msgid "Preț de vânzare setat"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model,name:deltatech_product_visibility.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,help:deltatech_product_visibility.field_deltatech_product_visibility_criterion__weight
+msgid "Punctele acordate când criteriul este îndeplinit."
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.actions.server,name:deltatech_product_visibility.visibility_recompute_action
+msgid "Recalculează scorurile de vizibilitate"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_seo
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__seo
+msgid "SEO complet (titlu + descriere + cuvinte cheie)"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,help:deltatech_product_visibility.field_product_product__website_visibility_score
+#: model:ir.model.fields,help:deltatech_product_visibility.field_product_template__website_visibility_score
+msgid ""
+"Scor 0-100: cât de complet/optimizat este produsul pentru catalogul de pe "
+"website."
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_score
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_score
+msgid "Scor vizibilitate"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__weak
+msgid "Slab"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.visibility_criterion_view_list
+msgid "Total"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_badge
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_badge
+msgid "Vizibilitate"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.ui.menu,name:deltatech_product_visibility.menu_visibility_criterion
+msgid "Vizibilitate produs"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_form_visibility_detail
+msgid "Vizibilitate website"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_search_visibility
+msgid "Vizibilitate: invizibil"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_search_visibility
+msgid "Vizibilitate: necesită atenție"
+msgstr ""
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__weight
+msgid "Weight"
+msgstr ""

--- a/deltatech_project_price_list/i18n/deltatech_project_price_list.pot
+++ b/deltatech_project_price_list/i18n/deltatech_project_price_list.pot
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_project_price_list
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_project_project__display_name
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_project_project__id
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_project_project__pricelist_id
+msgid "Pricelist"
+msgstr ""
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,help:deltatech_project_price_list.field_project_project__pricelist_id
+msgid ""
+"Pricelist to use by default when creating Sales Orders from this project."
+msgstr ""
+
+#. module: deltatech_project_price_list
+#: model:ir.model,name:deltatech_project_price_list.model_project_project
+msgid "Project"
+msgstr ""
+
+#. module: deltatech_project_price_list
+#: model:ir.model,name:deltatech_project_price_list.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_project_price_list
+#: model_terms:ir.ui.view,arch_db:deltatech_project_price_list.project_project_view_edit_inherit_pricelist
+msgid "The pricelist to use for billable tasks and timesheets."
+msgstr ""

--- a/deltatech_promissory_note/i18n/deltatech_promissory_note.pot
+++ b/deltatech_promissory_note/i18n/deltatech_promissory_note.pot
@@ -1,0 +1,395 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_promissory_note
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__agreement
+msgid "Agreement"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__amount
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:mail.message.subtype,description:deltatech_promissory_note.mt_state_cashed
+#: model:mail.message.subtype,name:deltatech_promissory_note.mt_state_cashed
+msgid "BO Cashed"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__acc_beneficiary
+msgid "Bank Account Beneficiary"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__acc_issuer
+msgid "Bank Account Issuer"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__bank_beneficiary_id
+msgid "Bank Beneficiary"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__bank_issuer_id
+msgid "Bank Issuer"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__beneficiary_id
+msgid "Beneficiary"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields.selection,name:deltatech_promissory_note.selection__promissory_note__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields.selection,name:deltatech_promissory_note.selection__promissory_note__state__cashed
+msgid "Cashed"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__cashed_amount
+msgid "Cashed Amount"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__cashed_date
+msgid "Cashed Date"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__note
+msgid "Comments"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields.selection,name:deltatech_promissory_note.selection__promissory_note__type__customer
+msgid "Customer"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__date_due
+msgid "Due Date"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__message_has_error
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__invoice_id
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__issuer_id
+msgid "Issuer"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__is_last_bo
+msgid "Last note"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields.selection,name:deltatech_promissory_note.selection__promissory_note__state__not_cashed
+msgid "Not Cashed"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:res.groups,name:deltatech_promissory_note.bo_notifications
+msgid "Primeste atentionari BO"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model,name:deltatech_promissory_note.model_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_form
+msgid "Promissory Note"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.actions.report,name:deltatech_promissory_note.action_report_promissory_note
+msgid "Promissory Note Bill"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.actions.report,name:deltatech_promissory_note.action_report_promissory_note_content
+msgid "Promissory Note Content"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.actions.act_window,name:deltatech_promissory_note.action_promissory_note
+#: model:ir.ui.menu,name:deltatech_promissory_note.menu_promissory_note
+msgid "Promissory Notes"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__rating_ids
+msgid "Ratings"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_filter
+msgid "Search"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__name
+msgid "Series and number"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_form
+msgid "Set Cashed"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_form
+msgid "Set Not Cashed"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__state
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: deltatech_promissory_note
+#. odoo-python
+#: code:addons/deltatech_promissory_note/models/promissory_note.py:0
+msgid "The <Value> field must be greater than 0!"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__type
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields.selection,name:deltatech_promissory_note.selection__promissory_note__type__vendor
+msgid "Vendor"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,field_description:deltatech_promissory_note.field_promissory_note__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model:ir.model.fields,help:deltatech_promissory_note.field_promissory_note__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_list
+msgid "amount"
+msgstr ""
+
+#. module: deltatech_promissory_note
+#: model_terms:ir.ui.view,arch_db:deltatech_promissory_note.view_promissory_note_list
+msgid "cashed_amount"
+msgstr ""

--- a/deltatech_purchase_add_extra_line/i18n/deltatech_purchase_add_extra_line.pot
+++ b/deltatech_purchase_add_extra_line/i18n/deltatech_purchase_add_extra_line.pot
@@ -1,0 +1,109 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_add_extra_line
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:27+0000\n"
+"PO-Revision-Date: 2026-07-31 10:27+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_purchase_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_add_extra_line.product_template_form_view
+msgid "Extra Line"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_product__extra_percent
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_template__extra_percent
+msgid "Extra Percent"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_purchase_order_line__extra_price_computed
+msgid "Extra Price Computed"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_product__extra_product_id
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_template__extra_product_id
+msgid "Extra Product"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_product__extra_qty
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_template__extra_qty
+msgid "Extra Qty"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_purchase_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,field_description:deltatech_purchase_add_extra_line.field_purchase_order_line__line_uuid
+msgid "Line Uuid"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_product_product__extra_qty
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_product_template__extra_qty
+msgid ""
+"Multiplier for the quantity of the extra line: extra quantity = quantity of "
+"the main line x this value"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_product_product__extra_percent
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_product_template__extra_percent
+msgid ""
+"Percent of the main line price used as the price of the extra line. If zero,"
+" the extra line keeps the standard price computed for its own product (price"
+" list or vendor price, currency and unit of measure of the order)"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model,name:deltatech_purchase_add_extra_line.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_product_product__extra_product_id
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_product_template__extra_product_id
+msgid ""
+"Product added automatically as an extra line when this product is ordered"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model,name:deltatech_purchase_add_extra_line.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model,name:deltatech_purchase_add_extra_line.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: deltatech_purchase_add_extra_line
+#: model:ir.model.fields,help:deltatech_purchase_add_extra_line.field_purchase_order_line__extra_price_computed
+msgid ""
+"Technical field: last unit price computed for this extra line. A unit price "
+"that differs from it was set by the user and is kept as is."
+msgstr ""

--- a/deltatech_purchase_create_bill_button/i18n/deltatech_purchase_create_bill_button.pot
+++ b/deltatech_purchase_create_bill_button/i18n/deltatech_purchase_create_bill_button.pot
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_create_bill_button
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_create_bill_button
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_create_bill_button.purchase_order_form
+msgid "Create Bill"
+msgstr ""
+
+#. module: deltatech_purchase_create_bill_button
+#: model:ir.model.fields,field_description:deltatech_purchase_create_bill_button.field_purchase_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_create_bill_button
+#: model:ir.model.fields,field_description:deltatech_purchase_create_bill_button.field_purchase_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_create_bill_button
+#: model:ir.model,name:deltatech_purchase_create_bill_button.model_purchase_order
+msgid "Purchase Order"
+msgstr ""

--- a/deltatech_purchase_mail/i18n/deltatech_purchase_mail.pot
+++ b/deltatech_purchase_mail/i18n/deltatech_purchase_mail.pot
@@ -1,0 +1,188 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_mail
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_mail
+#: model:mail.template,body_html:deltatech_purchase_mail.mail_template_purchase_send_xlsx
+msgid ""
+"<div>\n"
+"                <p>Hello,</p>\n"
+"                <p>Please find attached the selected purchase orders and an XLSX summary.</p>\n"
+"                <p>\n"
+"                    <strong>Orders:</strong>\n"
+"                    </p><ul>\n"
+"                        <t t-foreach=\"object.purchase_ids\" t-as=\"po\">\n"
+"                            <li>\n"
+"                                <t t-esc=\"po.name\"/> — <t t-esc=\"po.partner_id.display_name or ''\"/>\n"
+"                            </li>\n"
+"                        </t>\n"
+"                    </ul>\n"
+"                \n"
+"                <p>Thank you.</p>\n"
+"            </div>\n"
+"        "
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__attach_order_pdfs
+msgid "Attach Order PDFs"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__attach_combined_xlsx
+msgid "Attach XLSX Summary"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,help:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__email_to
+msgid ""
+"Comma-separated list of recipient emails. If empty, email will be sent to "
+"the vendor email when all POs share the same vendor having an email."
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "Compose Email"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__template_id
+msgid "Email Template"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "Order"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "Price"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "Product Code"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "Product Description"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model,name:deltatech_purchase_mail.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__purchase_ids
+#: model:mail.template,subject:deltatech_purchase_mail.mail_template_purchase_send_xlsx
+msgid "Purchase Orders"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,help:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__purchase_ids
+msgid "Purchase Orders that will be included in the email."
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:mail.template,name:deltatech_purchase_mail.mail_template_purchase_send_xlsx
+msgid "Purchase Orders: Send with XLSX"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "RFQ prepared for sending by email (batch compose)."
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.actions.server,name:deltatech_purchase_mail.action_purchase_compose_batch_email
+msgid "Send Email"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model,name:deltatech_purchase_mail.model_purchase_send_xlsx_wizard
+msgid "Send selected POs by email with XLSX and PDFs"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,help:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__template_id
+msgid ""
+"Template used to compose the email. You can customize it in Settings > "
+"Technical > Email > Templates."
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#: model:ir.model.fields,field_description:deltatech_purchase_mail.field_purchase_send_xlsx_wizard__email_to
+msgid "To"
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "XlsxWriter is required to generate XLSX files."
+msgstr ""
+
+#. module: deltatech_purchase_mail
+#. odoo-python
+#: code:addons/deltatech_purchase_mail/models/purchase_order.py:0
+msgid "You must select exactly one vendor to send the email to."
+msgstr ""

--- a/deltatech_purchase_phase/i18n/deltatech_purchase_phase.pot
+++ b/deltatech_purchase_phase/i18n/deltatech_purchase_phase.pot
@@ -1,0 +1,130 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_phase
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__action_id
+msgid "Action"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__code
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__color
+msgid "Color"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:purchase.order.phase,name:deltatech_purchase_phase.purchase_order_phase_delivered
+msgid "Delivered"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__id
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order__phase_id
+msgid "Phase"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:purchase.order.phase,name:deltatech_purchase_phase.purchase_order_phase_pre_advice
+msgid "Pre Advice"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:purchase.order.phase,name:deltatech_purchase_phase.purchase_order_phase_purchase_confirm
+msgid "Purchase Confirmed"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model,name:deltatech_purchase_phase.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.ui.menu,name:deltatech_purchase_phase.menu_purchase_order_phase
+msgid "Purchase Order Phase"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model,name:deltatech_purchase_phase.model_purchase_order_phase
+msgid "PurchaseOrderPhase"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:purchase.order.phase,name:deltatech_purchase_phase.purchase_order_phase_rfq
+msgid "RFQ"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model.fields,field_description:deltatech_purchase_phase.field_purchase_order_phase__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:purchase.order.phase,name:deltatech_purchase_phase.purchase_order_phase_shipped
+msgid "Shipped"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.model,name:deltatech_purchase_phase.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_purchase_phase
+#: model:ir.actions.act_window,name:deltatech_purchase_phase.action_purchase_order_phase
+msgid "purchase Order phase"
+msgstr ""

--- a/deltatech_purchase_picking_status/i18n/deltatech_purchase_picking_status.pot
+++ b/deltatech_purchase_picking_status/i18n/deltatech_purchase_picking_status.pot
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_picking_status
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_picking_status
+#: model:ir.model.fields,field_description:deltatech_purchase_picking_status.field_purchase_order__picking_status
+msgid "Delivery Status"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#: model:ir.model.fields,field_description:deltatech_purchase_picking_status.field_purchase_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#: model:ir.model.fields.selection,name:deltatech_purchase_picking_status.selection__purchase_order__picking_status__done
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_picking_status.view_purchase_order_filter_picking_status
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#: model:ir.model.fields,field_description:deltatech_purchase_picking_status.field_purchase_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#: model:ir.model.fields.selection,name:deltatech_purchase_picking_status.selection__purchase_order__picking_status__in_progress
+msgid "In Progress"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_picking_status.view_purchase_order_filter_picking_status
+msgid "In progress"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#. odoo-python
+#: code:addons/deltatech_purchase_picking_status/models/purchase_order.py:0
+msgid "Operator %s not supported"
+msgstr ""
+
+#. module: deltatech_purchase_picking_status
+#: model:ir.model,name:deltatech_purchase_picking_status.model_purchase_order
+msgid "Purchase Order"
+msgstr ""

--- a/deltatech_purchase_price/i18n/deltatech_purchase_price.pot
+++ b/deltatech_purchase_price/i18n/deltatech_purchase_price.pot
@@ -1,0 +1,258 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__purchase_add_supplier_to_product
+msgid "Add supplier to product"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,help:deltatech_purchase_price.field_product_pricelist_item__base
+msgid ""
+"Base price for computation.\n"
+"Sales Price: The base price will be the Sales Price.\n"
+"Cost Price: The base price will be the cost price.\n"
+"Other Pricelist: Computation of the base price based on another Pricelist."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_pricelist_item__base
+msgid "Based on"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_price.product_markup_wizard_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_product__standard_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_template__standard_price
+msgid "Cost"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_pricelist_item__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_supplierinfo__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_purchase_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_stock_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,help:deltatech_purchase_price.field_res_config_settings__purchase_force_price_at_validation
+msgid ""
+"Force product supplier price at purchase order validation and supplier bill "
+"validation"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__purchase_force_price_at_validation
+msgid "Force supplier price at PO and bill confirmation"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_pricelist_item__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_supplierinfo__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_purchase_order_line__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_stock_move__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_product__last_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_template__last_purchase_price
+#: model:ir.model.fields.selection,name:deltatech_purchase_price.selection__product_pricelist_item__base__last_purchase_price
+msgid "Last Purchase Price"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,help:deltatech_purchase_price.field_product_product__list_price
+#: model:ir.model.fields,help:deltatech_purchase_price.field_product_template__list_price
+msgid "Price at which the product is sold to customers."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_product_pricelist_item
+msgid "Pricelist Rule"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_product__list_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_template__list_price
+msgid "Sales Price"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__selected_line
+msgid "Selected Line"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_price.product_markup_wizard_form
+msgid "Set"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.actions.act_window,name:deltatech_purchase_price.action_product_template_markup_wizard
+msgid "Set Trade Markup"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_stock_move
+msgid "Stock Move"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_product_supplierinfo
+msgid "Supplier Pricelist"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_price.res_config_settings_view_form
+msgid ""
+"The list price will be updated according to trade markup value and the last "
+"purchase price."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_price.res_config_settings_view_form
+msgid "The price will be added/modified at PO validation and bill validation."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_price.res_config_settings_view_form
+msgid ""
+"The product's supplier price will be allways overwritten with the price from"
+" the purchase order."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_price.res_config_settings_view_form
+msgid ""
+"The supplier will be added to the product when a purchase order is "
+"confirmed."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_product_markup_wizard__trade_markup
+msgid "Trade Markup"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__purchase_update_list_price
+msgid "Update list price"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__purchase_update_product_price
+msgid "Update product price"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,field_description:deltatech_purchase_price.field_res_config_settings__purchase_update_standard_price
+msgid "Update standard price"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model.fields,help:deltatech_purchase_price.field_product_product__standard_price
+#: model:ir.model.fields,help:deltatech_purchase_price.field_product_template__standard_price
+msgid ""
+"Value of the product (automatically computed in AVCO).\n"
+"        Used to value the product when the purchase cost is not known (e.g. inventory adjustment).\n"
+"        Used to compute margins on sale orders."
+msgstr ""
+
+#. module: deltatech_purchase_price
+#. odoo-python
+#: code:addons/deltatech_purchase_price/models/product.py:0
+msgid ""
+"You cannot update the supplier price here. Please edit the supplier info "
+"separately"
+msgstr ""
+
+#. module: deltatech_purchase_price
+#: model:ir.model,name:deltatech_purchase_price.model_product_markup_wizard
+msgid "product.markup.wizard"
+msgstr ""

--- a/deltatech_purchase_stock/i18n/deltatech_purchase_stock.pot
+++ b/deltatech_purchase_stock/i18n/deltatech_purchase_stock.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_stock
+#: model:ir.model.fields,field_description:deltatech_purchase_stock.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_stock.field_stock_rule__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_stock
+#: model:ir.model.fields,field_description:deltatech_purchase_stock.field_purchase_order__from_replenishment
+msgid "From Replenishment"
+msgstr ""
+
+#. module: deltatech_purchase_stock
+#: model:ir.model.fields,field_description:deltatech_purchase_stock.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_stock.field_stock_rule__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_stock
+#: model:ir.model,name:deltatech_purchase_stock.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_stock
+#: model:ir.model,name:deltatech_purchase_stock.model_stock_rule
+msgid "Stock Rule"
+msgstr ""

--- a/deltatech_purchase_ubl/i18n/deltatech_purchase_ubl.pot
+++ b/deltatech_purchase_ubl/i18n/deltatech_purchase_ubl.pot
@@ -1,0 +1,393 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_ubl
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "<i class=\"fa fa-exclamation-triangle me-1\" title=\"Warning\"/>"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Added %s lines to the purchase order from source document."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid ""
+"Automatically create storable products for XML lines that cannot be matched "
+"to existing products"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Close"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model,name:deltatech_purchase_ubl.model_purchase_invoice_import_mixin
+msgid ""
+"Common matching/bill-creation logic for purchase invoice import wizards"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Create a vendor bill (account.move) from the XML invoice data"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__create_missing_products
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__create_missing_products
+msgid "Create missing products"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__create_bill
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__create_bill
+msgid "Create vendor bill"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Created products:\n"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_invoice_import_mixin__state__done
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard__state__done
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_invoice_import_mixin__state__draft
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "File"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__filename
+msgid "Filename"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__id
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Import"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.actions.act_window,name:deltatech_purchase_ubl.action_purchase_ubl_import_wizard
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.purchase_order_form_view_inherit_ubl_button
+msgid "Import UBL"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Import UBL XML"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model,name:deltatech_purchase_ubl.model_purchase_ubl_import_wizard
+msgid "Import UBL XML for Vendor Invoice/Receipt"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
+msgid "Invalid XML: %s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__log
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__log
+msgid "Log"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__log_html
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__log_html
+msgid "Log Html"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "No receipt found to validate."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"No vendor found for supplier VAT '%(vat)s' / name '%(name)s'. Launch the "
+"import from a purchase order or create the vendor first."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Options"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__order_lines_warning
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__order_lines_warning
+msgid "Order Lines Warning"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Order: %(order)s | XML Reference: %(ref)s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
+msgid "Please select an XML file."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model,name:deltatech_purchase_ubl.model_purchase_order
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__order_id
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__order_id
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Purchase order already has lines. Import will update only the existing order"
+" lines; new lines from the source document will not be added to the purchase"
+" order."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Receipt updated: %s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Receipt validation skipped: no purchase order was resolved from the context "
+"or source document."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Result"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid ""
+"Select a UBL XML invoice file from your vendor (e-Factura format supported)"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Set the done quantities on the linked stock receipt and validate it"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__state
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "The stock transfer cannot be validated!"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__total_check_warning
+msgid "Total Check Warning"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Total check OK: purchase order %(label)s %(order_amount)s %(currency)s "
+"matches XML %(label)s %(xml_amount)s %(currency)s."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Unmatched lines in the order: %s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Unmatched products: %s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__update_prices
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__update_prices
+msgid "Update vendor prices"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Updated %s purchase order lines from source document."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Updated prices:\n"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__validate_receipt
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__validate_receipt
+msgid "Validate receipt from XML"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_invoice_import_mixin__bill_id
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__bill_id
+msgid "Vendor Bill"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Vendor bill already exists for this invoice reference (%s). No new bill was "
+"created."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Vendor bill created: %s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Vendor bill creation skipped: no purchase order was resolved from the "
+"context or source document."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Vendor bill not created: %s"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Vendor: %(name)s (%(vat)s)"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "View Vendor Bill"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Warning: Supplier VAT in source document (%(xml_vat)s) differs from order "
+"supplier (%(po_vat)s). Proceeded with order's vendor."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Warning: purchase order %(label)s %(order_amount)s %(currency)s differs from"
+" XML %(label)s %(xml_amount)s %(currency)s (difference %(difference)s "
+"%(currency)s)."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid ""
+"Write the unit price from each XML line into the vendor pricelist "
+"(product.supplierinfo)"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__data_file
+msgid "XML File"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "total"
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "untaxed total"
+msgstr ""

--- a/deltatech_purchase_xls/i18n/deltatech_purchase_xls.pot
+++ b/deltatech_purchase_xls/i18n/deltatech_purchase_xls.pot
@@ -1,0 +1,236 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_purchase_xls
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.purchase_order_form
+msgid "<span>Order lines</span>"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_import_purchase_line_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_import_purchase_line_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__new_product
+msgid "Create missing product"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__create_uid
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__create_date
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_purchase_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+msgid "Exit"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+msgid "Export Complete"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+msgid "Export Purchase Line"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.actions.act_window,name:deltatech_purchase_xls.action_working_days_export
+#: model:ir.model,name:deltatech_purchase_xls.model_export_purchase_line
+msgid "Export Purchase Lines"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+msgid "Export selected purchase order lines"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__fields_list
+msgid "Fields"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,help:deltatech_purchase_xls.field_import_purchase_line__fields_list
+msgid ""
+"Fields and order in the file. Example: "
+"\"product_code,product_name,quantity,price,uom_name\""
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__data_file
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__data_file
+msgid "File"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__name
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__filename
+msgid "File Name"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__has_header
+msgid "Header row"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+msgid "Here is the exported file:"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__id
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__id
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_purchase_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.actions.act_window,name:deltatech_purchase_xls.action_import_purchase_line
+msgid "Import Purchase Line"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_import_purchase_line_form
+msgid "Import Purchase Lines"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model,name:deltatech_purchase_xls.model_import_purchase_line
+msgid "Import purchase line"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#. odoo-python
+#: code:addons/deltatech_purchase_xls/wizard/import_purchase_line.py:0
+msgid "Invalid file format"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__is_amount
+msgid "Is amount"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__write_uid
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__write_date
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#. odoo-python
+#: code:addons/deltatech_purchase_xls/wizard/import_purchase_line.py:0
+msgid "Product %(product_name)s does not have UOM %(uom_name)s"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#. odoo-python
+#: code:addons/deltatech_purchase_xls/wizard/import_purchase_line.py:0
+msgid "Product %s not found"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__purchase_id
+msgid "Purchase"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model,name:deltatech_purchase_xls.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model,name:deltatech_purchase_xls.model_purchase_order_line
+msgid "Purchase Order Line"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_import_purchase_line__search_by_default_code
+msgid "Search by internal code"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields,field_description:deltatech_purchase_xls.field_export_purchase_line__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#. odoo-python
+#: code:addons/deltatech_purchase_xls/wizard/import_purchase_line.py:0
+msgid "The 'openpyxl' Python library is required to read .xlsx files."
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_import_purchase_line_form
+msgid ""
+"The Excel file must contain the following columns:\n"
+"                        product_code, product_name, quantity, price, uom_name"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#. odoo-python
+#: code:addons/deltatech_purchase_xls/wizard/import_purchase_line.py:0
+msgid "The order is in the %s state"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields.selection,name:deltatech_purchase_xls.selection__export_purchase_line__state__choose
+msgid "choose"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model:ir.model.fields.selection,name:deltatech_purchase_xls.selection__export_purchase_line__state__get
+msgid "get"
+msgstr ""
+
+#. module: deltatech_purchase_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_export_purchase_line_form
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_xls.view_import_purchase_line_form
+msgid "or"
+msgstr ""

--- a/deltatech_putaway_strategy/i18n/deltatech_putaway_strategy.pot
+++ b/deltatech_putaway_strategy/i18n/deltatech_putaway_strategy.pot
@@ -1,0 +1,132 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_putaway_strategy
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_picking_type__avoid_putaway_rules
+msgid "Avoid Putaway Rules"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#. odoo-python
+#: code:addons/deltatech_putaway_strategy/models/stock_move_line.py:0
+msgid "Cannot assign move lines to locations"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model_terms:ir.ui.view,arch_db:deltatech_putaway_strategy.view_stock_location_form_inherit_deltatech_map
+msgid "Capacity"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__current_products
+msgid "Current quantity"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,help:deltatech_putaway_strategy.field_stock_location__current_products
+msgid ""
+"Current quantity on hand. For leaves, computed as the sum of quantities from"
+" stock quants (quantity > 0). For non-leaves, sum of children."
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__display_name
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_move__display_name
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,help:deltatech_putaway_strategy.field_stock_location__max_products_leaf
+msgid ""
+"For leaf locations, set the maximum number of products. For non-leaf "
+"locations, total capacity is computed as the sum of children."
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__id
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_move__id
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_move_line__id
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model,name:deltatech_putaway_strategy.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#. odoo-python
+#: code:addons/deltatech_putaway_strategy/models/stock_move_line.py:0
+msgid "Location %(location)s is over capacity (%(current)s > %(max)s)"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__max_products
+msgid "Max products"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__max_products_leaf
+msgid "Max products (leaf)"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,help:deltatech_putaway_strategy.field_stock_location__max_products
+msgid ""
+"Maximum number of products allowed in this location (sum of children for "
+"non-leaf locations)."
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__occupancy_ratio
+msgid "Occupancy"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,help:deltatech_putaway_strategy.field_stock_location__occupancy_ratio
+msgid "Occupancy ratio = current/max. 0 when max is 0."
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model,name:deltatech_putaway_strategy.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,field_description:deltatech_putaway_strategy.field_stock_location__planned_products
+msgid "Planned quantity"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model.fields,help:deltatech_putaway_strategy.field_stock_location__planned_products
+msgid ""
+"Planned quantity (incoming). For leaves, computed as the sum of quantities "
+"from stock moves not done or cancelled. For non-leaves, sum of children."
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model,name:deltatech_putaway_strategy.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr ""
+
+#. module: deltatech_putaway_strategy
+#: model:ir.model,name:deltatech_putaway_strategy.model_stock_move
+msgid "Stock Move"
+msgstr ""

--- a/deltatech_queue_job/i18n/deltatech_queue_job.pot
+++ b/deltatech_queue_job/i18n/deltatech_queue_job.pot
@@ -1,0 +1,231 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_queue_job
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "<strong>Body:</strong>"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "<strong>Headers:</strong> <code>Content-Type: application/json</code>"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "<strong>Method:</strong> POST"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "<strong>Schedule:</strong> Every minute (<code>* * * * *</code>)"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid ""
+"<strong>URL:</strong> <code>https://your-"
+"domain.com/api/v1/queue/process</code>"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_res_config_settings__queue_job_processor_api_key
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "API Key"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,help:deltatech_queue_job.field_res_config_settings__queue_job_processor_api_key
+msgid "API Key for external queue processor (cron-job.org)"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_res_config_settings__queue_job_processor_batch_size
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Batch Size"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "CRON Trigger already exists"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model,name:deltatech_queue_job.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Configure external cron processor (cron-job.org)"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Create a free account on"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Create a new cron job with these settings:"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_form
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_tree
+msgid "Cron Trigger"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_queue_job__display_name
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "External Processor"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Generate Key"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_queue_job__id
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "Job Processing Started"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,field_description:deltatech_queue_job.field_res_config_settings__queue_job_processor_max_seconds
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Max Seconds"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,help:deltatech_queue_job.field_res_config_settings__queue_job_processor_max_seconds
+msgid "Maximum execution time in seconds"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model.fields,help:deltatech_queue_job.field_res_config_settings__queue_job_processor_batch_size
+msgid "Maximum number of jobs to process per execution"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_search
+msgid "Model"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "No CRON Trigger found"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_form
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_tree
+msgid "Process"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_form
+msgid "Process (Thread)"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.view_queue_job_tree
+msgid "Process Background"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.model,name:deltatech_queue_job.model_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Queue Job"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "Queue Job Processor"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model:ir.actions.act_window,name:deltatech_queue_job.action_queue_job_config
+#: model:ir.ui.menu,name:deltatech_queue_job.menu_queue_job_config
+msgid "Settings"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "Superseded by a new job with the same identity_key"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "The API processing has been triggered in a separate thread!"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "The operation will be executed in the background!"
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "The processing of jobs has been triggered in the background."
+msgstr ""
+
+#. module: deltatech_queue_job
+#. odoo-python
+#: code:addons/deltatech_queue_job/models/queue_job.py:0
+msgid "Thread Processing"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "cron-job.org"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid ""
+"{\n"
+"    \"jsonrpc\": \"2.0\",\n"
+"    \"params\": {\n"
+"        \"api_key\": \"YOUR_API_KEY_HERE\"\n"
+"    }\n"
+"}"
+msgstr ""
+
+#. module: deltatech_queue_job
+#: model_terms:ir.ui.view,arch_db:deltatech_queue_job.res_config_settings_view_form
+msgid "🚀 External Cron Setup (cron-job.org)"
+msgstr ""

--- a/deltatech_ral/i18n/deltatech_ral.pot
+++ b/deltatech_ral/i18n/deltatech_ral.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_ral
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_ral
+#: model:ir.model.fields,field_description:deltatech_ral.field_mrp_production__display_name
+#: model:ir.model.fields,field_description:deltatech_ral.field_stock_lot__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_ral
+#: model:ir.model.fields,field_description:deltatech_ral.field_mrp_production__id
+#: model:ir.model.fields,field_description:deltatech_ral.field_stock_lot__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_ral
+#: model:ir.model,name:deltatech_ral.model_stock_lot
+msgid "Lot/Serial"
+msgstr ""
+
+#. module: deltatech_ral
+#: model:ir.model,name:deltatech_ral.model_mrp_production
+msgid "Manufacturing Order"
+msgstr ""
+
+#. module: deltatech_ral
+#: model:ir.model.fields,field_description:deltatech_ral.field_mrp_production__ral_id
+#: model:ir.model.fields,field_description:deltatech_ral.field_stock_lot__ral_id
+msgid "RAL"
+msgstr ""

--- a/deltatech_reception_note/i18n/deltatech_reception_note.pot
+++ b/deltatech_reception_note/i18n/deltatech_reception_note.pot
@@ -1,0 +1,227 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_reception_note
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.view_reception_note_create_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.view_reception_note_create_form
+msgid "Are you sure you want to create a reception note?"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.view_reception_note_create_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.purchase_order_form_discount
+msgid "Confirm Order"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.actions.act_window,help:deltatech_reception_note.prepare_reception_note_action
+#: model_terms:ir.actions.act_window,help:deltatech_reception_note.view_reception_assigned_action
+#: model_terms:ir.actions.act_window,help:deltatech_reception_note.view_receptions
+msgid "Create a new reception note"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.actions.act_window,name:deltatech_reception_note.action_reception_note_create
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.view_reception_note_create_form
+msgid "Create reception note"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_reception_note_create__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_reception_note_create__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__date_sent
+msgid "Date sent"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__delivery_note_no
+msgid "Delivery Note No"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_reception_note_create__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.purchase_order_search_type
+msgid "Empty"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_reception_note_create__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,help:deltatech_reception_note.field_purchase_order__ignore_quantities
+msgid ""
+"If checked, quantities bigger than those found on rfq's are forced for "
+"reception"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__ignore_quantities
+msgid "Ignore quantities"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__is_empty
+msgid "Is empty"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_reception_note_create__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_reception_note_create__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields.selection,name:deltatech_reception_note.selection__purchase_order__reception_type__normal
+msgid "Normal"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.purchase_order_search_type
+msgid "Not empty"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.ui.menu,name:deltatech_reception_note.menu_action_reception_note_prepare
+msgid "Prepare reception note"
+msgstr ""
+
+#. module: deltatech_reception_note
+#. odoo-python
+#: code:addons/deltatech_reception_note/models/purchase.py:0
+msgid ""
+"Product [{product_code}]{product_name}: quantity: {quantity} {uom}<br />"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model,name:deltatech_reception_note.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_reception_note
+#. odoo-python
+#: code:addons/deltatech_reception_note/models/purchase.py:0
+msgid "Quantities forced on this reception note:<br />"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields.selection,name:deltatech_reception_note.selection__purchase_order__reception_type__rfq_only
+msgid "RFQ Only"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields.selection,name:deltatech_reception_note.selection__purchase_order__reception_type__note
+msgid "Reception Note"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model,name:deltatech_reception_note.model_reception_note_create
+msgid "Reception Note Create Wizard"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.actions.act_window,name:deltatech_reception_note.prepare_reception_note_action
+msgid "Reception note"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.ui.menu,name:deltatech_reception_note.menu_action_reception_notes
+#: model_terms:ir.actions.act_window,help:deltatech_reception_note.prepare_reception_note_action
+#: model_terms:ir.actions.act_window,help:deltatech_reception_note.view_reception_assigned_action
+#: model_terms:ir.actions.act_window,help:deltatech_reception_note.view_receptions
+msgid "Reception notes"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.actions.act_window,name:deltatech_reception_note.view_reception_assigned_action
+#: model:ir.actions.act_window,name:deltatech_reception_note.view_receptions
+msgid "Receptions"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.purchase_order_form_sent
+msgid "Set as sent"
+msgstr ""
+
+#. module: deltatech_reception_note
+#. odoo-python
+#: code:addons/deltatech_reception_note/models/purchase.py:0
+msgid ""
+"The product [%(default_code)s]%(name)s is not found in a sent RFQ. Tick "
+"'Ignore quantities' to receive it anyway."
+msgstr ""
+
+#. module: deltatech_reception_note
+#. odoo-python
+#: code:addons/deltatech_reception_note/models/purchase.py:0
+msgid ""
+"The quantity %(quantity)s of the [%(default_code)s] %(name)s product is not "
+"found in a sent RFQ. Tick 'Ignore quantities' to receive it anyway."
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.ui.menu,name:deltatech_reception_note.menu_action_reception_note_view
+msgid "To arrive"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.ui.menu,name:deltatech_reception_note.menu_action_reception_view
+msgid "To invoice"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model:ir.model.fields,field_description:deltatech_reception_note.field_purchase_order__reception_type
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_reception_note
+#. odoo-python
+#: code:addons/deltatech_reception_note/models/purchase.py:0
+msgid "Unable to confirm"
+msgstr ""
+
+#. module: deltatech_reception_note
+#: model_terms:ir.ui.view,arch_db:deltatech_reception_note.view_reception_note_create_form
+msgid "or"
+msgstr ""

--- a/deltatech_record_type/i18n/deltatech_record_type.pot
+++ b/deltatech_record_type/i18n/deltatech_record_type.pot
@@ -1,0 +1,280 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_record_type
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__user_ids
+msgid "Allowed Users"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields.selection,name:deltatech_record_type.selection__record_type_default_values__field_type__boolean
+msgid "Boolean"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:res.groups,name:deltatech_record_type.group_confirm_order_without_record_type
+msgid "Can Confirm Orders Without Record Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model_terms:ir.ui.view,arch_db:deltatech_record_type.res_config_settings_view_form
+msgid "Can confirm orders without record type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields.selection,name:deltatech_record_type.selection__record_type_default_values__field_type__char
+msgid "Char"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_res_config_settings__group_confirm_order_without_record_type
+msgid "Confirmed without record type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__create_uid
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__create_date
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__default_values_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_record_type.view_record_type_form
+msgid "Default Values"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_report__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_order_line__display_name
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_report__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__field_id
+msgid "Field"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__field_name
+msgid "Field Name"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__field_type
+msgid "Field Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__field_value
+msgid "Field Value"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_report__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_order_line__id
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_report__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields.selection,name:deltatech_record_type.selection__record_type_default_values__field_type__id
+msgid "Id"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields.selection,name:deltatech_record_type.selection__record_type__model__account_move
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_account_bank_statement_line__invoice_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_account_move__invoice_type
+msgid "Invoice Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.actions.act_window,name:deltatech_record_type.action_invoice_type
+#: model:ir.ui.menu,name:deltatech_record_type.menu_invoice_order_type
+msgid "Invoice Types"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_order__journal_id
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__write_uid
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__write_date
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__model
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__model_id
+msgid "Model"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_order__po_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_report__po_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_order__so_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_report__so_type
+#: model_terms:ir.ui.view,arch_db:deltatech_record_type.view_saleorder_type_filter
+msgid "Order Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.actions.act_window,name:deltatech_record_type.action_purchase_order_type
+#: model:ir.actions.act_window,name:deltatech_record_type.action_sale_order_type
+#: model:ir.ui.menu,name:deltatech_record_type.menu_purchase_order_type
+#: model:ir.ui.menu,name:deltatech_record_type.menu_sale_order_type
+msgid "Order Types"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_purchase_order
+#: model:ir.model.fields.selection,name:deltatech_record_type.selection__record_type__model__purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_purchase_report
+msgid "Purchase Report"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__record_type_id
+#: model_terms:ir.ui.view,arch_db:deltatech_record_type.view_record_type_form
+msgid "Record Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.actions.act_window,name:deltatech_record_type.action_record_type
+msgid "Record Types"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type_default_values__value_ref
+msgid "Related"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_record_type__route_ids
+msgid "Route"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model_terms:ir.ui.view,arch_db:deltatech_record_type.view_record_type_form
+msgid "Routes"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields.selection,name:deltatech_record_type.selection__record_type__model__sale_order
+msgid "Sale Order"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_record_type_default_values
+msgid "Sale Order Type Default Values"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_sale_report
+msgid "Sales Analysis Report"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model,name:deltatech_record_type.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_account_bank_statement_line__show_invoice_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_account_move__show_invoice_type
+msgid "Show Invoice Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_purchase_order__show_po_type
+msgid "Show Po Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#: model:ir.model.fields,field_description:deltatech_record_type.field_sale_order__show_so_type
+msgid "Show So Type"
+msgstr ""
+
+#. module: deltatech_record_type
+#. odoo-python
+#: code:addons/deltatech_record_type/models/purchase.py:0
+#: code:addons/deltatech_record_type/models/sale.py:0
+msgid ""
+"You do not have the rights to confirm an order without specifying an Order "
+"Type."
+msgstr ""

--- a/deltatech_replenishment_explain/i18n/deltatech_replenishment_explain.pot
+++ b/deltatech_replenishment_explain/i18n/deltatech_replenishment_explain.pot
@@ -1,0 +1,411 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_replenishment_explain
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"%(qty)s %(uom)s of demand is scheduled after the lead horizon (%(date)s) and"
+" is NOT counted in the forecast. If it falls due before a replenishment "
+"arrives, you can stock out. Increase the Replenishment Horizon (currently "
+"%(horizon)s days) to make it visible."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "(overridden in the replenishment view)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid ""
+"),\n"
+"                i.e. today + lead time + horizon. Demand/receipts up to that date are counted."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "+ Replenishment Horizon"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "+ Scheduled receipts (≤ horizon)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid ", Max"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid ", so the rule orders <b>nothing</b>."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid ""
+".\n"
+"                The horizon is what makes future demand visible to the forecast."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "1 · How the forecast was built"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "2 · Why this quantity"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "3 · Lead time &amp; horizon"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "4 · Where it may lose"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "<span class=\"fw-bold\">To order now</span>"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "= Forecast"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "= Lead horizon date"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "= Raw need"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"A manual To Order quantity (%(manual)s) is set, overriding the computed "
+"%(computed)s."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid ""
+"A manual To Order quantity is set and overrides the computed value above."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.view_stock_replenishment_explanation_form
+msgid "Close"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "Demand beyond the horizon is invisible"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__display_name
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_warehouse_orderpoint__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__explanation_html
+msgid "Explanation Html"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__qty_forecast
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Forecast"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"Forecast (%(forecast)s) is at or above Min (%(min)s), so nothing is ordered "
+"— but a deadline of %(deadline)s was found. A future arrival is likely "
+"expected only after stock dips below Min. Check the Forecast Report."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Horizon"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__id
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_warehouse_orderpoint__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Lead time"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "Manual quantity override"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Max"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Min"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model,name:deltatech_replenishment_explain.model_stock_warehouse_orderpoint
+msgid "Minimum Inventory Rule"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"No stock rule resolves for this product at this location, so nothing can be "
+"procured even when stock is needed. Check the product's routes."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"No supplier is configured, so Odoo injects a %(days)s-day lead time. This "
+"pushes the forecast horizon a year out and usually distorts the quantity. "
+"Set a vendor on the product."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "No supply route / rule"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "No vendor found"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "No visibility or horizon issues detected"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "On hand (now)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.view_stock_replenishment_explanation_form
+msgid "Open Forecast Report"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__orderpoint_id
+msgid "Orderpoint"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "Potential stockout despite no order"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__product_id
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Quantity (UoM)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model,name:deltatech_replenishment_explain.model_stock_replenishment_explanation
+msgid "Replenishment Explanation"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "Rounded up to a multiple"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Rounded up to multiple of '"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "Snoozed"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Stock projected at the <b>lead horizon</b> ("
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Target — max(Min"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"The forecast window covers the scheduled demand and a supply route is "
+"available."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid ""
+"The raw need (%(raw)s) was rounded up to %(rounded)s to respect the multiple"
+" '%(multiple)s' (+%(extra)s %(uom)s)."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+msgid "This rule is snoozed until %(date)s and will be skipped until then."
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__qty_to_order
+msgid "To Order"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "Today"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model:ir.model.fields,field_description:deltatech_replenishment_explain.field_stock_replenishment_explanation__warehouse_id
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#. odoo-python
+#: code:addons/deltatech_replenishment_explain/models/stock_orderpoint.py:0
+#: model:ir.actions.server,name:deltatech_replenishment_explain.action_explain_replenishment_server
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.view_warehouse_orderpoint_form_explain
+msgid "Why this replenishment?"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "day(s)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "is <b>at or above</b> Min"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "is <b>below</b> Min"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "lead time"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "max(Min, Max) ="
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "± In progress (POs/MOs not yet moves)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "→ replenish up to"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "− Forecast"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "− Scheduled demand (≤ horizon)"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "▆ Forecast"
+msgstr ""
+
+#. module: deltatech_replenishment_explain
+#: model_terms:ir.ui.view,arch_db:deltatech_replenishment_explain.replenishment_explanation
+msgid "▆ To order"
+msgstr ""

--- a/deltatech_report_packaging/i18n/deltatech_report_packaging.pot
+++ b/deltatech_report_packaging/i18n/deltatech_report_packaging.pot
@@ -1,0 +1,237 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_report_packaging
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__aluminium
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__aluminium
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__aluminium
+msgid "Aluminium"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.invoice_packaging_material_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.invoice_packaging_material_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material__state__choose
+msgid "Choose"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.invoice_packaging_material_form
+msgid "Close"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__create_uid
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__create_uid
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__create_uid
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__create_date
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__create_date
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__create_date
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__display_name
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__display_name
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__display_name
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__display_name
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__glass
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__glass
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__glass
+msgid "Glass"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__id
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__id
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__id
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__id
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__invoice_id
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model,name:deltatech_report_packaging.model_packaging_report_material
+msgid "Invoice Packaging Material Report"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model,name:deltatech_report_packaging.model_packaging_report_material_line
+msgid "Invoice Packaging Material Report Line"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model,name:deltatech_report_packaging.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__write_uid
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__write_uid
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__write_uid
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__write_date
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__write_date
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__write_date
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__line_ids
+msgid "Lines"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__material_type
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__material_type
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__material_type
+msgid "Material Type"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__metal
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__metal
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__metal
+msgid "Metal"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__pet
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__pet
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__pet
+msgid "PET"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model,name:deltatech_report_packaging.model_packaging_product_material
+msgid "Packaging material used for a product"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model,name:deltatech_report_packaging.model_packaging_invoice_material
+msgid "Packaging material used in an invoice"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_account_bank_statement_line__packaging_material_ids
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_account_move__packaging_material_ids
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_product_product__packaging_material_ids
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_product_template__packaging_material_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.account_move_form_view
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.product_template_form_view
+msgid "Packaging materials"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.actions.act_window,name:deltatech_report_packaging.action_packaging_wizard
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.invoice_packaging_material_form
+msgid "Packaging materials report"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__paper
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__paper
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__paper
+msgid "Paper"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__plastic
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__plastic
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__plastic
+msgid "Plastic"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model,name:deltatech_report_packaging.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__product_tmpl_id
+msgid "Product Tmpl"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_invoice_material__qty
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_product_material__qty
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__qty
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.account_move_form_view
+msgid "Refresh"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material_line__report_id
+msgid "Report"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model_terms:ir.ui.view,arch_db:deltatech_report_packaging.invoice_packaging_material_form
+msgid "Report packaging materials used for invoiced products"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material__state__get
+msgid "Result"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields,field_description:deltatech_report_packaging.field_packaging_report_material__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_report_packaging
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_invoice_material__material_type__wood
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_product_material__material_type__wood
+#: model:ir.model.fields.selection,name:deltatech_report_packaging.selection__packaging_report_material_line__material_type__wood
+msgid "Wood"
+msgstr ""

--- a/deltatech_report_prn/i18n/deltatech_report_prn.pot
+++ b/deltatech_report_prn/i18n/deltatech_report_prn.pot
@@ -1,0 +1,50 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_report_prn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,field_description:deltatech_report_prn.field_ir_actions_report__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,field_description:deltatech_report_prn.field_ir_actions_report__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields.selection,name:deltatech_report_prn.selection__ir_actions_report__report_type__qweb-prn
+msgid "PRN"
+msgstr ""
+
+#. module: deltatech_report_prn
+#: model:ir.model,name:deltatech_report_prn.model_ir_actions_report
+msgid "Report Action"
+msgstr ""
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,field_description:deltatech_report_prn.field_ir_actions_report__report_type
+msgid "Report Type"
+msgstr ""
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,help:deltatech_report_prn.field_ir_actions_report__report_type
+msgid ""
+"The type of the report that will be rendered, each one having its own "
+"rendering method. HTML means the report will be opened directly in your "
+"browser PDF means the report will be rendered using Wkhtmltopdf and "
+"downloaded by the user."
+msgstr ""

--- a/deltatech_sale_activity_report/i18n/deltatech_sale_activity_report.pot
+++ b/deltatech_sale_activity_report/i18n/deltatech_sale_activity_report.pot
@@ -1,0 +1,244 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_activity_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__awb_generated
+msgid "AWB Generated"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model,name:deltatech_sale_activity_report.model_mail_activity
+msgid "Activity"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__activity_log
+msgid "Activity Log"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_form
+msgid "Activity Record"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.actions.act_window,name:deltatech_sale_activity_report.action_sale_order_activity_record
+#: model:ir.ui.menu,name:deltatech_sale_activity_report.menu_sale_order_activity_record
+msgid "Activity Records"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_form
+msgid "Basic Information"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__canceled
+msgid "Canceled"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__change_date
+msgid "Change Date"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__chatter_message
+msgid "Chatter Message"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__delivered
+msgid "Delivered"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_mail_activity__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_mail_activity__id
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__in_delivery
+msgid "In Delivery"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__in_process
+msgid "In Process"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__state__done
+msgid "Locked"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_form
+msgid "Log"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__placed
+msgid "Placed"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__postponed
+msgid "Postponed"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__pre_advice
+msgid "Pre advice"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__state__draft
+msgid "Quotation"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__state__sent
+msgid "Quotation Sent"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.ui.menu,name:deltatech_sale_activity_report.menu_sale_report_menu
+msgid "Reporting"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__rfq
+msgid "Request for Quotation"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__returned
+msgid "Returned"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__sale_order_id
+msgid "Sale Order"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model,name:deltatech_sale_activity_report.model_sale_order_activity_record
+msgid "Sale Order Activity Record"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model,name:deltatech_sale_activity_report.model_sale_order
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__state__sale
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__stage
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "Stage"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__state
+msgid "State"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__tags_changed
+msgid "Tags Changed"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "This Month"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "This Year"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__to_be_delivery
+msgid "To Be Delivery"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "Today"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_form
+msgid "Tracked Events"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields,field_description:deltatech_sale_activity_report.field_sale_order_activity_record__user_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "User"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model:ir.model.fields.selection,name:deltatech_sale_activity_report.selection__sale_order_activity_record__stage__waiting
+msgid "Waiting availability"
+msgstr ""
+
+#. module: deltatech_sale_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_activity_report.view_sale_order_activity_record_search
+msgid "Yesterday"
+msgstr ""

--- a/deltatech_sale_activity_search/i18n/deltatech_sale_activity_search.pot
+++ b/deltatech_sale_activity_search/i18n/deltatech_sale_activity_search.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_activity_search
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_activity_search
+#: model:ir.model.fields,field_description:deltatech_sale_activity_search.field_sale_order__active_activity_types
+msgid "Active Activity Types"
+msgstr ""
+
+#. module: deltatech_sale_activity_search
+#: model:ir.model,name:deltatech_sale_activity_search.model_mail_activity
+msgid "Activity"
+msgstr ""
+
+#. module: deltatech_sale_activity_search
+#: model:ir.model.fields,field_description:deltatech_sale_activity_search.field_mail_activity__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_activity_search.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_activity_search
+#: model:ir.model.fields,field_description:deltatech_sale_activity_search.field_mail_activity__id
+#: model:ir.model.fields,field_description:deltatech_sale_activity_search.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_activity_search
+#: model:ir.model,name:deltatech_sale_activity_search.model_sale_order
+msgid "Sales Order"
+msgstr ""

--- a/deltatech_sale_add_extra_line_pos/i18n/deltatech_sale_add_extra_line_pos.pot
+++ b/deltatech_sale_add_extra_line_pos/i18n/deltatech_sale_add_extra_line_pos.pot
@@ -1,0 +1,38 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_add_extra_line_pos
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_add_extra_line_pos
+#: model:ir.model.fields,field_description:deltatech_sale_add_extra_line_pos.field_pos_session__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_add_extra_line_pos.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_add_extra_line_pos
+#: model:ir.model.fields,field_description:deltatech_sale_add_extra_line_pos.field_pos_session__id
+#: model:ir.model.fields,field_description:deltatech_sale_add_extra_line_pos.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_add_extra_line_pos
+#: model:ir.model,name:deltatech_sale_add_extra_line_pos.model_pos_session
+msgid "Point of Sale Session"
+msgstr ""
+
+#. module: deltatech_sale_add_extra_line_pos
+#: model:ir.model,name:deltatech_sale_add_extra_line_pos.model_product_template
+msgid "Product"
+msgstr ""

--- a/deltatech_sale_commission/i18n/deltatech_sale_commission.pot
+++ b/deltatech_sale_commission/i18n/deltatech_sale_commission.pot
@@ -1,0 +1,648 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_commission
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.res_config_settings_view_form_stock
+msgid "<span class=\"o_form_label\">Salesperson commission compute</span>"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__account_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Account"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__invoice_line_ids
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__invoice_line_ids
+msgid "Account invoice line"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_compute_form
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_update_purchase_price_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_compute_form
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_update_purchase_price_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__categ_id
+msgid "Category"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Category of Product"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__commercial_partner_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Commercial Partner"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#. odoo-python
+#: code:addons/deltatech_sale_commission/wizard/commission_compute.py:0
+#: model:ir.actions.act_window,name:deltatech_sale_commission.action_sale_margin_commission_report
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move_line__commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_order_line__commission
+#: model:ir.ui.menu,name:deltatech_sale_commission.menu_commission
+#: model:ir.ui.menu,name:deltatech_sale_commission.menu_sale_margin_commission_report_list
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+msgid "Commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__commission_computed
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+msgid "Commission Computed"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__commission_director_computed
+msgid "Commission Director Computed"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:res.groups,name:deltatech_sale_commission.group_commission_manager
+msgid "Commission Manager"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__commission_manager_computed
+msgid "Commission Manager Computed"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Commission Not Paid"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move_line__commission_paid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__commission_paid
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Commission Paid"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:res.groups,name:deltatech_sale_commission.group_commission_viewer
+msgid "Commission Viewer"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_sale_commission_condition
+msgid "Commission condition"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__company_id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__company_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__company_currency_id
+msgid "Company Currency"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.actions.act_window,name:deltatech_sale_commission.action_commission_compute
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_compute_form
+msgid "Compute Commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_commission_compute
+msgid "Compute commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move_line__purchase_price
+msgid "Cost Price"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__create_uid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__create_uid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__create_uid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__create_date
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__create_date
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__create_date
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__move_type__out_invoice
+msgid "Customer Invoice"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__move_type__out_refund
+msgid "Customer Refund"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__date
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__due_date
+msgid "Due Date"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__for_all
+msgid "For all lines"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_update_purchase_price_form
+msgid "For the ALL invoice line will update purchase price"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_compute_form
+msgid "For the selected invoice line will compute commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_update_purchase_price_form
+msgid "For the selected invoice line will update purchase price"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move_line__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__payment_state__in_payment
+msgid "In Payment"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__invoice_id
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__res_config_settings__sale_user_detail__invoice
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Invoice"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__state
+msgid "Invoice Status"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__payment_state__invoicing_legacy
+msgid "Invoicing App Legacy"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__journal_id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__journal_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Journal"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.inherit_sale_view_order_product_search
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Last 7 Days"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__write_uid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__write_uid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__write_uid
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_compute__write_date
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__write_date
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__write_date
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__less_than_days
+msgid "Less Than Days"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__markup
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_pivot
+msgid "Markup"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__move_type
+msgid "Move Type"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "My Sales"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__payment_state__not_paid
+msgid "Not Paid"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Open"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__payment_state__paid
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Paid"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__payment_state__partial
+msgid "Partially Paid"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__partner_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__payment_state
+msgid "Payment Status"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__payment_term_id
+msgid "Payment Term"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__percentage
+msgid "Percentage"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__state__posted
+msgid "Posted"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_update_purchase_price__price_from_doc
+msgid "Price from delivery"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__product_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_list
+msgid "Profit"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__profit_val
+msgid "Profit Amount"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__profit_margin
+msgid "Profit Margin"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,help:deltatech_sale_commission.field_sale_margin_report__profit_val
+msgid "Profit obtained at invoicing in company currency"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__purchase_price
+msgid "Purchase price"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_list
+msgid "Qty"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__product_uom_qty
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__rate
+msgid "Rate"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__director_rate
+msgid "Rate director"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__manager_rate
+msgid "Rate manager"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__commission
+msgid "Real Commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__state_id
+msgid "Region"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__payment_state__reversed
+msgid "Reversed"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__sale_val
+msgid "Sale Amount"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,help:deltatech_sale_commission.field_sale_margin_report__sale_val
+msgid "Sale Amount in company currency"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.module.category,name:deltatech_sale_commission.module_category_sale_commission
+#: model:res.groups.privilege,name:deltatech_sale_commission.res_groups_privilege_sale_commission
+msgid "Sale Commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_sale_margin_report
+msgid "Sale Margin Report"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_res_config_settings__sale_user_detail
+msgid "Sale User Detail"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.actions.act_window,name:deltatech_sale_commission.action_sale_margin_report
+#: model:ir.ui.menu,name:deltatech_sale_commission.menu_sale_margin_report_list
+msgid "Sale margin report"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__res_config_settings__sale_user_detail__sale
+msgid "Sale order"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_list
+msgid "Sale value"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__director_user_id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__director_user_id
+msgid "Sales Director"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__manager_user_id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__manager_user_id
+msgid "Sales Manager"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__move_type__out_receipt
+msgid "Sales Receipt"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_account_move_line__sale_user_id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_commission_users__user_id
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__user_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Salesperson"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.res_config_settings_view_form_stock
+msgid ""
+"Salesperson compute on:<br/>\n"
+"                            - Invoice: the salesperson from the invoice will get the commission<br/>\n"
+"                            - Sale order: the salesperson from the Sale Order will get the commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_commission_condition__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_list
+msgid "Set Paid"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__stock_val
+msgid "Stock Amount"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,help:deltatech_sale_commission.field_sale_margin_report__stock_val
+msgid "Stock Amount in company currency"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_commission_list
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_list
+msgid "Stock value"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.actions.act_window,help:deltatech_sale_commission.action_sale_margin_report
+msgid "This report performs analysis on your invoices."
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.inherit_sale_view_order_product_search
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Today"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields,field_description:deltatech_sale_commission.field_sale_margin_report__product_uom
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.actions.act_window,name:deltatech_sale_commission.action_commission_update_purchase_price
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_update_purchase_price_form
+msgid "Update Purchase Price"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.actions.server,name:deltatech_sale_commission.cron_update_purchase_price_ir_actions_server
+msgid "Update Purchase Price Daily"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_commission_update_purchase_price
+msgid "Update purchase price"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.actions.act_window,name:deltatech_sale_commission.action_commission_users
+#: model:ir.ui.menu,name:deltatech_sale_commission.menu_commission_users
+msgid "Users Commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model,name:deltatech_sale_commission.model_commission_users
+msgid "Users commission"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__move_type__in_invoice
+msgid "Vendor Bill"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model:ir.model.fields.selection,name:deltatech_sale_commission.selection__sale_margin_report__move_type__in_refund
+msgid "Vendor Refund"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.inherit_sale_view_order_product_search
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.inherit_sale_view_order_product_search
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_sale_margin_report_filter
+msgid "Yesterday"
+msgstr ""
+
+#. module: deltatech_sale_commission
+#. odoo-python
+#: code:addons/deltatech_sale_commission/models/account_invoice.py:0
+msgid "You can not sell below the purchase price."
+msgstr ""
+
+#. module: deltatech_sale_commission
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_compute_form
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_commission.view_commission_update_purchase_price_form
+msgid "or"
+msgstr ""

--- a/deltatech_sale_contact/i18n/deltatech_sale_contact.pot
+++ b/deltatech_sale_contact/i18n/deltatech_sale_contact.pot
@@ -1,0 +1,95 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_contact
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_contact
+#: model:ir.model,name:deltatech_sale_contact.model_account_move_send
+msgid "Account Move Send"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model,name:deltatech_sale_contact.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_res_partner__contact_default
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_res_users__contact_default
+msgid "Contact Default"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model,website_form_label:deltatech_sale_contact.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_sale_order__partner_id
+msgid "Customer"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_sale_order__partner_shipping_id
+msgid "Delivery Address"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_account_move_send__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_res_partner__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_res_partner__print_green_invoice
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_res_users__print_green_invoice
+msgid "Green Invoice"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_account_move_send__id
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_res_partner__id
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,help:deltatech_sale_contact.field_res_partner__print_green_invoice
+#: model:ir.model.fields,help:deltatech_sale_contact.field_res_users__print_green_invoice
+msgid "If checked, the invoice will not be printed."
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_sale_order__partner_invoice_id
+msgid "Invoice Address"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model,name:deltatech_sale_contact.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model.fields,field_description:deltatech_sale_contact.field_account_move__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_sale_contact
+#: model:ir.model,name:deltatech_sale_contact.model_sale_order
+msgid "Sales Order"
+msgstr ""

--- a/deltatech_sale_cost_product/i18n/deltatech_sale_cost_product.pot
+++ b/deltatech_sale_cost_product/i18n/deltatech_sale_cost_product.pot
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_cost_product
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_cost_product
+#: model:ir.actions.server,name:deltatech_sale_cost_product.action_calculate_cost_of_goods
+msgid "Calculate Cost of Goods"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model:res.groups,name:deltatech_sale_cost_product.group_view_cost_on_sale
+msgid "Can See Cost Of Goods"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model:ir.model.fields,field_description:deltatech_sale_cost_product.field_sale_order__cost_of_goods
+msgid "Cost of Goods"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model:ir.model.fields,field_description:deltatech_sale_cost_product.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model:ir.model.fields,field_description:deltatech_sale_cost_product.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model:ir.model,name:deltatech_sale_cost_product.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_cost_product.view_order_list_inherit
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_cost_product.view_quotation_list_inherit
+msgid "Total Cost of Goods"
+msgstr ""
+
+#. module: deltatech_sale_cost_product
+#: model:res.groups,comment:deltatech_sale_cost_product.group_view_cost_on_sale
+msgid "Users in this group can see Cost of Goods column."
+msgstr ""

--- a/deltatech_sale_currency/i18n/deltatech_sale_currency.pot
+++ b/deltatech_sale_currency/i18n/deltatech_sale_currency.pot
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_currency
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_currency
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_currency
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_currency
+#: model:ir.model,name:deltatech_sale_currency.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_sale_currency
+#: model:ir.model,name:deltatech_sale_currency.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_currency
+#: model:ir.model,name:deltatech_sale_currency.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_sale_currency
+#. odoo-python
+#: code:addons/deltatech_sale_currency/models/account_move.py:0
+msgid "You cannot have multiple currencies in the same invoice line."
+msgstr ""

--- a/deltatech_sale_feedback/i18n/deltatech_sale_feedback.pot
+++ b/deltatech_sale_feedback/i18n/deltatech_sale_feedback.pot
@@ -1,0 +1,195 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_feedback
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_feedback
+#: model:mail.template,subject:deltatech_sale_feedback.mail_template_sale_feedback
+msgid "${object.company_id.name} (Ref ${object.name or 'n/a' })"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:mail.template,body_html:deltatech_sale_feedback.mail_template_sale_feedback
+msgid ""
+"<div style=\"margin: 0px; padding: 0px;\">\n"
+"                <p style=\"margin: 0px; padding: 0px; font-size: 12px;\">\n"
+"                    Dear\n"
+"                    <t t-if=\"object.partner_id.parent_id\">\n"
+"                        <t t-esc=\"object.partner_id.parent_id.name\"/>\n"
+"                        <t t-esc=\"' (' + object.partner_id.name + ')'\"/>\n"
+"                    </t>\n"
+"                    <t t-else=\"\">\n"
+"                        <t t-esc=\"object.partner_id.name\"/>\n"
+"                    </t>\n"
+"                    ,\n"
+"                </p>\n"
+"                <p>\n"
+"                    Please take a moment to rate our products related to the invoice \"<strong t-out=\"object.name\"/>\"\n"
+"                </p>\n"
+"                <br/>\n"
+"                <div style=\"margin: 0px; padding: 0px;\">\n"
+"                    <t t-foreach=\"object.invoice_line_ids\" t-as=\"line\">\n"
+"\n"
+"                        <t t-if=\"line.display_type in ['line_section', 'line_note']\">\n"
+"                            <table width=\"100%\" style=\"color: #454748; font-size: 12px; border-collapse: collapse;\">\n"
+"                                <tr>\n"
+"                                    <td colspan=\"4\">\n"
+"                                        <t t-if=\"line.display_type == 'line_section'\">\n"
+"                                            <strong t-out=\"line.name\"/>\n"
+"                                        </t>\n"
+"                                        <t t-elif=\"line.display_type == 'line_note'\">\n"
+"                                            <i t-out=\"line.name\"/>\n"
+"                                        </t>\n"
+"                                    </td>\n"
+"                                </tr>\n"
+"                            </table>\n"
+"                        </t>\n"
+"                        <t t-else=\"\">\n"
+"                            <t t-set=\"access_token\" t-value=\"line.rating_get_access_token()\"/>\n"
+"\n"
+"\n"
+"                            <table t-attf-width=\"100%\" style=\"color: #454748; font-size: 12px; border-collapse: collapse;\">\n"
+"                                <tr>\n"
+"                                    <td style=\"width: 100px;\">\n"
+"                                        <img t-att-src=\"'/web/image/product.product/' + str(line.product_id.id) + '/image_128'\" style=\"width: 64px; height: 64px; object-fit: contain;\" alt=\"Product image\"/>\n"
+"                                    </td>\n"
+"                                    <td align=\"left\">\n"
+"                                        <a t-att-href=\"line.product_id.website_url\">\n"
+"                                            <t t-esc=\"line.product_id.name\"/>\n"
+"                                        </a>\n"
+"                                    </td>\n"
+"                                    <td width=\"15%\" align=\"center\">\n"
+"                                        <t t-esc=\"line.quantity\"/>\n"
+"                                    </td>\n"
+"                                    <td style=\"font-size: 10px;\">\n"
+"                                        <table style=\"width:100%;text-align:center;\">\n"
+"                                            <tr>\n"
+"                                                <td>\n"
+"                                                    <a t-att-href=\"'/rate/' + access_token + '/5'\">\n"
+"                                                        <img alt=\"Satisfied\" src=\"/rating/static/src/img/rating_5.png\" title=\"Satisfied\"/>\n"
+"                                                    </a>\n"
+"                                                </td>\n"
+"                                                <td>\n"
+"                                                    <a t-att-href=\"'/rate/' + access_token + '/3'\">\n"
+"                                                        <img alt=\"Not satisfied\" src=\"/rating/static/src/img/rating_3.png\" title=\"Not satisfied\"/>\n"
+"                                                    </a>\n"
+"                                                </td>\n"
+"                                                <td>\n"
+"                                                    <a t-att-href=\"'/rate/' + access_token + '/1'\">\n"
+"                                                        <img alt=\"Highly Dissatisfied\" src=\"/rating/static/src/img/rating_1.png\" title=\"Highly Dissatisfied\"/>\n"
+"                                                    </a>\n"
+"                                                </td>\n"
+"                                            </tr>\n"
+"                                        </table>\n"
+"                                    </td>\n"
+"                                </tr>\n"
+"                            </table>\n"
+"\n"
+"                        </t>\n"
+"                    </t>\n"
+"                </div>\n"
+"\n"
+"\n"
+"            </div>\n"
+"        "
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model,name:deltatech_sale_feedback.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model,name:deltatech_sale_feedback.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_config_settings__days_request_feedback
+msgid "Days Request Feedback"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_account_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_ir_config_parameter__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_mail_template__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_company__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_company__sale_feedback_template_id
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_config_settings__sale_feedback_template_id
+msgid "Email Template Request Feedback"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model,name:deltatech_sale_feedback.model_mail_template
+msgid "Email Templates"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_company__sale_feedback
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_config_settings__sale_feedback
+msgid "Email feedback after sale"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model.fields,help:deltatech_sale_feedback.field_res_company__sale_feedback_template_id
+#: model:ir.model.fields,help:deltatech_sale_feedback.field_res_config_settings__sale_feedback_template_id
+msgid "Email sent to the customer after invoice for feedback."
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_account_move_line__id
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_ir_config_parameter__id
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_mail_template__id
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_company__id
+#: model:ir.model.fields,field_description:deltatech_sale_feedback.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:mail.template,name:deltatech_sale_feedback.mail_template_sale_feedback
+msgid "Invoice: request feedback"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model,name:deltatech_sale_feedback.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model,name:deltatech_sale_feedback.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.actions.server,name:deltatech_sale_feedback.ir_cron_feedback_ir_actions_server
+msgid "Request Feedback"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.actions.server,name:deltatech_sale_feedback.action_request_feedback
+msgid "Request feedback"
+msgstr ""
+
+#. module: deltatech_sale_feedback
+#: model:ir.model,name:deltatech_sale_feedback.model_ir_config_parameter
+msgid "System Parameter"
+msgstr ""

--- a/deltatech_sale_invoice_status/i18n/deltatech_sale_invoice_status.pot
+++ b/deltatech_sale_invoice_status/i18n/deltatech_sale_invoice_status.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_invoice_status
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_invoice_status
+#: model:ir.model.fields,field_description:deltatech_sale_invoice_status.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_invoice_status
+#: model:ir.model.fields,field_description:deltatech_sale_invoice_status.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_invoice_status
+#: model:ir.model,name:deltatech_sale_invoice_status.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/deltatech_sale_margin/i18n/deltatech_sale_margin.pot
+++ b/deltatech_sale_margin/i18n/deltatech_sale_margin.pot
@@ -1,0 +1,124 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_margin
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_margin
+#: model:ir.model.fields,field_description:deltatech_sale_margin.field_sale_order__can_change_price
+msgid "Can Change Price"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:ir.model.fields,field_description:deltatech_sale_margin.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_margin.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "Do not sell below the purchase price."
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:ir.model.fields,field_description:deltatech_sale_margin.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_margin.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:res.groups,name:deltatech_sale_margin.group_sale_no_change_price
+msgid "No change price on sale order"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "Price Error!"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:ir.model.fields,field_description:deltatech_sale_margin.field_sale_order__price_warning_message
+msgid "Price Warning Message"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "Sale %s below margin."
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "Sale %s under the purchase price."
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "Sale %s without price."
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:ir.model,name:deltatech_sale_margin.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:ir.model,name:deltatech_sale_margin.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:res.groups,name:deltatech_sale_margin.group_sale_below_margin
+msgid "Sell below margin limit"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:res.groups,name:deltatech_sale_margin.group_sale_below_purchase_price
+msgid "Sell below the purchase price"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#: model:res.groups,name:deltatech_sale_margin.group_sale_margin
+msgid "Show purchase price on sale order lines and customer invoice"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid ""
+"The unit price of product %s is lower than the purchase price. The margin is"
+" negative."
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "You can not sell %s without price."
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "You can not sell below margin: %s"
+msgstr ""
+
+#. module: deltatech_sale_margin
+#. odoo-python
+#: code:addons/deltatech_sale_margin/models/sale.py:0
+msgid "You can not sell below the purchase price: %s."
+msgstr ""

--- a/deltatech_sale_multiple/i18n/deltatech_sale_multiple.pot
+++ b/deltatech_sale_multiple/i18n/deltatech_sale_multiple.pot
@@ -1,0 +1,91 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_multiple
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_multiple
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model,name:deltatech_sale_multiple.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model,name:deltatech_sale_multiple.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_product__qty_minim
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_template__qty_minim
+msgid "Qty Minim"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_product__qty_multiple
+#: model:ir.model.fields,field_description:deltatech_sale_multiple.field_product_template__qty_multiple
+msgid "Qty Multiple"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple.product_template_form_view
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple.product_variant_easy_edit_view
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model,name:deltatech_sale_multiple.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#. odoo-python
+#: code:addons/deltatech_sale_multiple/models/product.py:0
+#: model:ir.model.constraint,message:deltatech_sale_multiple.constraint_product_product_qty_minim_non_negative
+msgid "The minimum sale quantity must be greater than or equal to zero."
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model.fields,help:deltatech_sale_multiple.field_product_product__qty_minim
+#: model:ir.model.fields,help:deltatech_sale_multiple.field_product_template__qty_minim
+msgid "The minimum sale quantity. If it is 0, no minimum is enforced."
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#. odoo-python
+#: code:addons/deltatech_sale_multiple/models/product.py:0
+#: model:ir.model.constraint,message:deltatech_sale_multiple.constraint_product_product_qty_multiple_non_negative
+msgid "The sale quantity multiple must be greater than or equal to zero."
+msgstr ""
+
+#. module: deltatech_sale_multiple
+#: model:ir.model.fields,help:deltatech_sale_multiple.field_product_product__qty_multiple
+#: model:ir.model.fields,help:deltatech_sale_multiple.field_product_template__qty_multiple
+msgid ""
+"The sale quantity will be rounded up to this multiple. If it is 0 or 1, no "
+"multiple is enforced."
+msgstr ""

--- a/deltatech_sale_multiple_website/i18n/deltatech_sale_multiple_website.pot
+++ b/deltatech_sale_multiple_website/i18n/deltatech_sale_multiple_website.pot
@@ -1,0 +1,111 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_multiple_website
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model.fields,help:deltatech_sale_multiple_website.field_product_product__check_min_website
+#: model:ir.model.fields,help:deltatech_sale_multiple_website.field_product_template__check_min_website
+msgid "Apply minimum and multiple quantity rules only on the website."
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.cart_line_description_following_lines
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.product_qty_restrictions
+msgid "Min:"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#. odoo-javascript
+#: code:addons/deltatech_sale_multiple_website/static/src/js/qty_popover.esm.js:0
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.product_qty_restrictions
+msgid "Minimum quantity"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.product_qty_restrictions
+msgid "Multiple of:"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model,name:deltatech_sale_multiple_website.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model,name:deltatech_sale_multiple_website.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#. odoo-javascript
+#: code:addons/deltatech_sale_multiple_website/static/src/js/qty_popover.esm.js:0
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.product_qty_restrictions
+msgid "Quantity multiple"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#. odoo-javascript
+#: code:addons/deltatech_sale_multiple_website/static/src/js/qty_popover.esm.js:0
+msgid "Quantity must be a multiple of %s (e.g. %s, %s, %s...)."
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.product_qty_restrictions
+msgid "Quantity must be a multiple of {{0}} (e.g. {{1}}, {{2}}, {{3}}...)."
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model,name:deltatech_sale_multiple_website.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model,name:deltatech_sale_multiple_website.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#. odoo-javascript
+#: code:addons/deltatech_sale_multiple_website/static/src/js/qty_popover.esm.js:0
+msgid "The minimum order quantity is %s units."
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_multiple_website.product_qty_restrictions
+msgid "The minimum order quantity is {{0}} units."
+msgstr ""
+
+#. module: deltatech_sale_multiple_website
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_product_product__check_min_website
+#: model:ir.model.fields,field_description:deltatech_sale_multiple_website.field_product_template__check_min_website
+msgid "Website Check Quantity"
+msgstr ""

--- a/deltatech_sale_pallet/i18n/deltatech_sale_pallet.pot
+++ b/deltatech_sale_pallet/i18n/deltatech_sale_pallet.pot
@@ -1,0 +1,92 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_pallet
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_pallet
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model,name:deltatech_sale_pallet.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_category__pallet
+msgid "Pallet"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_product__pallet_price
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_template__pallet_price
+msgid "Pallet Price"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_product__pallet_product_id
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_template__pallet_product_id
+msgid "Pallet Product"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_product__pallet_qty_min
+#: model:ir.model.fields,field_description:deltatech_sale_pallet.field_product_template__pallet_qty_min
+msgid "Pallet Qty Min"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_pallet.product_template_form_view
+msgid "Palletizing"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model,name:deltatech_sale_pallet.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model,name:deltatech_sale_pallet.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model,name:deltatech_sale_pallet.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model:ir.model,name:deltatech_sale_pallet.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_sale_pallet
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_pallet.view_move_form
+msgid "Show pallets status"
+msgstr ""

--- a/deltatech_sale_pallet_website/i18n/deltatech_sale_pallet_website.pot
+++ b/deltatech_sale_pallet_website/i18n/deltatech_sale_pallet_website.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_pallet_website
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_pallet_website
+#: model:ir.model.fields,field_description:deltatech_sale_pallet_website.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_pallet_website
+#: model:ir.model.fields,field_description:deltatech_sale_pallet_website.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_pallet_website
+#: model:ir.model,name:deltatech_sale_pallet_website.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_pallet_website
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_pallet_website.show_pallet_price
+msgid "When buying"
+msgstr ""
+
+#. module: deltatech_sale_pallet_website
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_pallet_website.show_pallet_price
+msgid ""
+"units,\n"
+"                    the price is"
+msgstr ""

--- a/deltatech_sale_payment/i18n/deltatech_sale_payment.pot
+++ b/deltatech_sale_payment/i18n/deltatech_sale_payment.pot
@@ -1,0 +1,176 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_payment.view_sale_confirm_payment_form
+msgid "Add"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__amount
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_order__payment_amount
+msgid "Amount Payment"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields.selection,name:deltatech_sale_payment.selection__sale_order__payment_status__authorized
+msgid "Authorized"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_payment.view_sale_confirm_payment_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields.selection,name:deltatech_sale_payment.selection__sale_order__payment_status__cancelled
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_payment.view_sale_confirm_payment_form
+msgid "Confirm"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.actions.act_window,name:deltatech_sale_payment.action_sale_confirm_payment
+msgid "Confirm Payment"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields.selection,name:deltatech_sale_payment.selection__sale_order__payment_status__done
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__id
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields.selection,name:deltatech_sale_payment.selection__sale_order__payment_status__initiated
+msgid "Initiated"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields.selection,name:deltatech_sale_payment.selection__sale_order__payment_status__partial
+msgid "Partial"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_payment.view_order_form
+msgid "Payment"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__payment_date
+msgid "Payment Date"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__payment_method_id
+msgid "Payment Method"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_order__payment_status
+msgid "Payment Status"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_payment.view_sales_order_filter
+msgid "Payment initiated"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#. odoo-python
+#: code:addons/deltatech_sale_payment/wizard/sale_confirm_payment.py:0
+msgid "Please select a sale order"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__provider_id
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_order__provider_id
+msgid "Provider"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model,name:deltatech_sale_payment.model_sale_confirm_payment
+msgid "Sale Confirm Payment"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model,name:deltatech_sale_payment.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#. odoo-python
+#: code:addons/deltatech_sale_payment/wizard/sale_confirm_payment.py:0
+msgid "Then amount must be positive"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields,field_description:deltatech_sale_payment.field_sale_confirm_payment__transaction_id
+msgid "Transaction"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model:ir.model.fields.selection,name:deltatech_sale_payment.selection__sale_order__payment_status__without
+msgid "Without"
+msgstr ""
+
+#. module: deltatech_sale_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_payment.view_sale_confirm_payment_form
+msgid "or"
+msgstr ""

--- a/deltatech_sale_phone/i18n/deltatech_sale_phone.pot
+++ b/deltatech_sale_phone/i18n/deltatech_sale_phone.pot
@@ -1,0 +1,45 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_phone
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_phone
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_phone
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_phone
+#: model:ir.model,name:deltatech_sale_phone.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_sale_phone
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_account_bank_statement_line__partner_phone
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_account_move__partner_phone
+#: model:ir.model.fields,field_description:deltatech_sale_phone.field_sale_order__partner_phone
+msgid "Phone"
+msgstr ""
+
+#. module: deltatech_sale_phone
+#: model:ir.model,name:deltatech_sale_phone.model_sale_order
+msgid "Sales Order"
+msgstr ""

--- a/deltatech_sale_picking_status/i18n/deltatech_sale_picking_status.pot
+++ b/deltatech_sale_picking_status/i18n/deltatech_sale_picking_status.pot
@@ -1,0 +1,59 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_picking_status
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model.fields,field_description:deltatech_sale_picking_status.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_picking_status.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model.fields.selection,name:deltatech_sale_picking_status.selection__sale_order__picking_status__done
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_picking_status.view_sales_order_filter_picking_status
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model.fields,field_description:deltatech_sale_picking_status.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_picking_status.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model.fields.selection,name:deltatech_sale_picking_status.selection__sale_order__picking_status__in_progress
+msgid "In Progress"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_picking_status.view_sales_order_filter_picking_status
+msgid "In progress"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model.fields,field_description:deltatech_sale_picking_status.field_sale_order__picking_status
+msgid "Picking Status"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model,name:deltatech_sale_picking_status.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_picking_status
+#: model:ir.model,name:deltatech_sale_picking_status.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_sale_purchase/i18n/deltatech_sale_purchase.pot
+++ b/deltatech_sale_purchase/i18n/deltatech_sale_purchase.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_purchase
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_purchase
+#: model:ir.model.fields,field_description:deltatech_sale_purchase.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_purchase
+#: model:ir.model.fields,field_description:deltatech_sale_purchase.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_purchase
+#: model:ir.model,name:deltatech_sale_purchase.model_sale_order
+msgid "Sales Order"
+msgstr ""

--- a/deltatech_sale_purchase_requisition/i18n/deltatech_sale_purchase_requisition.pot
+++ b/deltatech_sale_purchase_requisition/i18n/deltatech_sale_purchase_requisition.pot
@@ -1,0 +1,82 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_purchase_requisition
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_purchase_requisition
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_purchase_requisition.view_order_form_inherit_deltatech_requisition
+msgid "Create RFQ"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_purchase_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_purchase_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#. odoo-python
+#: code:addons/deltatech_sale_purchase_requisition/models/sale_order.py:0
+msgid ""
+"No eligible line for purchase (products without purchase_ok or quantity <= "
+"0)."
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model,name:deltatech_sale_purchase_requisition.model_purchase_order
+msgid "Purchase Order"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_sale_order__rfq_ids
+msgid "RFQ"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_sale_order__rfq_count
+msgid "RFQ Count"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_purchase_requisition.view_order_form_inherit_deltatech_requisition
+msgid "RFQs"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model.fields,help:deltatech_sale_purchase_requisition.field_purchase_order__quote_id
+msgid "Related quote from which this RFQ/PO was initiated."
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model.fields,field_description:deltatech_sale_purchase_requisition.field_purchase_order__quote_id
+msgid "Sale Quote"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#: model:ir.model,name:deltatech_sale_purchase_requisition.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_purchase_requisition
+#. odoo-python
+#: code:addons/deltatech_sale_purchase_requisition/models/sale_order.py:0
+msgid "There are no lines on this quotation."
+msgstr ""

--- a/deltatech_sale_qty_available/i18n/deltatech_sale_qty_available.pot
+++ b/deltatech_sale_qty_available/i18n/deltatech_sale_qty_available.pot
@@ -1,0 +1,53 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_qty_available
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_qty_available
+#: model:ir.model.fields,field_description:deltatech_sale_qty_available.field_sale_order_line__qty_available_text
+msgid "Available"
+msgstr ""
+
+#. module: deltatech_sale_qty_available
+#: model:ir.model.fields,field_description:deltatech_sale_qty_available.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_qty_available.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_qty_available
+#: model:ir.model.fields,field_description:deltatech_sale_qty_available.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_qty_available.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_qty_available
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_qty_available.view_sales_order_filter
+msgid "Is Ready"
+msgstr ""
+
+#. module: deltatech_sale_qty_available
+#: model:ir.model.fields,field_description:deltatech_sale_qty_available.field_sale_order__is_ready
+msgid "Is ready"
+msgstr ""
+
+#. module: deltatech_sale_qty_available
+#: model:ir.model,name:deltatech_sale_qty_available.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_qty_available
+#: model:ir.model,name:deltatech_sale_qty_available.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/deltatech_sale_report/i18n/deltatech_sale_report.pot
+++ b/deltatech_sale_report/i18n/deltatech_sale_report.pot
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_report
+#: model:ir.model.fields,field_description:deltatech_sale_report.field_sale_report__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_report
+#: model:ir.model.fields,field_description:deltatech_sale_report.field_sale_report__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_report
+#: model:ir.model.fields,field_description:deltatech_sale_report.field_sale_report__partner_email
+msgid "Partner Email"
+msgstr ""
+
+#. module: deltatech_sale_report
+#: model:ir.model,name:deltatech_sale_report.model_sale_report
+msgid "Sales Analysis Report"
+msgstr ""

--- a/deltatech_sale_return_cause/i18n/deltatech_sale_return_cause.pot
+++ b/deltatech_sale_return_cause/i18n/deltatech_sale_return_cause.pot
@@ -1,0 +1,215 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_return_cause
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__200_warranty
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__200_warranty
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_200_warranty
+msgid "200% warranty"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__b2b_return
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__b2b_return
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_b2b_return
+msgid "B2B Return"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__name
+msgid "Cause"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.actions.server,name:deltatech_sale_return_cause.ir_cron_check_and_update_return_amount_ir_actions_server
+msgid "Check and Update Return Amount"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_report__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__does_not_expect
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__does_not_expect
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_does_not_expect
+msgid "Does not expect the order"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__does_not_fit
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__does_not_fit
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_does_not_fit
+msgid "Does not fit"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__duplicate_order
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__duplicate_order
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_duplicate_order
+msgid "Duplicate order"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__exchange
+msgid "Exchange"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__external_tva_restitution
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__external_tva_restitution
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_external_tva_restitution
+msgid "External TVA Restitution"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_report__id
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__sale_team_mistake
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__sale_team_mistake
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_sale_team_mistake
+msgid "Incorrectly advised by Sales"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__is_return_amount_readonly
+msgid "Is Return Amount Readonly"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__lost_package
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__lost_package
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_lost_package
+msgid "Lost Package"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__not_satisfied
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__not_satisfied
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_not_satisfied
+msgid "Not satisfied with quality"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__ordered_incorrectly
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__ordered_incorrectly
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_ordered_incorrectly
+msgid "Ordered incorrectly by client"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__not_picked
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__not_picked
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_not_picked
+msgid "Package not picked up by client"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__return_amount
+msgid "Return Amount"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__return_cause_id
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_report__return_cause_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_return_cause.view_order_product_search
+msgid "Return Cause"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_return_cause.view_order_product_search
+msgid "Return Cause (Legacy)"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__return_cause_date
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_report__return_cause_date
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_return_cause.view_order_product_search
+msgid "Return Cause Date"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_order__return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_report__return_cause
+msgid "Return Cause(Legacy)"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.actions.act_window,name:deltatech_sale_return_cause.action_sale_return_cause
+#: model:ir.ui.menu,name:deltatech_sale_return_cause.menu_sale_return_cause
+msgid "Return Causes"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model,name:deltatech_sale_return_cause.model_sale_return_cause
+msgid "Sale Return Cause"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model,name:deltatech_sale_return_cause.model_sale_report
+msgid "Sales Analysis Report"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model,name:deltatech_sale_return_cause.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields,field_description:deltatech_sale_return_cause.field_sale_return_cause__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_sale_return_cause
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_order__return_cause__wrong_shipped
+#: model:ir.model.fields.selection,name:deltatech_sale_return_cause.selection__sale_report__return_cause__wrong_shipped
+#: model:sale.return.cause,name:deltatech_sale_return_cause.cause_wrong_shipped
+msgid "Wrongly shipped warehouse"
+msgstr ""

--- a/deltatech_sale_stage/i18n/deltatech_sale_stage.pot
+++ b/deltatech_sale_stage/i18n/deltatech_sale_stage.pot
@@ -1,0 +1,162 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_stage
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__action_id
+msgid "Action"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__canceled
+msgid "Canceled"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__code
+msgid "Code"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__color
+msgid "Color"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__confirmed
+msgid "Confirmed"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__delivered
+msgid "Delivered"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_stock_picking_type__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__id
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_stock_picking_type__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__invoiced
+msgid "Invoiced"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__paid
+msgid "Paid"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order__phase_id
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_stock_picking_type__phase_id
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_stage.view_sales_order_filter
+msgid "Phase"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model,name:deltatech_sale_stage.model_stock_picking_type
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__pre_advice
+msgid "Pre Advice"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__refused
+msgid "Refused"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.actions.act_window,name:deltatech_sale_stage.action_sale_order_phase
+#: model:ir.ui.menu,name:deltatech_sale_stage.menu_sale_order_phase
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_stage.view_sale_order_phase_form
+msgid "Sale Order phase"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model,name:deltatech_sale_stage.model_sale_order_phase
+msgid "SaleOrderPhase"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model,name:deltatech_sale_stage.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__send_email
+msgid "Send Email"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model.fields,field_description:deltatech_sale_stage.field_sale_order_phase__shipped
+msgid "Shipped"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#. odoo-python
+#: code:addons/deltatech_sale_stage/models/sale.py:0
+msgid "The order was not invoiced"
+msgstr ""
+
+#. module: deltatech_sale_stage
+#: model:ir.model,name:deltatech_sale_stage.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_sale_team/i18n/deltatech_sale_team.pot
+++ b/deltatech_sale_team/i18n/deltatech_sale_team.pot
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields,field_description:deltatech_sale_team.field_crm_team__warehouse_id
+msgid "Default Warehouse"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields,field_description:deltatech_sale_team.field_crm_team__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_team.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields,field_description:deltatech_sale_team.field_crm_team__id
+#: model:ir.model.fields,field_description:deltatech_sale_team.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields.selection,name:deltatech_sale_team.selection__crm_team__team_type__sales
+msgid "Sales"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model,name:deltatech_sale_team.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model,name:deltatech_sale_team.model_crm_team
+msgid "Sales Team"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:res.groups,name:deltatech_sale_team.group_sale_team_manager
+msgid "Team Manager"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields,field_description:deltatech_sale_team.field_crm_team__team_type
+msgid "Team Type"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields,help:deltatech_sale_team.field_crm_team__team_type
+msgid ""
+"The type of this channel, it will define the resources this channel uses."
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:ir.model.fields.selection,name:deltatech_sale_team.selection__crm_team__team_type__website
+msgid "Website"
+msgstr ""
+
+#. module: deltatech_sale_team
+#: model:res.groups,comment:deltatech_sale_team.group_sale_team_manager
+msgid ""
+"the user will have access to the documents of the sales team he/she belongs "
+"to."
+msgstr ""

--- a/deltatech_sale_xls/i18n/deltatech_sale_xls.pot
+++ b/deltatech_sale_xls/i18n/deltatech_sale_xls.pot
@@ -1,0 +1,43 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_xls
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_xls
+#: model_terms:ir.ui.view,arch_db:deltatech_sale_xls.sale_order_form
+msgid "<span>Order lines</span>"
+msgstr ""
+
+#. module: deltatech_sale_xls
+#: model:ir.model.fields,field_description:deltatech_sale_xls.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_xls.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sale_xls
+#: model:ir.model.fields,field_description:deltatech_sale_xls.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_xls.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sale_xls
+#: model:ir.model,name:deltatech_sale_xls.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sale_xls
+#: model:ir.model,name:deltatech_sale_xls.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""

--- a/deltatech_saleorder_pickup_list/i18n/deltatech_saleorder_pickup_list.pot
+++ b/deltatech_saleorder_pickup_list/i18n/deltatech_saleorder_pickup_list.pot
@@ -1,0 +1,108 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_saleorder_pickup_list
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<span>Pro-Forma Invoice #</span>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong class=\"mr16\">Subtotal</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong>Expiration Date:</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong>Payment Terms:</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong>Quotation Date:</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong>Salesperson:</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong>Shipping address:</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "<strong>Your Reference:</strong>"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Cutie"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Description"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Invoicing address:"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid ""
+"Invoicing and shipping\n"
+"                        address:"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model:ir.actions.report,name:deltatech_saleorder_pickup_list.action_report_saleorder_pickup_list
+msgid "Lista de ridicare"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Order #"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Quotation #"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Raft"
+msgstr ""
+
+#. module: deltatech_saleorder_pickup_list
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_pickup_list.report_saleorder_document_pickup_list
+msgid "Rând"
+msgstr ""

--- a/deltatech_saleorder_search/i18n/deltatech_saleorder_search.pot
+++ b/deltatech_saleorder_search/i18n/deltatech_saleorder_search.pot
@@ -1,0 +1,26 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_saleorder_search
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_saleorder_search
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_search.view_sales_order_filter
+msgid "E-mail"
+msgstr ""
+
+#. module: deltatech_saleorder_search
+#: model_terms:ir.ui.view,arch_db:deltatech_saleorder_search.view_sales_order_filter
+msgid "Phone"
+msgstr ""

--- a/deltatech_sms/i18n/deltatech_sms.pot
+++ b/deltatech_sms/i18n/deltatech_sms.pot
@@ -1,0 +1,63 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sms
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__display_name
+#: model:ir.model.fields,field_description:deltatech_sms.field_sms_sms__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model,name:deltatech_sms.model_iap_account
+msgid "IAP Account"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__id
+#: model:ir.model.fields,field_description:deltatech_sms.field_sms_sms__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model,name:deltatech_sms.model_sms_sms
+msgid "Outgoing SMS"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model.fields.selection,name:deltatech_sms.selection__iap_account__sms_provider__4pay
+msgid "SMS 4Pay"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__sms_gateway
+msgid "SMS Gateway"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__sms_provider
+msgid "SMS Provider"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__sms_secret
+msgid "SMS Secret"
+msgstr ""
+
+#. module: deltatech_sms
+#: model:ir.model.fields.selection,name:deltatech_sms.selection__iap_account__sms_provider__wapi
+msgid "SMS Wapi"
+msgstr ""

--- a/deltatech_sms_sale/i18n/deltatech_sms_sale.pot
+++ b/deltatech_sms_sale/i18n/deltatech_sms_sale.pot
@@ -1,0 +1,137 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sms_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sms_sale
+#: model:sms.template,body:deltatech_sms_sale.sms_template_data_sale_order_confirm
+msgid ""
+"\n"
+"                {{ (object.company_id.name + ': We are glad to inform you that your order n° ' + object.name + ' has been confirmed.' ) }}\n"
+"            "
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:sms.template,body:deltatech_sms_sale.sms_template_data_sale_order_post
+msgid ""
+"\n"
+"                {{ (object.company_id.name + ': We are glad to inform you that your order n° ' + object.name + ' has been posted.' ) }}\n"
+"            "
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model,name:deltatech_sms_sale.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model,name:deltatech_sms_sale.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_company__display_name
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_company__id
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_company__sale_order_sms_confirm
+msgid "SMS Confirm"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_company__sale_order_sms_post
+msgid "SMS Post"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_config_settings__sale_order_sms_confirm
+#: model_terms:ir.ui.view,arch_db:deltatech_sms_sale.res_config_settings_view_form_sale
+msgid "SMS Sale Order Confirm"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_config_settings__sale_order_sms_post
+#: model_terms:ir.ui.view,arch_db:deltatech_sms_sale.res_config_settings_view_form_sale
+msgid "SMS Sale Order Post"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_sms_sale.res_config_settings_view_form_sale
+msgid "SMS Template"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_company__sale_order_sms_confirm_template_id
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_config_settings__sale_order_sms_confirm_template_id
+msgid "SMS Template Order Confirmed"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_company__sale_order_sms_post_template_id
+#: model:ir.model.fields,field_description:deltatech_sms_sale.field_res_config_settings__sale_order_sms_post_template_id
+msgid "SMS Template Order Post"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,help:deltatech_sms_sale.field_res_company__sale_order_sms_confirm_template_id
+#: model:ir.model.fields,help:deltatech_sms_sale.field_res_config_settings__sale_order_sms_confirm_template_id
+msgid "SMS sent to the customer once the sale order is confirmed."
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model.fields,help:deltatech_sms_sale.field_res_company__sale_order_sms_post_template_id
+#: model:ir.model.fields,help:deltatech_sms_sale.field_res_config_settings__sale_order_sms_post_template_id
+msgid "SMS sent to the customer once the sale order is posted from website."
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:sms.template,name:deltatech_sms_sale.sms_template_data_sale_order_post
+msgid "Sale Order Post: Send by SMS Text Message"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:sms.template,name:deltatech_sms_sale.sms_template_data_sale_order_confirm
+msgid "Sale Order confirm: Send by SMS Text Message"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model:ir.model,name:deltatech_sms_sale.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_sms_sale.res_config_settings_view_form_sale
+msgid "Send an automatic SMS Text Message when the Sale Order is confirmed."
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_sms_sale.res_config_settings_view_form_sale
+msgid "Send an automatic SMS Text Message when the Sale Order is posted."
+msgstr ""
+
+#. module: deltatech_sms_sale
+#: model_terms:ir.ui.view,arch_db:deltatech_sms_sale.res_config_settings_view_form_sale
+msgid "Values set here are company-specific."
+msgstr ""

--- a/deltatech_stock_account/i18n/deltatech_stock_account.pot
+++ b/deltatech_stock_account/i18n/deltatech_stock_account.pot
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_account
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_account
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_stock_picking__amount
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:res.groups,name:deltatech_stock_account.group_change_product_price
+msgid "Change Product Price"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_stock_picking__currency_id
+msgid "Currency"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_product_category__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_product_category__id
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_stock_account.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.model,name:deltatech_stock_account.model_product_category
+msgid "Product Category"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.model,name:deltatech_stock_account.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.actions.server,name:deltatech_stock_account.action_product_category_propagate
+msgid "Propagate Accounts"
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model:ir.model,name:deltatech_stock_account.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_stock_account
+#. odoo-python
+#: code:addons/deltatech_stock_account/models/product.py:0
+msgid "You are not allowed to change the cost price of a product."
+msgstr ""
+
+#. module: deltatech_stock_account
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_account.vpicktree
+msgid "amount"
+msgstr ""

--- a/deltatech_stock_close/i18n/deltatech_stock_close.pot
+++ b/deltatech_stock_close/i18n/deltatech_stock_close.pot
@@ -1,0 +1,62 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_close
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_close
+#: model:ir.model.fields,field_description:deltatech_stock_close.field_l10n_ro_stock_storage_sheet__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_close.field_stock_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model.fields,field_description:deltatech_stock_close.field_l10n_ro_stock_storage_sheet__id
+#: model:ir.model.fields,field_description:deltatech_stock_close.field_stock_move__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model.fields,field_description:deltatech_stock_close.field_l10n_ro_stock_storage_sheet__only_active
+msgid "Only Active"
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model,name:deltatech_stock_close.model_stock_move
+msgid "Stock Move"
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model,name:deltatech_stock_close.model_l10n_ro_stock_storage_sheet
+msgid "StorageSheet"
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model.fields,field_description:deltatech_stock_close.field_stock_move__l10n_ro_valuation_active
+msgid "Valuation Active"
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model.fields,help:deltatech_stock_close.field_l10n_ro_stock_storage_sheet__only_active
+msgid ""
+"When set, the storage sheet only includes stock moves whose valuation is "
+"still active (not closed)."
+msgstr ""
+
+#. module: deltatech_stock_close
+#: model:ir.model.fields,help:deltatech_stock_close.field_stock_move__l10n_ro_valuation_active
+msgid ""
+"When unset, this stock move valuation is considered closed and is excluded "
+"from the storage sheet when the 'Only active' option is used."
+msgstr ""

--- a/deltatech_stock_count_zero/i18n/deltatech_stock_count_zero.pot
+++ b/deltatech_stock_count_zero/i18n/deltatech_stock_count_zero.pot
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_count_zero
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_count_zero
+#: model:ir.model.fields,field_description:deltatech_stock_count_zero.field_stock_request_count__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_count_zero
+#: model:ir.model.fields,field_description:deltatech_stock_count_zero.field_stock_request_count__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_count_zero
+#: model:ir.model.fields,field_description:deltatech_stock_count_zero.field_stock_request_count__set_count_zero
+msgid "Set Count to Zero"
+msgstr ""
+
+#. module: deltatech_stock_count_zero
+#: model:ir.model,name:deltatech_stock_count_zero.model_stock_request_count
+msgid "Stock Request an Inventory Count"
+msgstr ""

--- a/deltatech_stock_delivery/i18n/deltatech_stock_delivery.pot
+++ b/deltatech_stock_delivery/i18n/deltatech_stock_delivery.pot
@@ -1,0 +1,47 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_delivery
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_delivery
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_delivery.invoice_form
+msgid "<span class=\"o_stat_text\">Delivery</span>"
+msgstr ""
+
+#. module: deltatech_stock_delivery
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_delivery.invoice_form
+msgid "<span class=\"o_stat_text\">Reception</span>"
+msgstr ""
+
+#. module: deltatech_stock_delivery
+#: model:ir.model.fields,field_description:deltatech_stock_delivery.field_account_move__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_delivery
+#: model:ir.model.fields,field_description:deltatech_stock_delivery.field_account_move__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_delivery
+#: model:ir.model,name:deltatech_stock_delivery.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_stock_delivery
+#. odoo-python
+#: code:addons/deltatech_stock_delivery/models/account_invoice.py:0
+msgid "This invoice has no deliveries"
+msgstr ""

--- a/deltatech_stock_inventory/i18n/deltatech_stock_inventory.pot
+++ b/deltatech_stock_inventory/i18n/deltatech_stock_inventory.pot
@@ -1,0 +1,1210 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_inventory
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid "%s (copy)"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+msgid "<span class=\"o_stat_text\">On Hand</span>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_total
+msgid "<strong>After:</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Amount</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_total
+msgid "<strong>Before:</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header_location
+msgid "<strong>Date</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Difference Quantity</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header_location
+msgid "<strong>Inventory</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header_location
+msgid "<strong>Location</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Minus Amount</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Package</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Plus Amount</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Product</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Production Lot</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Real Quantity</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Theoretical Quantity</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_total
+msgid "<strong>Total general</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_header
+msgid "<strong>Unit of measure</strong>"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_warehouse__kanban_display_stock__all
+msgid "All"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/wizard/stock_inventory_merge.py:0
+msgid "All inventories must be in done state to be merged"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:res.groups,name:deltatech_stock_inventory.group_change_inventory_date
+msgid "Allow to change inventory date"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__prefill_counted_quantity
+msgid ""
+"Allows to start with a pre-filled counted quantity for each lines or with "
+"all counted quantities set to zero."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__start_empty
+msgid "Allows to start with an empty inventory."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.actions.act_window,help:deltatech_stock_inventory.action_inventory_form
+msgid ""
+"Barcode scanner can be activated via inventory settings.\n"
+"                Manual inventory adjustments can also be performed and pre-filled with\n"
+"                suggested counted quantity."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__can_archive_svl
+msgid "Can Archive Svl"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:res.groups,name:deltatech_stock_inventory.group_merge_inventory
+msgid "Can merge inventory documents"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:res.groups,name:deltatech_stock_inventory.group_view_inventory_button
+msgid "Can update quantities"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_confirm_inventory_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_inventory_merge_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Cancel Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_inventory__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__loc_case
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__loc_case
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_template_property_form
+msgid "Case"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__loc_case
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__loc_case
+msgid "Case Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__categ_id
+msgid "Category"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_confirm_inventory_form
+msgid "Change"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__archive_svl
+msgid "Clear old valuation"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__company_id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__company_id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_confirm_inventory_form
+msgid "Confirm"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.act_window,name:deltatech_stock_inventory.action_stock_confirm_inventory
+msgid "Confirm Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+msgid "Confirm Stock"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Continue Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.stock_inventory_line_tree
+msgid "Counted"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__prefill_counted_quantity
+msgid "Counted Quantities"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__product_qty
+msgid "Counted Quantity"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__move_ids
+msgid "Created Moves"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__create_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__create_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__create_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__create_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__create_uid
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__create_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__create_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__create_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__create_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__date
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_inventory__prefill_counted_quantity__counted
+msgid "Default to stock on hand"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_inventory__prefill_counted_quantity__zero
+msgid "Default to zero"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_warehouse__kanban_display_stock__detailed
+msgid "Detailed"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__difference_qty
+msgid "Difference"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_replenish__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_adjustment_name__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_location__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_move__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_return_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_warehouse__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_res_config_settings__group_show_manual_location_fields
+msgid ""
+"Display manual location fields on products and inventory (Rack/Row/Shelf/Case).\n"
+"Recommended when you are NOT using putaway rules."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_warehouse__kanban_display_stock
+msgid "Display stock in kanban view"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_inventory__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__start_empty
+msgid "Empty Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory_line__product_tracking
+msgid "Ensure the traceability of a storable product in your warehouse."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/product.py:0
+msgid "FREE STOCK"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_replenish__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_adjustment_name__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_location__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_move__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_return_picking__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_warehouse__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__message_has_error
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__date
+msgid ""
+"If the inventory adjustment is not validated, date at which the theoretical quantities have been checked.\n"
+"If the inventory adjustment is validated, date at which the inventory adjustment has been validated."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid ""
+"If you cancel this inventory adjustment, all its inventory adjustment lines "
+"will be lost. Are you sure you want to discard it ?"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_inventory__state__confirm
+msgid "In Progress"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__exhausted
+msgid "Include Exhausted Products"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__exhausted
+msgid "Include also products with quantity of 0"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory_line__difference_qty
+msgid ""
+"Indicates the gap between the product's theoretical quantity and its newest "
+"quantity."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__line_ids
+msgid "Inventories"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.report,name:deltatech_stock_inventory.action_report_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__inventory_id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__inventory_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+msgid "Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/wizard/stock_request_count.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Inventory Adjustment"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_inventory_adjustment_name
+msgid "Inventory Adjustment Reference / Reason"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__inventory_date
+msgid "Inventory Date"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.report,name:deltatech_stock_inventory.action_report_inventory_diff
+msgid "Inventory Diff"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_move__inventory_id
+msgid "Inventory Document"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.act_window,name:deltatech_stock_inventory.action_inventory_form
+#: model:ir.ui.menu,name:deltatech_stock_inventory.menu_action_inventory_form
+msgid "Inventory Documents"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_inventory_line
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__inventory_line_id
+msgid "Inventory Line"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid "Inventory Lines"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__inventory_note
+msgid "Inventory Note"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__is_inventory_ok
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__is_inventory_ok
+msgid "Inventory OK"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.report,name:deltatech_stock_inventory.action_report_inventory_position
+msgid "Inventory Position"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_adjustment_name__inventory_adjustment_name
+msgid "Inventory Reason"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__is_editable
+msgid "Is Editable"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__is_ok
+msgid "Is Ok"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__is_price_editable
+msgid "Is Price Editable"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_warehouse__kanban_display_stock
+msgid "Kanban Display Stock"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__last_inventory_id
+msgid "Last Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__last_inventory_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__last_inventory_date
+msgid "Last Inventory Date"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__write_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__write_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__write_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__write_uid
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__write_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__write_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__write_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__write_date
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory_line__inventory_date
+msgid "Last date at which the On Hand Quantity has been computed."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__location_id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__location_id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__location_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_template_property_form
+msgid "Location"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__location_ids
+msgid "Locations"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__prod_lot_id
+msgid "Lot/Serial Number"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_warehouse__kanban_display_stock__main
+msgid "Main Location"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_inventory_merge_form
+msgid "Merge"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.act_window,name:deltatech_stock_inventory.action_stock_inventory_merge
+msgid "Merge Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_inventory_merge_form
+msgid "Merge inventories in"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/wizard/stock_inventory_merge.py:0
+msgid "Merged inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.server,name:deltatech_stock_inventory.move_product_to_location
+msgid "Move product to location"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_merge__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock.py:0
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+#: code:addons/deltatech_stock_inventory/models/stock_quant.py:0
+msgid "New"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "New inventory for Not Ok"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid "No lines"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/product.py:0
+msgid "No putaway rule found for %s"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__note
+msgid "Note"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.stock_inventory_line_tree
+msgid "On Hand"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__partner_id
+msgid "Owner"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__package_id
+msgid "Pack"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.stock_inventory_line_tree
+msgid "Package"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__standard_price
+msgid "Price"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Print Count Sheet"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_product_template
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__product_id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__product_id
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Product Moves"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+msgid "Product Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_product_replenish
+msgid "Product Replenish"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__product_tmpl_id
+msgid "Product Tmpl"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__product_uom_id
+msgid "Product Unit of Measure"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_product_warehouse_location
+msgid "Product Warehouse Location"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.act_window,name:deltatech_stock_inventory.action_product_template_warehouse
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__product_ids
+msgid "Products"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_confirm_inventory__qty_available
+msgid "Qty Available"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__quant_id
+msgid "Quant"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_location__restricted_stock
+msgid ""
+"Quantities stored in this location (and its children) are shown as "
+"unavailable in the detailed kanban stock display and are excluded from the "
+"free stock."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_quant.py:0
+msgid "Quantity %(quant)s %(location) at location was confirmed."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__outdated
+msgid "Quantity outdated"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_quant
+msgid "Quants"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__loc_rack
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__loc_rack
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__filterbyrack
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_template_property_form
+msgid "Rack"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__loc_rack
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__loc_rack
+msgid "Rack Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__rating_ids
+msgid "Ratings"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.server,name:deltatech_stock_inventory.model_stock_inventory_line_action_recompute_quantity
+msgid "Recompute On Hand Quantity"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.stock_inventory_line_tree
+msgid "Refresh quantity"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Remove Not Ok"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_location__restricted_stock
+msgid "Restricted Stock"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_return_picking
+msgid "Return Picking"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__loc_row
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__loc_row
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_template_property_form
+msgid "Row"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__loc_row
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__loc_row
+msgid "Row Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.actions.server,name:deltatech_stock_inventory.model_stock_inventory_line_action_reset_product_qty
+msgid "Set counted quantities to 0"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Set to Draft"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__loc_shelf
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__loc_shelf
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_template_property_form
+msgid "Shelf"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__loc_shelf
+msgid "Shelf Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Show Lines"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.res_config_settings_view_form_deltatech_stock_inventory
+msgid ""
+"Show Rack/Row/Shelf/Case fields on products and inventory. Enable this when "
+"you do not use putaway (storage) rules."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.res_config_settings_view_form_deltatech_stock_inventory
+msgid "Show manual location fields"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_res_config_settings__group_show_manual_location_fields
+#: model:res.groups,name:deltatech_stock_inventory.group_show_manual_location_fields
+msgid "Show manual location fields (Rack/Row/Shelf/Case)"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid "Some products have not been moved. Please check the inventory moves."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__product_ids
+msgid "Specify Products to focus your inventory on particular Products."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Start Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__state
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__state
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_product_template_warehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_template_property_form
+msgid "Stock"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_confirm_inventory
+msgid "Stock Confirm Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_diff
+msgid "Stock Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_inventory_merge
+msgid "Stock Inventory Merge Wizard"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.report_inventory_position
+msgid "Stock Inventory by position"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_move
+msgid "Stock Move"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__warehouse_stock
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__warehouse_stock
+msgid "Stock/WH"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory_line__is_editable
+msgid "Technical field to restrict editing."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory_line__is_price_editable
+msgid "Technical field to restrict price editing."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_quant.py:0
+msgid "The selected items are in different inventories"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__theoretical_qty
+msgid "Theoretical Quantity"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid ""
+"There is already one inventory adjustment line for this product, you should "
+"rather modify this one instead of creating a new one."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory_line__product_tracking
+msgid "Tracking"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid "Unsupported search on %s outside of an Inventory Adjustment"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.stock_inventory_line_tree
+msgid "UoM"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/wizard/stock_inventory_merge.py:0
+msgid "User %(user_name)s has merged inventories %(inventory_names)s"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "Validate Inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields.selection,name:deltatech_stock_inventory.selection__stock_inventory__state__done
+msgid "Validated"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.actions.act_window,help:deltatech_stock_inventory.action_inventory_form
+msgid "Want to speed up your inventory counts? Try our Barcode app"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model,name:deltatech_stock_inventory.model_stock_warehouse
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_warehouse_location__warehouse_id
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__warehouse_loc_ids
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_template__warehouse_loc_ids
+msgid "Warehouse Loc"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.ui.menu,name:deltatech_stock_inventory.menu_product_template_warehouse
+msgid "Warehouse Products"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.constraint,message:deltatech_stock_inventory.constraint_product_warehouse_location_product_product_uniq
+msgid "Warehouse must be unique per product!"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_inventory__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model:ir.model.fields,help:deltatech_stock_inventory.field_stock_inventory__website_message_ids
+msgid "Website communication history"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid "You can only adjust storable products."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid ""
+"You can't validate the inventory '%s', maybe this inventory has been already"
+" validated or isn't ready."
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_inventory.py:0
+msgid ""
+"You cannot set a negative product quantity in an inventory line:\n"
+"\t%(product_name)s - qty: %(product_qty)s"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/wizard/stock_inventory_merge.py:0
+msgid "You must select at least two inventory documents"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#. odoo-python
+#: code:addons/deltatech_stock_inventory/models/stock_quant.py:0
+msgid "Your user cannot update product quantities"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_inventory_form
+msgid "e.g. Annual inventory"
+msgstr ""
+
+#. module: deltatech_stock_inventory
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_confirm_inventory_form
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory.view_stock_inventory_merge_form
+msgid "or"
+msgstr ""

--- a/deltatech_stock_inventory_product_display/i18n/deltatech_stock_inventory_product_display.pot
+++ b/deltatech_stock_inventory_product_display/i18n/deltatech_stock_inventory_product_display.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_inventory_product_display
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_inventory_product_display
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory_product_display.invoice_view_form_saleorder_button
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_inventory_product_display.sale_order_view_form
+msgid "<span>Products</span>"
+msgstr ""
+
+#. module: deltatech_stock_inventory_product_display
+#: model:ir.model.fields,field_description:deltatech_stock_inventory_product_display.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_inventory_product_display.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_inventory_product_display
+#: model:ir.model.fields,field_description:deltatech_stock_inventory_product_display.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_stock_inventory_product_display.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_inventory_product_display
+#: model:ir.model,name:deltatech_stock_inventory_product_display.model_account_move
+msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_stock_inventory_product_display
+#: model:ir.model,name:deltatech_stock_inventory_product_display.model_sale_order
+msgid "Sales Order"
+msgstr ""

--- a/deltatech_stock_negative/i18n/deltatech_stock_negative.pot
+++ b/deltatech_stock_negative/i18n/deltatech_stock_negative.pot
@@ -1,0 +1,102 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_negative
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_location__allow_negative_stock
+msgid "Allow Negative Stock"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,help:deltatech_stock_negative.field_res_company__no_negative_stock
+#: model:ir.model.fields,help:deltatech_stock_negative.field_res_config_settings__no_negative_stock
+msgid "Allows you to prohibit negative stock quantities."
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_location__check_serial_no
+msgid "Check Serial No."
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model,name:deltatech_stock_negative.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model,name:deltatech_stock_negative.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_company__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_location__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_quant__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_company__id
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_location__id
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_stock_quant__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,help:deltatech_stock_negative.field_stock_location__check_serial_no
+msgid ""
+"If checked, the serial numbers will be checked on the moves and an error "
+"will be raised if the serial number is reserved on another move or is "
+"unavailable."
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model,name:deltatech_stock_negative.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_company__no_negative_stock
+#: model:ir.model.fields,field_description:deltatech_stock_negative.field_res_config_settings__no_negative_stock
+msgid "No negative stock"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_negative.res_config_settings_view_form
+msgid "No negative stocks are allowed"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#: model:ir.model,name:deltatech_stock_negative.model_stock_quant
+msgid "Quants"
+msgstr ""
+
+#. module: deltatech_stock_negative
+#. odoo-python
+#: code:addons/deltatech_stock_negative/models/stock.py:0
+msgid "You cannot search for available quantity across several companies."
+msgstr ""
+
+#. module: deltatech_stock_negative
+#. odoo-python
+#: code:addons/deltatech_stock_negative/models/stock.py:0
+msgid ""
+"You have chosen to avoid negative stock. %(lot_qty)s pieces of "
+"%(product_name)s are remaining in location %(location_name)s. Please adjust "
+"your quantities or correct your stock with an inventory adjustment."
+msgstr ""

--- a/deltatech_stock_picking_activity_report/i18n/deltatech_stock_picking_activity_report.pot
+++ b/deltatech_stock_picking_activity_report/i18n/deltatech_stock_picking_activity_report.pot
@@ -1,0 +1,210 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_picking_activity_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__awb_generated
+msgid "AWB Generated"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__activity_log
+msgid "Activity Log"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_form
+msgid "Activity Record"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.ui.menu,name:deltatech_stock_picking_activity_report.menu_stock_picking_activity_record
+msgid "Activity Records"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_form
+msgid "Basic Information"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields.selection,name:deltatech_stock_picking_activity_report.selection__stock_picking_activity_record__state__cancel
+msgid "Cancelled"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__change_date
+msgid "Change Date"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__chatter_message
+msgid "Chatter Message"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__chatter_message_count
+msgid "Chatter Message Count"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields.selection,name:deltatech_stock_picking_activity_report.selection__stock_picking_activity_record__state__done
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields.selection,name:deltatech_stock_picking_activity_report.selection__stock_picking_activity_record__state__draft
+msgid "Draft"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__entry_product_number
+msgid "Entry Product Number"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__exit_product_number
+msgid "Exit Product Number"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__has_validated
+msgid "Has Validated"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking__id
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__internal_product_number
+msgid "Internal Product Number"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_form
+msgid "Log"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__picking_id
+msgid "Picking"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.actions.act_window,name:deltatech_stock_picking_activity_report.action_stock_picking_activity_record
+msgid "Picking Activity Records"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields.selection,name:deltatech_stock_picking_activity_report.selection__stock_picking_activity_record__state__assigned
+msgid "Ready"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__state
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "State"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model,name:deltatech_stock_picking_activity_report.model_stock_picking_activity_record
+msgid "Stock Picking Activity Record"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "This Month"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "This Year"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "Today"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_form
+msgid "Tracked Events"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model,name:deltatech_stock_picking_activity_report.model_stock_picking
+msgid "Transfer"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__user_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "User"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields,field_description:deltatech_stock_picking_activity_report.field_stock_picking_activity_record__has_validated_count
+msgid "Validated Count"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields.selection,name:deltatech_stock_picking_activity_report.selection__stock_picking_activity_record__state__confirmed
+msgid "Waiting"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model:ir.model.fields.selection,name:deltatech_stock_picking_activity_report.selection__stock_picking_activity_record__state__waiting
+msgid "Waiting Another Operation"
+msgstr ""
+
+#. module: deltatech_stock_picking_activity_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_picking_activity_report.view_stock_picking_activity_record_search
+msgid "Yesterday"
+msgstr ""

--- a/deltatech_stock_removal_priority/i18n/deltatech_stock_removal_priority.pot
+++ b/deltatech_stock_removal_priority/i18n/deltatech_stock_removal_priority.pot
@@ -1,0 +1,53 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_removal_priority
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_removal_priority
+#: model:ir.model.fields,field_description:deltatech_stock_removal_priority.field_stock_putaway_rule__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_removal_priority.field_stock_quant__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_removal_priority
+#: model:ir.model.fields,field_description:deltatech_stock_removal_priority.field_stock_putaway_rule__id
+#: model:ir.model.fields,field_description:deltatech_stock_removal_priority.field_stock_quant__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_removal_priority
+#: model:product.removal,name:deltatech_stock_removal_priority.removal_priority
+msgid "Priority"
+msgstr ""
+
+#. module: deltatech_stock_removal_priority
+#: model:ir.model,name:deltatech_stock_removal_priority.model_stock_putaway_rule
+msgid "Putaway Rule"
+msgstr ""
+
+#. module: deltatech_stock_removal_priority
+#: model:ir.model,name:deltatech_stock_removal_priority.model_stock_quant
+msgid "Quants"
+msgstr ""
+
+#. module: deltatech_stock_removal_priority
+#: model:ir.model.fields,field_description:deltatech_stock_removal_priority.field_stock_quant__removal_priority
+msgid "Removal Priority"
+msgstr ""
+
+#. module: deltatech_stock_removal_priority
+#: model:product.removal,method:deltatech_stock_removal_priority.removal_priority
+msgid "priority"
+msgstr ""

--- a/deltatech_stock_report/i18n/deltatech_stock_report.pot
+++ b/deltatech_stock_report/i18n/deltatech_stock_report.pot
@@ -1,0 +1,161 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_report
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__amount
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_tree
+msgid "Amount"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__categ_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Category"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__commercial_partner_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Commercial Entity"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__company_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__date
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Date"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Incoming"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Internal"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__location_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Location"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__location_dest_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Location Destination"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Outgoing"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__partner_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__picking_id
+msgid "Picking"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.ui.menu,name:deltatech_stock_report.menu_stock_picking_report_tree
+msgid "Picking Analysis"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.actions.act_window,name:deltatech_stock_report.action_stock_picking_report
+msgid "Picking Report"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__picking_type_id
+msgid "Picking Type"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__picking_type_code
+msgid "Picking Type Code"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Picking type"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__price
+msgid "Price Unit"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__product_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__product_qty
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_tree
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_report.view_stock_picking_report_filter
+msgid "Search"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model,name:deltatech_stock_report.model_stock_picking_report
+msgid "Stock picking report"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model_terms:ir.actions.act_window,help:deltatech_stock_report.action_stock_picking_report
+msgid "This reporting allows you to analysis stock pickings."
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__product_uom
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: deltatech_stock_report
+#: model:ir.model.fields,field_description:deltatech_stock_report.field_stock_picking_report__product_weight
+msgid "Weight"
+msgstr ""

--- a/deltatech_stock_reseller/i18n/deltatech_stock_reseller.pot
+++ b/deltatech_stock_reseller/i18n/deltatech_stock_reseller.pot
@@ -1,0 +1,217 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_stock_reseller
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__stock_threshold_1
+msgid "1st threshold"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__stock_threshold_1_text
+msgid "1st threshold text"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__stock_threshold_2
+msgid "2nd threshold"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__stock_threshold_2_text
+msgid "2nd threshold text"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__stock_no_threshold_text
+msgid "Above 2nd threshold text"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_reseller.view_stock_quant_report_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_reseller.view_stock_quant_report_form
+msgid "Cancel"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_reseller.view_stock_quant_report_report_filter
+msgid "Category of Product"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__create_uid
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__create_date
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,help:deltatech_stock_reseller.field_stock_quant_report_value__product_uom_id
+msgid "Default unit of measure used for all stock operations."
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__description
+msgid "Description"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__display_name
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__id
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__categ_id
+msgid "Internal Category"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__write_uid
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__write_date
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__lines_ids
+msgid "Lines"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__list_currency_id
+msgid "List Currency"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__list_price
+msgid "List Price"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.actions.act_window,name:deltatech_stock_reseller.action_stock_quant_report
+#: model:ir.ui.menu,name:deltatech_stock_reseller.menu_stock_quant_report
+msgid "Location Stock"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.actions.act_window,name:deltatech_stock_reseller.action_stock_quant_report_value
+msgid "Location Stock Quant Report"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__partner_id
+msgid "Partner"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__product_id
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_reseller.view_stock_quant_report_report_filter
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__qty_text
+msgid "Qty Text"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__qty
+msgid "Quantity"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,help:deltatech_stock_reseller.field_stock_quant_report_value__qty
+msgid ""
+"Quantity of products in this quant, in the default unit of measure of the "
+"product"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__refresh_report
+msgid "Refresh Report"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__report_id
+msgid "Report"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__reseller_currency_id
+msgid "Reseller Currency"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__pricelist_id
+msgid "Reseller Price List"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__price_reseller
+msgid "Reseller price"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_reseller.view_stock_quant_report_report_filter
+msgid "Search"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__show_thresholds
+msgid "Show text instead of stock"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report__location_id
+msgid "Source Location"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model,name:deltatech_stock_reseller.model_stock_quant_report
+#: model:ir.model,name:deltatech_stock_reseller.model_stock_quant_report_value
+msgid "Stock Quant Report"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model:ir.model.fields,field_description:deltatech_stock_reseller.field_stock_quant_report_value__product_uom_id
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: deltatech_stock_reseller
+#: model_terms:ir.ui.view,arch_db:deltatech_stock_reseller.view_stock_quant_report_form
+msgid "or"
+msgstr ""

--- a/deltatech_tc/i18n/deltatech_tc.pot
+++ b/deltatech_tc/i18n/deltatech_tc.pot
@@ -1,0 +1,319 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_tc
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_tc
+#. odoo-python
+#: code:addons/deltatech_tc/models/deltatech_tc_station.py:0
+msgid "%(name)s sent a manual heartbeat."
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__api_key
+msgid "API Key"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "Archived"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid ""
+"Are you sure? Terrabit Connect will need to be reconfigured with the new "
+"key."
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields.selection,name:deltatech_tc.selection__deltatech_tc_job__state__claimed
+msgid "Claimed"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__claimed_at
+msgid "Claimed At"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,help:deltatech_tc.field_deltatech_tc_station__features
+msgid ""
+"Comma-separated list of features enabled on the station (reported at "
+"heartbeat)."
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__company_id
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__company_id
+msgid "Company"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__create_uid
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__create_date
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__display_name
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields.selection,name:deltatech_tc.selection__deltatech_tc_job__state__done
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_search
+msgid "Done"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__done_at
+msgid "Done At"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "Download config"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__error
+#: model:ir.model.fields.selection,name:deltatech_tc.selection__deltatech_tc_job__state__error
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_form
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_search
+msgid "Error"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__features
+msgid "Features"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__id
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__job_ids
+msgid "Job"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__job_count
+msgid "Job Count"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__job_type
+msgid "Job Type"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,help:deltatech_tc.field_deltatech_tc_job__payload
+msgid "Job parameters, JSON (e.g. {\"zile\": 30} or {\"id\": \"...\"})."
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.ui.menu,name:deltatech_tc.menu_deltatech_tc_job
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "Jobs"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__last_seen
+msgid "Last Seen"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__write_uid
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__write_date
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:res.groups,name:deltatech_tc.group_deltatech_tc_manager
+msgid "Manager"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__name
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.actions.act_window,help:deltatech_tc.action_deltatech_tc_station
+msgid "No Terrabit Connect station registered"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__note
+msgid "Note"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "Notes (location, responsible, token...)"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__os
+msgid "Operating System"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__payload
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_form
+msgid "Payload"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields.selection,name:deltatech_tc.selection__deltatech_tc_job__state__pending
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_search
+msgid "Pending"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields.selection,name:deltatech_tc.selection__deltatech_tc_job__job_type__ping
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "Ping"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "Regenerate key"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.actions.act_window,help:deltatech_tc.action_deltatech_tc_station
+msgid ""
+"Register the workstation running Terrabit Connect, copy the API key into it,\n"
+"               and it will exchange jobs with this Odoo instance."
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__result
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_form
+msgid "Result"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,help:deltatech_tc.field_deltatech_tc_station__api_key
+msgid ""
+"Secret used by Terrabit Connect in the X-Station-Key header. Regenerate as "
+"needed."
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__state
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_search
+msgid "State"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_job__station_id
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_search
+msgid "Station"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.ui.menu,name:deltatech_tc.menu_deltatech_tc_station
+msgid "Stations"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.fields,field_description:deltatech_tc.field_deltatech_tc_station__tc_version
+msgid "TC Version"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.ui.menu,name:deltatech_tc.menu_deltatech_tc_root
+#: model:res.groups.privilege,name:deltatech_tc.groups_privilege_deltatech_tc
+msgid "Terrabit Connect"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model,name:deltatech_tc.model_deltatech_tc_job
+msgid "Terrabit Connect Job"
+msgstr ""
+
+#. module: deltatech_tc
+#. odoo-python
+#: code:addons/deltatech_tc/models/deltatech_tc_station.py:0
+#: model:ir.actions.act_window,name:deltatech_tc.action_deltatech_tc_job
+msgid "Terrabit Connect Jobs"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model,name:deltatech_tc.model_deltatech_tc_station
+msgid "Terrabit Connect Station"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.actions.act_window,name:deltatech_tc.action_deltatech_tc_station
+msgid "Terrabit Connect Stations"
+msgstr ""
+
+#. module: deltatech_tc
+#. odoo-python
+#: code:addons/deltatech_tc/models/deltatech_tc_station.py:0
+msgid "Terrabit Connect heartbeat"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:ir.model.constraint,message:deltatech_tc.constraint_deltatech_tc_station_api_key_uniq
+msgid "The API key must be unique."
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_job_search
+msgid "Type"
+msgstr ""
+
+#. module: deltatech_tc
+#: model:res.groups,name:deltatech_tc.group_deltatech_tc_user
+msgid "User"
+msgstr ""
+
+#. module: deltatech_tc
+#: model_terms:ir.ui.view,arch_db:deltatech_tc.view_deltatech_tc_station_form
+msgid "e.g. Accounting PC"
+msgstr ""
+
+#. module: deltatech_tc
+#. odoo-python
+#: code:addons/deltatech_tc/models/deltatech_tc_station.py:0
+msgid "station_id"
+msgstr ""

--- a/deltatech_team_logo/i18n/deltatech_team_logo.pot
+++ b/deltatech_team_logo/i18n/deltatech_team_logo.pot
@@ -1,0 +1,57 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_team_logo
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_crm_team__display_name
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_stock_picking__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,help:deltatech_team_logo.field_stock_picking__team_id
+msgid ""
+"Echipa de vânzare a comenzii sursă, folosită pentru logo-ul din rapoarte."
+msgstr ""
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_crm_team__id
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_stock_picking__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_crm_team__logo
+msgid "Logo"
+msgstr ""
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,help:deltatech_team_logo.field_crm_team__logo
+msgid ""
+"Logo afișat în rapoartele (factură, ofertă, aviz) emise pentru această "
+"echipă de vânzare. Dacă este gol, se folosește logo-ul firmei."
+msgstr ""
+
+#. module: deltatech_team_logo
+#: model:ir.model,name:deltatech_team_logo.model_crm_team
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_stock_picking__team_id
+msgid "Sales Team"
+msgstr ""
+
+#. module: deltatech_team_logo
+#: model:ir.model,name:deltatech_team_logo.model_stock_picking
+msgid "Transfer"
+msgstr ""

--- a/deltatech_test_system/i18n/deltatech_test_system.pot
+++ b/deltatech_test_system/i18n/deltatech_test_system.pot
@@ -1,0 +1,76 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_test_system
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_test_system
+#: model_terms:ir.ui.view,arch_db:deltatech_test_system.module_view_kanban
+msgid ""
+"<span invisible=\"state != 'installed'\" class=\"text-success\">Is installed</span>\n"
+"                        <span invisible=\"state == 'installed'\" class=\"text-muted\">Is not installed</span>"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model:ir.model,name:deltatech_test_system.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model:ir.model.fields,field_description:deltatech_test_system.field_ir_module_module__database_is_neutralized
+#: model:ir.model.fields,field_description:deltatech_test_system.field_res_config_settings__database_is_neutralized
+#: model_terms:ir.ui.view,arch_db:deltatech_test_system.res_config_settings_view_form
+msgid "Database Is Neutralized"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model:ir.model.fields,field_description:deltatech_test_system.field_ir_module_module__display_name
+#: model:ir.model.fields,field_description:deltatech_test_system.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model:ir.model.fields,field_description:deltatech_test_system.field_ir_module_module__id
+#: model:ir.model.fields,field_description:deltatech_test_system.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model_terms:ir.ui.view,arch_db:deltatech_test_system.res_config_settings_view_form
+msgid "It is a productive system"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model_terms:ir.ui.view,arch_db:deltatech_test_system.res_config_settings_view_form
+msgid "It is a test system"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model:ir.model,name:deltatech_test_system.model_ir_module_module
+msgid "Module"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model_terms:ir.ui.view,arch_db:deltatech_test_system.notification_banner
+msgid ""
+"Some functionalities may run in restricted mode. Please check the support "
+"contract payment!"
+msgstr ""
+
+#. module: deltatech_test_system
+#: model_terms:ir.ui.view,arch_db:deltatech_test_system.res_config_settings_view_form
+msgid ""
+"This setting is used to determine if the database is a test or production "
+"system."
+msgstr ""

--- a/deltatech_transport_change/i18n/deltatech_transport_change.pot
+++ b/deltatech_transport_change/i18n/deltatech_transport_change.pot
@@ -1,0 +1,365 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_transport_change
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_needaction
+msgid "Action Needed"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_ids
+msgid "Activities"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_state
+msgid "Activity State"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_type_icon
+msgid "Activity Type Icon"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_attachment_count
+msgid "Attachment Count"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__repo_branch
+msgid "Branch"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.ui.menu,name:deltatech_transport_change.menu_transport_config
+msgid "Configurations"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__create_uid
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__create_date
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__credential_type
+msgid "Credential Type"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__display_name
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__domain
+msgid "Domain"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.actions.server,name:deltatech_transport_change.server_action_transport_config_export
+#: model_terms:ir.ui.view,arch_db:deltatech_transport_change.view_transport_config_form
+msgid "Export CSV"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__domain
+msgid "Expression list, e.g. [('company_id','=',1)]"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__field_ids
+msgid "Fields"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_repo__module_name
+msgid "Folded module name from repository"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_follower_ids
+msgid "Followers"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_partner_ids
+msgid "Followers (Partners)"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model_terms:ir.ui.view,arch_db:deltatech_transport_change.view_transport_config_form
+msgid "Generate File"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__repo_id
+msgid "Git Repository"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__password
+msgid "Git Token / Password"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__repo_url
+msgid "Git URL"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__username
+msgid "Git Username"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields.selection,name:deltatech_transport_change.selection__transport_repo__credential_type__https
+msgid "HTTPS"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__has_message
+msgid "Has Message"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__id
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_exception_icon
+msgid "Icon"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_has_error
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_is_follower
+msgid "Is Follower"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__last_export
+msgid "Last Export"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__write_uid
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__write_date
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__repo_local_path
+msgid "Local Path"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_has_error
+msgid "Message Delivery error"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_ids
+msgid "Messages"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__model_id
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__model_name
+msgid "Model"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__module_name
+msgid "Module Code"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_summary
+msgid "Next Activity Summary"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_type_id
+msgid "Next Activity Type"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_needaction_counter
+msgid "Number of Actions"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_has_error_counter
+msgid "Number of errors"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__rating_ids
+msgid "Ratings"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.ui.menu,name:deltatech_transport_change.menu_transport_repo
+msgid "Repositories"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__name
+msgid "Repository Name"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_user_id
+msgid "Responsible User"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields.selection,name:deltatech_transport_change.selection__transport_repo__credential_type__ssh
+msgid "SSH Key"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__ssh_key
+msgid "SSH Private Key"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__field_ids
+msgid ""
+"The fields to export. Only fields from the selected model are available."
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.ui.menu,name:deltatech_transport_change.menu_transport_root
+msgid "Transport"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.actions.act_window,name:deltatech_transport_change.action_transport_config
+msgid "Transport Config"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model,name:deltatech_transport_change.model_transport_config
+msgid "Transport Configuration Export"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.actions.act_window,name:deltatech_transport_change.action_transport_repo
+msgid "Transport Repos"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model,name:deltatech_transport_change.model_transport_repo
+msgid "Transport Repository Configuration"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__website_message_ids
+msgid "Website Messages"
+msgstr ""
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__website_message_ids
+msgid "Website communication history"
+msgstr ""

--- a/deltatech_vendor_stock/i18n/deltatech_vendor_stock.pot
+++ b/deltatech_vendor_stock/i18n/deltatech_vendor_stock.pot
@@ -1,0 +1,171 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_vendor_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_vendor_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_vendor_stock.res_config_settings_view_form_deltatech_vendor_stock
+msgid ""
+"<span class=\"d-block w-75 py-2\">Color when fulfilled but no free qty "
+"today</span>"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_vendor_stock.res_config_settings_view_form_deltatech_vendor_stock
+msgid "<span class=\"d-block w-75 py-2\">Color when not fulfilled</span>"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_vendor_stock.res_config_settings_view_form_deltatech_vendor_stock
+msgid ""
+"<span class=\"d-block w-75 py-2\">Color when stock will be fulfilled</span>"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_vendor_stock.res_config_settings_view_form_deltatech_vendor_stock
+msgid ""
+"<span class=\"d-block w-75 py-2\">Color when vendor qty is available</span>"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_vendor_stock.res_config_settings_view_form_deltatech_vendor_stock
+msgid "<span class=\"d-block w-75 py-2\">Default color</span>"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__stock_color_default
+msgid "Color - Default"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__stock_color_fulfilled
+msgid "Color - Fulfilled"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__stock_color_fulfilled_no_free_qty
+msgid "Color - Fulfilled (No Free Qty)"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__stock_color_not_fulfilled
+msgid "Color - Not Fulfilled"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__stock_color_vendor_available
+msgid "Color - Vendor Available"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,help:deltatech_vendor_stock.field_res_config_settings__stock_color_fulfilled_no_free_qty
+msgid "Color when fulfilled but no free qty today"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,help:deltatech_vendor_stock.field_res_config_settings__stock_color_not_fulfilled
+msgid "Color when not fulfilled"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,help:deltatech_vendor_stock.field_res_config_settings__stock_color_fulfilled
+msgid "Color when stock will be fulfilled"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,help:deltatech_vendor_stock.field_res_config_settings__stock_color_vendor_available
+msgid "Color when vendor qty is available"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model,name:deltatech_vendor_stock.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,help:deltatech_vendor_stock.field_res_config_settings__stock_color_default
+msgid "Default color"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_supplierinfo__display_name
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_supplierinfo__id
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_sale_order_line__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_product__other_qty_available
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_sale_order_line__other_qty_available
+msgid "Other Quantity Available"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#. odoo-javascript
+#: code:addons/deltatech_vendor_stock/static/src/xml/qty.xml:0
+msgid "Other Stock"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model,name:deltatech_vendor_stock.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_supplierinfo__qty_available
+msgid "Quantity Available"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model,name:deltatech_vendor_stock.model_sale_order_line
+msgid "Sales Order Line"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_sale_order_line__warehouse_stock
+msgid "Stock/WH"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model,name:deltatech_vendor_stock.model_product_supplierinfo
+msgid "Supplier Pricelist"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_product_product__vendor_qty_available
+#: model:ir.model.fields,field_description:deltatech_vendor_stock.field_sale_order_line__vendor_qty_available
+msgid "Vendor Quantity Available"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#. odoo-javascript
+#: code:addons/deltatech_vendor_stock/static/src/xml/qty.xml:0
+msgid "Vendor Stock"
+msgstr ""
+
+#. module: deltatech_vendor_stock
+#. odoo-javascript
+#: code:addons/deltatech_vendor_stock/static/src/xml/qty.xml:0
+msgid "Warehouse Stock"
+msgstr ""

--- a/deltatech_warehouse_arrangement/i18n/deltatech_warehouse_arrangement.pot
+++ b/deltatech_warehouse_arrangement/i18n/deltatech_warehouse_arrangement.pot
@@ -1,0 +1,359 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_warehouse_arrangement
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__active
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__active
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__active
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__active
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_lot_change_location_form
+msgid "Apply"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__barcode
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.report_rack
+msgid "Barcode"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location___barcode_scanned
+msgid "Barcode Scanned"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.act_window,name:deltatech_warehouse_arrangement.action_lot_change_location
+msgid "Change Lot Location"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_change_lot_location
+msgid "Change lot"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__create_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__create_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__create_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__create_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__create_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__create_uid
+msgid "Created by"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__create_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__create_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__create_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__create_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__create_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__create_date
+msgid "Created on"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_move_line__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__display_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__full_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__full_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__full_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__full_name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__full_name
+msgid "Full Name"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_move_line__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__write_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__write_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__write_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__write_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__write_uid
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__write_uid
+msgid "Last Updated by"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__write_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__write_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__write_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__write_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__write_date
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__write_date
+msgid "Last Updated on"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_locations
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.product_template_form_view
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_production_lot_form
+msgid "Locations"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__lot_id
+msgid "Lot"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_lot_change_location
+msgid "Lot Change Location Wizard"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__lot_scanned
+msgid "Lot Scanned"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_stock_lot
+msgid "Lot/Serial"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__name
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__name
+msgid "Name"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_stock_move_line
+msgid "Product Moves (Stock Move Line)"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_stock_quant
+msgid "Quants"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.act_window,name:deltatech_warehouse_arrangement.action_rack
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_lot_change_location__rack_id
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_rack
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.quant_search_view
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_rack_form
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_rack_tree
+msgid "Rack"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.report,name:deltatech_warehouse_arrangement.action_report_rack
+msgid "Rack Labels"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_product__loc_rack_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__loc_rack_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__loc_rack_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__loc_rack_id
+msgid "Rack Location"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#. odoo-python
+#: code:addons/deltatech_warehouse_arrangement/models/warehouse_location.py:0
+msgid "Rack: "
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_lot_change_location_form
+msgid "Reset"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.act_window,name:deltatech_warehouse_arrangement.action_section
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__section_id
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_section
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.quant_search_view
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_section_form
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_section_tree
+msgid "Section"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_product__loc_section_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__loc_section_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__loc_section_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__loc_section_id
+msgid "Section Location"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#. odoo-python
+#: code:addons/deltatech_warehouse_arrangement/models/warehouse_location.py:0
+msgid "Section: "
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_rack__sequence
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__sequence
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__sequence
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__sequence
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__sequence
+msgid "Sequence"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.act_window,name:deltatech_warehouse_arrangement.action_shelf
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_section__shelf_id
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_shelf
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.quant_search_view
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_shelf_form
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_shelf_tree
+msgid "Shelf"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_product__loc_shelf_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__loc_shelf_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__loc_shelf_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__loc_shelf_id
+msgid "Shelf Location"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#. odoo-python
+#: code:addons/deltatech_warehouse_arrangement/models/warehouse_location.py:0
+msgid "Shelf: "
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.act_window,name:deltatech_warehouse_arrangement.action_storehouse
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_product__loc_storehouse_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__loc_storehouse_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__loc_storehouse_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__loc_storehouse_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_zone__storehouse_id
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_storehouse
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.quant_search_view
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_storehouse_form
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_storehouse_tree
+msgid "Storehouse"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#. odoo-python
+#: code:addons/deltatech_warehouse_arrangement/models/warehouse_location.py:0
+msgid "Storehouse: "
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,help:deltatech_warehouse_arrangement.field_lot_change_location___barcode_scanned
+msgid "Value of the last barcode scanned."
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_storehouse__location_id
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:res.groups,name:deltatech_warehouse_arrangement.group_locations_manager
+msgid "Warehouse Locations manager"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_warehouse_location_rack
+msgid "Warehouse Rack"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_warehouse_location_section
+msgid "Warehouse Section"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_warehouse_location_shelf
+msgid "Warehouse Shelf"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_warehouse_location_storehouse
+msgid "Warehouse Storehouse"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model,name:deltatech_warehouse_arrangement.model_warehouse_location_zone
+msgid "Warehouse Zone"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.actions.act_window,name:deltatech_warehouse_arrangement.action_zone
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_warehouse_location_shelf__zone_id
+#: model:ir.ui.menu,name:deltatech_warehouse_arrangement.menu_zone
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.quant_search_view
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_zone_form
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_zone_tree
+msgid "Zone"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_product__loc_zone_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_product_template__loc_zone_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_lot__loc_zone_id
+#: model:ir.model.fields,field_description:deltatech_warehouse_arrangement.field_stock_quant__loc_zone_id
+msgid "Zone Location"
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#. odoo-python
+#: code:addons/deltatech_warehouse_arrangement/models/warehouse_location.py:0
+msgid "Zone: "
+msgstr ""
+
+#. module: deltatech_warehouse_arrangement
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_arrangement.view_lot_change_location_form
+msgid "or"
+msgstr ""

--- a/deltatech_warehouse_map/i18n/deltatech_warehouse_map.pot
+++ b/deltatech_warehouse_map/i18n/deltatech_warehouse_map.pot
@@ -1,0 +1,79 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_warehouse_map
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "<small class=\"text-muted\">Vizualizare ierarhică depozit</small>"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Cantitate Disponibilă"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model:ir.model.fields,field_description:deltatech_warehouse_map.field_stock_location__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Hartă Depozit -"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model:ir.model.fields,field_description:deltatech_warehouse_map.field_stock_location__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model:ir.model,name:deltatech_warehouse_map.model_stock_location
+msgid "Inventory Locations"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.location_recursive_node
+msgid ""
+"Locație: {{0}} \n"
+"Grad Ocupare: {{1}}% \n"
+"Stoc: {{2}} / {{3}}"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_stock_location_tree_inherit_deltatech_map
+msgid "Map"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_stock_location_form_inherit_deltatech_map
+msgid "Open Map"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Produse în această locație"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Referință / Produs"
+msgstr ""
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "← Înapoi la Părinte"
+msgstr ""

--- a/deltatech_watermark/i18n/deltatech_watermark.pot
+++ b/deltatech_watermark/i18n/deltatech_watermark.pot
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_watermark
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_watermark
+#: model:ir.model,name:deltatech_watermark.model_res_company
+msgid "Companies"
+msgstr ""
+
+#. module: deltatech_watermark
+#: model:ir.model,name:deltatech_watermark.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_watermark
+#: model:ir.model.fields,field_description:deltatech_watermark.field_res_company__display_name
+#: model:ir.model.fields,field_description:deltatech_watermark.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_watermark
+#: model:ir.model.fields,field_description:deltatech_watermark.field_res_company__id
+#: model:ir.model.fields,field_description:deltatech_watermark.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_watermark
+#: model_terms:ir.ui.view,arch_db:deltatech_watermark.res_config_settings_view_form
+msgid "If set, the watermark can be used on the website or in documents."
+msgstr ""
+
+#. module: deltatech_watermark
+#: model_terms:ir.ui.view,arch_db:deltatech_watermark.res_config_settings_view_form
+msgid "Values set here are company-specific."
+msgstr ""
+
+#. module: deltatech_watermark
+#: model:ir.model.fields,field_description:deltatech_watermark.field_res_company__watermark_image
+#: model:ir.model.fields,field_description:deltatech_watermark.field_res_config_settings__watermark_image
+msgid "Watermark image"
+msgstr ""

--- a/deltatech_website_blog/i18n/deltatech_website_blog.pot
+++ b/deltatech_website_blog/i18n/deltatech_website_blog.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_blog
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_blog
+#: model:ir.model,name:deltatech_website_blog.model_blog_post
+msgid "Blog Post"
+msgstr ""
+
+#. module: deltatech_website_blog
+#: model:ir.model.fields,field_description:deltatech_website_blog.field_blog_post__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_blog
+#: model:ir.model.fields,field_description:deltatech_website_blog.field_blog_post__id
+msgid "ID"
+msgstr ""

--- a/deltatech_website_breadcrumb/i18n/deltatech_website_breadcrumb.pot
+++ b/deltatech_website_breadcrumb/i18n/deltatech_website_breadcrumb.pot
@@ -1,0 +1,21 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_breadcrumb
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_breadcrumb
+#: model_terms:ir.ui.view,arch_db:deltatech_website_breadcrumb.breadcrumb
+msgid "Products"
+msgstr ""

--- a/deltatech_website_category/i18n/deltatech_website_category.pot
+++ b/deltatech_website_category/i18n/deltatech_website_category.pot
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_category
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_category
+#: model:ir.model.fields,field_description:deltatech_website_category.field_product_public_category__active
+msgid "Active"
+msgstr ""
+
+#. module: deltatech_website_category
+#: model:ir.model.fields,field_description:deltatech_website_category.field_product_public_category__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_category
+#: model:ir.model.fields,field_description:deltatech_website_category.field_product_public_category__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_category
+#: model:ir.model.fields,help:deltatech_website_category.field_product_public_category__active
+msgid ""
+"If unchecked, it will allow you to hide the category without removing it."
+msgstr ""
+
+#. module: deltatech_website_category
+#: model:ir.model.fields,help:deltatech_website_category.field_product_public_category__website_url
+msgid "The full URL to access the document through the website."
+msgstr ""
+
+#. module: deltatech_website_category
+#: model:ir.model,name:deltatech_website_category.model_product_public_category
+msgid "Website Product Category"
+msgstr ""
+
+#. module: deltatech_website_category
+#: model:ir.model.fields,field_description:deltatech_website_category.field_product_public_category__website_url
+msgid "Website URL"
+msgstr ""

--- a/deltatech_website_city/i18n/deltatech_website_city.pot
+++ b/deltatech_website_city/i18n/deltatech_website_city.pot
@@ -1,0 +1,42 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_city
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_city
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.address_form_fields
+msgid "<option value=\"\">City...</option>"
+msgstr ""
+
+#. module: deltatech_website_city
+#: model:ir.model.fields,field_description:deltatech_website_city.field_res_country_state__city_ids
+#: model_terms:ir.ui.view,arch_db:deltatech_website_city.address_form_fields
+msgid "City"
+msgstr ""
+
+#. module: deltatech_website_city
+#: model:ir.model,name:deltatech_website_city.model_res_country_state
+msgid "Country state"
+msgstr ""
+
+#. module: deltatech_website_city
+#: model:ir.model.fields,field_description:deltatech_website_city.field_res_country_state__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_city
+#: model:ir.model.fields,field_description:deltatech_website_city.field_res_country_state__id
+msgid "ID"
+msgstr ""

--- a/deltatech_website_delivery_and_payment/i18n/deltatech_website_delivery_and_payment.pot
+++ b/deltatech_website_delivery_and_payment/i18n/deltatech_website_delivery_and_payment.pot
@@ -1,0 +1,124 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_delivery_and_payment
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model,name:deltatech_website_delivery_and_payment.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model,website_form_label:deltatech_website_delivery_and_payment.model_res_partner
+msgid "Create a Customer"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__display_name
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_payment_provider__display_name
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_res_partner__display_name
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_sale_order__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__id
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_payment_provider__id
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_res_partner__id
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_sale_order__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__logo
+msgid "Logo"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_website_delivery_and_payment.view_delivery_carrier_form
+msgid "Max"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_website_delivery_and_payment.view_delivery_carrier_form
+msgid "Min"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_website_delivery_and_payment.view_delivery_carrier_form
+msgid "Payment Acquirer"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model,name:deltatech_website_delivery_and_payment.model_payment_provider
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_res_partner__provider_id
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_res_users__provider_id
+msgid "Payment Provider"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__acquirer_allowed_ids
+msgid "Payments Provider Allowed"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_payment_provider__restrict_label_ids
+msgid "Restrict Label"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__restrict_label_ids
+msgid "Restrict for partners with label"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_website_delivery_and_payment.payment_provider_form
+msgid "Restrictions"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model,name:deltatech_website_delivery_and_payment.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model,name:deltatech_website_delivery_and_payment.model_delivery_carrier
+msgid "Shipping Methods"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_website_delivery_and_payment.payment_provider_form
+msgid "Tags..."
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_payment_provider__value_limit
+msgid "Value Limit"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__weight_max
+msgid "Weight Max"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model:ir.model.fields,field_description:deltatech_website_delivery_and_payment.field_delivery_carrier__weight_min
+msgid "Weight Min"
+msgstr ""
+
+#. module: deltatech_website_delivery_and_payment
+#: model_terms:ir.ui.view,arch_db:deltatech_website_delivery_and_payment.view_delivery_carrier_form
+msgid "Weight limits"
+msgstr ""

--- a/deltatech_website_fixed_price/i18n/deltatech_website_fixed_price.pot
+++ b/deltatech_website_fixed_price/i18n/deltatech_website_fixed_price.pot
@@ -1,0 +1,31 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_fixed_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_fixed_price
+#: model:ir.model.fields,field_description:deltatech_website_fixed_price.field_product_pricelist_item__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_fixed_price
+#: model:ir.model.fields,field_description:deltatech_website_fixed_price.field_product_pricelist_item__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_fixed_price
+#: model:ir.model,name:deltatech_website_fixed_price.model_product_pricelist_item
+msgid "Pricelist Rule"
+msgstr ""

--- a/deltatech_website_phone_validation/i18n/deltatech_website_phone_validation.pot
+++ b/deltatech_website_phone_validation/i18n/deltatech_website_phone_validation.pot
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_phone_validation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_phone_validation
+#. odoo-python
+#: code:addons/deltatech_website_phone_validation/controllers/website_sale.py:0
+msgid "The phone number is not valid: %s"
+msgstr ""

--- a/deltatech_website_price_without_tax/i18n/deltatech_website_price_without_tax.pot
+++ b/deltatech_website_price_without_tax/i18n/deltatech_website_price_without_tax.pot
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_price_without_tax
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_price_without_tax
+#: model_terms:ir.ui.view,arch_db:deltatech_website_price_without_tax.base_unit_price_without_tax
+msgid "<span>Base Unit Price without tax</span>"
+msgstr ""
+
+#. module: deltatech_website_price_without_tax
+#: model:ir.model.fields,field_description:deltatech_website_price_without_tax.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_price_without_tax
+#: model:ir.model.fields,field_description:deltatech_website_price_without_tax.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_price_without_tax
+#: model:ir.model,name:deltatech_website_price_without_tax.model_product_template
+msgid "Product"
+msgstr ""

--- a/deltatech_website_product_code/i18n/deltatech_website_product_code.pot
+++ b/deltatech_website_product_code/i18n/deltatech_website_product_code.pot
@@ -1,0 +1,132 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_product_code
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_product_code
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.product_code
+msgid "<span>Code:</span>"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model,name:deltatech_website_product_code.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_res_config_settings__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,help:deltatech_website_product_code.field_res_config_settings__website_search_exact_phrase
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid ""
+"Match the search term as a single string instead of splitting it on spaces. "
+"Enable it when product codes contain spaces, so that searching '352 030 15 "
+"97' returns the product having that code instead of every product containing"
+" '352', '030', '15' or '97'. When no product matches the whole term, the "
+"regular search is used."
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid ""
+"Number of code-looking terms pasted together before the search starts "
+"looking for any of them instead of requiring a single product to match them "
+"all. Use 0 to disable it."
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,help:deltatech_website_product_code.field_res_config_settings__website_search_multi_code_min_terms
+msgid ""
+"Number of code-looking terms pasted together before the search starts "
+"looking for any of them, instead of requiring a single product to match them"
+" all. Use 0 to disable."
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_res_config_settings__website_search_multi_code_min_terms
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid "Pasted Code Lists"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model,name:deltatech_website_product_code.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid "Product Search"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_res_config_settings__website_search_exact_phrase
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid "Search The Whole Term"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_res_config_settings__website_search_min_term_length
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid "Shortest Search Term"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,field_description:deltatech_website_product_code.field_res_config_settings__website_search_standalone_code_min_length
+msgid "Shortest Standalone Code"
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid ""
+"Shortest term still treated as a code of its own. Shorter terms are\n"
+"                                taken to be groups of one code, so they are never searched\n"
+"                                separately. Use 0 to accept any length."
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_code.res_config_settings_view_form
+msgid ""
+"Terms shorter than this are ignored, since they cannot use the database "
+"indexes and only slow the search down. Kept when every term is shorter than "
+"this, so that such a search still returns its results."
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,help:deltatech_website_product_code.field_res_config_settings__website_search_min_term_length
+msgid ""
+"Terms shorter than this are ignored, since they cannot use the database "
+"indexes and only slow the search down. Kept when every term is shorter than "
+"this, so that such a search still returns its results. Use 0 to keep every "
+"term."
+msgstr ""
+
+#. module: deltatech_website_product_code
+#: model:ir.model.fields,help:deltatech_website_product_code.field_res_config_settings__website_search_standalone_code_min_length
+msgid ""
+"Used only while the whole term is searched, to tell a pasted list of "
+"complete codes from the groups of a single code written with spaces. Terms "
+"shorter than this are taken to be groups of one code, so they are never "
+"searched separately. Use 0 to accept terms of any length as codes."
+msgstr ""

--- a/deltatech_website_product_placeholder/i18n/deltatech_website_product_placeholder.pot
+++ b/deltatech_website_product_placeholder/i18n/deltatech_website_product_placeholder.pot
@@ -1,0 +1,84 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_product_placeholder
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model,name:deltatech_website_product_placeholder.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model.fields,help:deltatech_website_product_placeholder.field_res_config_settings__product_placeholder_image
+#: model:ir.model.fields,help:deltatech_website_product_placeholder.field_website__product_placeholder_image
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_placeholder.res_config_settings_view_form
+msgid "Default image used for products without an image"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_ir_binary__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_ir_qweb_field_image__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_website__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model,name:deltatech_website_product_placeholder.model_ir_binary
+msgid "File streaming helper model for controllers"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_ir_binary__id
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_ir_qweb_field_image__id
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_website__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model,name:deltatech_website_product_placeholder.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model_terms:ir.ui.view,arch_db:deltatech_website_product_placeholder.res_config_settings_view_form
+msgid "Product Placeholder"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_res_config_settings__product_placeholder_image
+#: model:ir.model.fields,field_description:deltatech_website_product_placeholder.field_website__product_placeholder_image
+msgid "Product Placeholder Image"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model,name:deltatech_website_product_placeholder.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model,name:deltatech_website_product_placeholder.model_ir_qweb_field_image
+msgid "Qweb Field Image"
+msgstr ""
+
+#. module: deltatech_website_product_placeholder
+#: model:ir.model,name:deltatech_website_product_placeholder.model_website
+msgid "Website"
+msgstr ""

--- a/deltatech_website_product_url_image/i18n/deltatech_website_product_url_image.pot
+++ b/deltatech_website_product_url_image/i18n/deltatech_website_product_url_image.pot
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_product_url_image
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_image__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_image__id
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_product__image_file_name
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_template__image_file_name
+msgid "Image File Name"
+msgstr ""
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model,name:deltatech_website_product_url_image.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model,name:deltatech_website_product_url_image.model_product_image
+msgid "Product Image"
+msgstr ""

--- a/deltatech_website_sale_attributes/i18n/deltatech_website_sale_attributes.pot
+++ b/deltatech_website_sale_attributes/i18n/deltatech_website_sale_attributes.pot
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_attributes
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model,name:deltatech_website_sale_attributes.model_product_attribute_value
+msgid "Attribute Value"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model.fields,field_description:deltatech_website_sale_attributes.field_product_attribute_value__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_attributes.field_product_template_attribute_value__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model.fields.selection,name:deltatech_website_sale_attributes.selection__product_attribute_value__visibility__hidden
+msgid "Hidden"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model.fields,field_description:deltatech_website_sale_attributes.field_product_attribute_value__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_attributes.field_product_template_attribute_value__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model,name:deltatech_website_sale_attributes.model_product_template_attribute_value
+msgid "Product Template Attribute Value"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model.fields,field_description:deltatech_website_sale_attributes.field_product_attribute_value__visibility
+msgid "Visibility"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model.fields.selection,name:deltatech_website_sale_attributes.selection__product_attribute_value__visibility__visible
+msgid "Visible"
+msgstr ""
+
+#. module: deltatech_website_sale_attributes
+#: model:ir.model.fields,field_description:deltatech_website_sale_attributes.field_product_template_attribute_value__website_visible
+msgid "Website visible"
+msgstr ""

--- a/deltatech_website_sale_cost_price/i18n/deltatech_website_sale_cost_price.pot
+++ b/deltatech_website_sale_cost_price/i18n/deltatech_website_sale_cost_price.pot
@@ -1,0 +1,74 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_cost_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__cost_price_include_tax
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__cost_price_include_tax
+msgid "Cost Price Includes Tax"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_cost_price.res_config_settings_view_form
+msgid "Cost Price Margin %"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__cost_price_margin_percentage
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__cost_price_margin_percentage
+msgid "Cost Price Margin Percentage"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_cost_price.res_config_settings_view_form
+msgid "The cost price is kept with taxes included in the product"
+msgstr ""
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_website
+msgid "Website"
+msgstr ""

--- a/deltatech_website_sale_portal/i18n/deltatech_website_sale_portal.pot
+++ b/deltatech_website_sale_portal/i18n/deltatech_website_sale_portal.pot
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_portal
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Client Reference"
+msgstr ""
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Order Name"
+msgstr ""
+
+#. module: deltatech_website_sale_portal
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_portal.portal_my_orders
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_portal.portal_my_quotations
+msgid "Reference"
+msgstr ""
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Search in All"
+msgstr ""
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Search in Client Reference"
+msgstr ""
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Search in Name"
+msgstr ""

--- a/deltatech_website_sale_sort/i18n/deltatech_website_sale_sort.pot
+++ b/deltatech_website_sale_sort/i18n/deltatech_website_sale_sort.pot
@@ -1,0 +1,140 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_sort
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "Availability"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "Best Review"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "Best sellers"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__comment_count
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__comment_count
+msgid "Comments"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_website__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_website__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__in_stock
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__in_stock
+msgid "In Stock"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "Most Visited"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model,name:deltatech_website_sale_sort.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model,name:deltatech_website_sale_sort.model_product_product
+msgid "Product Variant"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.actions.server,name:deltatech_website_sale_sort.ir_cron_product_sale_scheduled_ir_actions_server
+msgid "Products: Update products statistics"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__rating_avg2
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__rating_avg2
+msgid "Rating Average2"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__rating_count2
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__rating_count2
+msgid "Rating count2"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "Reviews"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__sales_count2
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__sales_count2
+msgid "Sold2"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_product__visit_count
+#: model:ir.model.fields,field_description:deltatech_website_sale_sort.field_product_template__visit_count
+msgid "Visits"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#: model:ir.model,name:deltatech_website_sale_sort.model_website
+msgid "Website"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "in_stock desc"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "rating_avg2 desc"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "rating_count2 desc"
+msgstr ""
+
+#. module: deltatech_website_sale_sort
+#. odoo-python
+#: code:addons/deltatech_website_sale_sort/models/website.py:0
+msgid "visit_count desc"
+msgstr ""

--- a/deltatech_website_sale_status/i18n/deltatech_website_sale_status.pot
+++ b/deltatech_website_sale_status/i18n/deltatech_website_sale_status.pot
@@ -1,0 +1,168 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_status
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+msgid "All"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__canceled
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__canceled
+msgid "Canceled"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+msgid "Closed Orders"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__delivered
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__delivered
+msgid "Delivered"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model:ir.model.fields,field_description:deltatech_website_sale_status.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_status.field_sale_report__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model:ir.model.fields,field_description:deltatech_website_sale_status.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_status.field_sale_report__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__in_delivery
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__in_delivery
+msgid "In Delivery"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__in_process
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__in_process
+msgid "In Process"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_status.view_sales_order_filter
+msgid "In process"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+msgid "Open Orders"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+msgid "Order Stage"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+msgid "Order Status"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_status.view_sales_order_filter
+msgid "Phone"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__placed
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__placed
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_status.view_sales_order_filter
+msgid "Placed"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__postponed
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__postponed
+msgid "Postponed"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__returned
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__returned
+msgid "Returned"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model:ir.model,name:deltatech_website_sale_status.model_sale_report
+msgid "Sales Analysis Report"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model:ir.model,name:deltatech_website_sale_status.model_sale_order
+msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model:ir.model.fields,field_description:deltatech_website_sale_status.field_sale_order__stage
+#: model:ir.model.fields,field_description:deltatech_website_sale_status.field_sale_report__stage
+msgid "Stage"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_status.portal_my_orders_status
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_status.portal_my_quotations_status
+msgid "Status"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__to_be_delivery
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__to_be_delivery
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_status.view_sales_order_filter
+msgid "To Be Delivery"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_order__stage__waiting
+#: model:ir.model.fields.selection,name:deltatech_website_sale_status.selection__sale_report__stage__waiting
+msgid "Waiting availability"
+msgstr ""
+
+#. module: deltatech_website_sale_status
+#. odoo-python
+#: code:addons/deltatech_website_sale_status/controllers/portal.py:0
+msgid "stage"
+msgstr ""

--- a/deltatech_website_short_description/i18n/deltatech_website_short_description.pot
+++ b/deltatech_website_short_description/i18n/deltatech_website_short_description.pot
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_short_description
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_short_description
+#: model:ir.model,name:deltatech_website_short_description.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_short_description
+#: model:ir.actions.server,name:deltatech_website_short_description.action_website_publish_product_template
+msgid "Publish on Website"
+msgstr ""
+
+#. module: deltatech_website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_product__website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_template__website_short_description
+msgid "Short description for the website"
+msgstr ""
+
+#. module: deltatech_website_short_description
+#: model_terms:ir.ui.view,arch_db:deltatech_website_short_description.product_template_form_view
+msgid "Website description"
+msgstr ""
+
+#. module: deltatech_website_short_description
+#: model_terms:ir.ui.view,arch_db:deltatech_website_short_description.product_template_form_view
+msgid "Website short description"
+msgstr ""

--- a/deltatech_website_stock_availability/i18n/deltatech_website_stock_availability.pot
+++ b/deltatech_website_stock_availability/i18n/deltatech_website_stock_availability.pot
@@ -1,0 +1,144 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_stock_availability
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_stock_availability
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.cart_line_description_following_lines
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.cart_summary_website_sale_stock_product_lead_time
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.products_qty_available
+msgid "<span class=\"badge bg-success\">Immediate delivery</span>"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.cart_line_description_following_lines
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.cart_summary_website_sale_stock_product_lead_time
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.products_qty_available
+msgid "<span class=\"badge bg-warning\">Subsequent delivery</span>"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.product_template_form_view_hide_out_of_stock_message
+msgid "<span invisible=\"not is_storable\">Hide \"Out of stock\" message</span>"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_product__sale_delay_safety
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_template__sale_delay_safety
+msgid "Customer Safety Lead Time"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_supplierinfo__delay
+msgid "Delay"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "Delivery in"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "Delivery time unknown"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "Delivery tomorrow"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_ir_http__display_name
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_supplierinfo__display_name
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_template__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model.fields,help:deltatech_website_stock_availability.field_product_product__hide_out_of_stock_message
+#: model:ir.model.fields,help:deltatech_website_stock_availability.field_product_template__hide_out_of_stock_message
+msgid ""
+"Do not show the 'Out of stock' website message for this product, even when "
+"it has no own or vendor availability."
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model,name:deltatech_website_stock_availability.model_ir_http
+msgid "HTTP Routing"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_product__hide_out_of_stock_message
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_template__hide_out_of_stock_message
+msgid "Hide Out-of-Stock Message"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_ir_http__id
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_supplierinfo__id
+#: model:ir.model.fields,field_description:deltatech_website_stock_availability.field_product_template__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "Immediate delivery"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "In stock"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "In stock at vendor"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "Out of stock"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model,name:deltatech_website_stock_availability.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#: model:ir.model,name:deltatech_website_stock_availability.model_product_supplierinfo
+msgid "Supplier Pricelist"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+#: model_terms:ir.ui.view,arch_db:deltatech_website_stock_availability.view_template_property_form
+msgid "days"
+msgstr ""
+
+#. module: deltatech_website_stock_availability
+#. odoo-javascript
+#: code:addons/deltatech_website_stock_availability/static/src/xml/website_sale_stock_product_availability.xml:0
+msgid "weeks"
+msgstr ""

--- a/deltatech_website_vat_validation/i18n/deltatech_website_vat_validation.pot
+++ b/deltatech_website_vat_validation/i18n/deltatech_website_vat_validation.pot
@@ -1,0 +1,34 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_vat_validation
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_vat_validation
+#. odoo-python
+#: code:addons/deltatech_website_vat_validation/controllers/website_sale.py:0
+msgid "An other partner already exists with the same %s"
+msgstr ""
+
+#. module: deltatech_website_vat_validation
+#. odoo-python
+#: code:addons/deltatech_website_vat_validation/controllers/website_sale.py:0
+msgid "The VAT number is not valid according to ANAF"
+msgstr ""
+
+#. module: deltatech_website_vat_validation
+#. odoo-python
+#: code:addons/deltatech_website_vat_validation/controllers/website_sale.py:0
+msgid "The VAT number must contain only digits (after the country code)"
+msgstr ""

--- a/deltatech_website_warehouse_stock/i18n/deltatech_website_warehouse_stock.pot
+++ b/deltatech_website_warehouse_stock/i18n/deltatech_website_warehouse_stock.pot
@@ -1,0 +1,83 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_warehouse_stock
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_warehouse_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_website_warehouse_stock.product_warehouse_distribution
+msgid ""
+"<span id=\"warehouse_stock_title\" class=\"fw-bold\">\n"
+"                    In stock availability\n"
+"                </span>"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#. odoo-python
+#: code:addons/deltatech_website_warehouse_stock/models/product.py:0
+msgid "Available"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model,name:deltatech_website_warehouse_stock.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_stock_warehouse__display_name
+msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_stock_warehouse__website_stock_display
+msgid "Display on Website"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_stock_warehouse__id
+msgid "ID"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#. odoo-python
+#: code:addons/deltatech_website_warehouse_stock/models/product.py:0
+msgid "Out of stock"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model,name:deltatech_website_warehouse_stock.model_product_template
+msgid "Product"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model,name:deltatech_website_warehouse_stock.model_stock_warehouse
+msgid "Warehouse"
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model_terms:ir.ui.view,arch_db:deltatech_website_warehouse_stock.res_config_settings_view_form
+msgid ""
+"Warehouse Stock Display: Threshold for displaying stock as 'Available'. This"
+" setting is specific to the Warehouse Stock module and controls the "
+"individual warehouse availability display on the product page."
+msgstr ""
+
+#. module: deltatech_website_warehouse_stock
+#: model:ir.model.fields,field_description:deltatech_website_warehouse_stock.field_res_config_settings__website_warehouse_stock_threshold
+msgid "Website Warehouse Stock Threshold"
+msgstr ""

--- a/deltatech_widget_fontawesome/i18n/deltatech_widget_fontawesome.pot
+++ b/deltatech_widget_fontawesome/i18n/deltatech_widget_fontawesome.pot
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_widget_fontawesome
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_widget_fontawesome
+#. odoo-javascript
+#: code:addons/deltatech_widget_fontawesome/static/src/js/field_fontawesome.esm.js:0
+msgid "Icon Selection"
+msgstr ""

--- a/deltatech_widget_many2one_badge/i18n/deltatech_widget_many2one_badge.pot
+++ b/deltatech_widget_many2one_badge/i18n/deltatech_widget_many2one_badge.pot
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_widget_many2one_badge
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_widget_many2one_badge
+#. odoo-javascript
+#: code:addons/deltatech_widget_many2one_badge/static/src/xml/many2one_badge_field.xml:0
+msgid "Remove"
+msgstr ""


### PR DESCRIPTION
Generează șabloanele de traducere `i18n/<modul>.pot`, care lipseau aproape complet din suită.

**170 fișiere noi**, 0 actualizate, ~3661 termeni.

Exportul e făcut cu `odoo-bin i18n export` dintr-o bază curată în care toate modulele suitei sunt instalate — nu printr-o extragere din surse. Diferența contează: exportul real prinde etichetele de câmpuri derivate din numele câmpului, valorile de selecție, mesajele `models.Constraint`, `res.groups.name` și textul `nocontent` al acțiunilor, pe care un grep peste cod nu le vede.

Modulele fără niciun termen traductibil nu primesc fișier.

Doar fișiere `.pot` — niciun cod atins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)