### PR TITLE
[IMP] deltatech_stock_inventory: show Inventory Note column by default

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "19.0.2.7.0",
+    "version": "19.0.2.7.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/readme/HISTORY.md
+++ b/deltatech_stock_inventory/readme/HISTORY.md
@@ -1,0 +1,8 @@
+## 19.0.2.7.1 (2026-08-04)
+
+- The **Inventory Note** column in the inventory adjustment list is now shown by
+  default (`optional="show"` instead of `optional="hide"`). Users had to enable
+  it manually from the optional-columns menu to record why a quantity was
+  changed, so in practice the reason was almost never filled in. The note is
+  used as the name of the generated stock move, which makes it the only
+  per-line trace of the reason in the product move history.

--- a/deltatech_stock_inventory/views/stock_quant_view.xml
+++ b/deltatech_stock_inventory/views/stock_quant_view.xml
@@ -8,7 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='inventory_date']" position="before">
                 <field name="last_inventory_date" optional="show" readonly="not inventory_quantity_set" />
-                <field name="inventory_note" optional="hide" readonly="not inventory_quantity_set" />
+                <field name="inventory_note" optional="show" readonly="not inventory_quantity_set" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Port of #2728 to 19.0.

Ticket 9156 (AGROAMAT) — the customer asked to be able to record a comment every time someone updates a product quantity, so the reason is visible later.

The module already has a per-line `stock.quant.inventory_note`, which `_get_inventory_move_values` uses as the name of the generated stock move — the only per-line trace of the reason in the product move history. It was hidden behind the optional-columns menu (`optional="hide"`), so in practice it was almost never filled in.

- `views/stock_quant_view.xml`: `optional="hide"` → `optional="show"`
- version bump 19.0.2.7.0 → 19.0.2.7.1 + `readme/HISTORY.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)