### PR TITLE
[FIX] deltatech_sale_analysis_vat: read the report with sudo() in tests

### DIFF
--- a/deltatech_sale_analysis_vat/__manifest__.py
+++ b/deltatech_sale_analysis_vat/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Analysis by VAT",
     "summary": "VAT rate dimension in Invoice Analysis and Point of Sale Analysis",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.0.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Sales",

--- a/deltatech_sale_analysis_vat/readme/HISTORY.md
+++ b/deltatech_sale_analysis_vat/readme/HISTORY.md
@@ -1,3 +1,10 @@
+## 18.0.1.0.1 (2026-08-04)
+
+- The tests read the report with `sudo()`: they check the content of the report, not
+  its visibility, so a module such as `deltatech_restrict_reports` (which hides the
+  report from users outside its access groups with a global `ir.rule`) no longer makes
+  them fail when installed in the same database.
+
 ## 18.0.1.0.0 (2026-08-03)
 
 - Initial version: VAT rate and VAT tax as dimensions in Invoice Analysis and Point of

--- a/deltatech_sale_analysis_vat/tests/test_pos_analysis_vat.py
+++ b/deltatech_sale_analysis_vat/tests/test_pos_analysis_vat.py
@@ -73,8 +73,12 @@ class TestPosAnalysisVat(TestPoSCommon):
 
         # The same turnover must not be reported twice: the invoice issued for a fiscal
         # receipt is flagged, so it can be excluded from the invoice analysis.
-        invoice_report = self.env["account.invoice.report"].search(
-            [("move_id", "=", orders["receipt-invoiced"].account_move.id)]
+        # `sudo()`: see test_sale_analysis_vat - the content is under test, not the
+        # visibility, which deltatech_restrict_reports restricts with a global ir.rule
+        invoice_report = (
+            self.env["account.invoice.report"]
+            .sudo()
+            .search([("move_id", "=", orders["receipt-invoiced"].account_move.id)])
         )
         self.assertTrue(invoice_report.is_fiscal_receipt)
         self.assertEqual(invoice_report.vat_tax_id, self.tax_vat)

--- a/deltatech_sale_analysis_vat/tests/test_sale_analysis_vat.py
+++ b/deltatech_sale_analysis_vat/tests/test_sale_analysis_vat.py
@@ -70,7 +70,10 @@ class TestSaleAnalysisVat(AccountTestInvoicingCommon):
 
     def test_vat_dimension_on_invoice_report(self):
         invoice = self._create_invoice(self.tax_fixed | self.tax_vat)
-        report = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        # `sudo()`: the tests check the content of the report, not its visibility;
+        # a module such as deltatech_restrict_reports may hide the report from the
+        # test user (a global ir.rule), which is not what is under test here
+        report = self.env["account.invoice.report"].sudo().search([("move_id", "=", invoice.id)])
         self.assertEqual(len(report), 1)
         self.assertEqual(report.vat_tax_id, self.tax_vat, "The percentage tax must be reported as VAT")
         self.assertEqual(report.vat_tax_group_id, self.tax_vat.tax_group_id)
@@ -78,13 +81,19 @@ class TestSaleAnalysisVat(AccountTestInvoicingCommon):
 
     def test_invoice_without_tax(self):
         invoice = self._create_invoice(self.env["account.tax"])
-        report = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        # `sudo()`: the tests check the content of the report, not its visibility;
+        # a module such as deltatech_restrict_reports may hide the report from the
+        # test user (a global ir.rule), which is not what is under test here
+        report = self.env["account.invoice.report"].sudo().search([("move_id", "=", invoice.id)])
         self.assertEqual(len(report), 1, "A line without taxes must still be reported once")
         self.assertFalse(report.vat_tax_id)
 
     def test_line_is_not_duplicated_by_several_taxes(self):
         tax_second_vat = self.tax_vat.copy({"name": "VAT 11%", "amount": 11.0, "sequence": 20})
         invoice = self._create_invoice(self.tax_vat | tax_second_vat)
-        report = self.env["account.invoice.report"].search([("move_id", "=", invoice.id)])
+        # `sudo()`: the tests check the content of the report, not its visibility;
+        # a module such as deltatech_restrict_reports may hide the report from the
+        # test user (a global ir.rule), which is not what is under test here
+        report = self.env["account.invoice.report"].sudo().search([("move_id", "=", invoice.id)])
         self.assertEqual(len(report), 1, "A line with two VAT taxes must be reported once")
         self.assertEqual(report.vat_tax_id, self.tax_vat, "The tax with the lowest sequence wins")


### PR DESCRIPTION
CI-ul de pe 18.0 e roșu din 3 august: 4 teste din `deltatech_sale_analysis_vat` pică pe orice run („0 != 1" / „False is not true").

## Cauză

`deltatech_restrict_reports` (#2726) instalează reguli **globale** de `ir.rule` pe `sale.report` / `account.invoice.report`: un user din afara grupurilor lui vede 0 rânduri (by design). Pe CI toate modulele stau în același DB, iar testele rulează ca `accountman` (user obișnuit — `BaseCommon` comută mediul de pe superuser), deci regula li se aplică și `search()` pe `account.invoice.report` întoarce gol.

Confirmat A/B local: modulul singur → 4/4 verzi; cu `deltatech_restrict_reports` instalat → exact cele 4 eșecuri din CI.

## Fix

Testele verifică **conținutul** raportului (dimensiunea de TVA, `is_fiscal_receipt`), nu vizibilitatea lui — căutările pe raport se fac acum cu `sudo()`, imune la regulile de vizibilitate ale altor module.

Verificat pe baza care reproduce eșecul (`deltatech_restrict_reports` instalat): `0 failed, 0 error(s) of 4 tests`.

Deblochează CI-ul pentru #2733 și orice alt PR pe 18.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)