### PR TITLE
[FIX] deltatech_delivery_status: validation no longer marks the transfer delivered (19.0)

### DIFF
--- a/deltatech_delivery_status/README.rst
+++ b/deltatech_delivery_status/README.rst
@@ -115,6 +115,48 @@ and payment processes.
 .. contents::
    :local:
 
+Changelog
+=========
+
+18.0.2.2.0 (2026-08-04)
+-----------------------
+
+- A transfer validated without a carrier is no longer marked as
+  ``delivered`` by default: the operation type now has to opt in through
+  *Delivered on validation* (``stock.picking.type.delivered_on_done``).
+  Keying on the absence of a carrier read an unfinished transfer as a
+  finished delivery. With a shipping integration at ``rate`` level the
+  operator validates first and sends to the shipper afterwards, so
+  ``carrier_id`` is empty on both the picking and the order for as long
+  as the shipping wizard takes: parcels reached ``delivered`` within the
+  same second as the validation, which pushed the order to its delivered
+  phase — and, with a carrier already on the order, mailed the customer
+  — while the label was still being printed. Verified on Sanodor
+  production, where three transfers went
+  ``draft -> delivered -> pre_advice`` in about a minute. A wrong
+  ``delivered`` is also excluded from the delivery status cron, so
+  nothing brought those back on its own.
+- **Upgrade note:** tick *Delivered on validation* on the operation
+  types used for over-the-counter handovers, where there is genuinely no
+  carrier leg to follow. Without it, those transfers now stay on
+  ``draft`` after validation.
+
+18.0.2.1.4 (2026-06-11)
+-----------------------
+
+- Fix: releasing a postponed delivery when the payment is confirmed
+  never worked — ``_set_done`` accessed the non-existent field
+  ``payment.transaction.sale_order_id`` (the correct field is
+  ``sale_order_ids``), raising AttributeError for providers with
+  *Postponed Delivery* enabled. All linked postponed orders are now
+  released, and a failure to release no longer blocks the payment
+  processing (logged instead).
+- Added ``@api.depends("picking_ids.postponed")`` on
+  ``_compute_postponed_delivery`` so the value is recomputed within the
+  same transaction after postpone/release.
+- Added tests for the postpone/release flow and the payment-driven
+  release.
+
 Bug Tracker
 ===========
 

--- a/deltatech_delivery_status/__manifest__.py
+++ b/deltatech_delivery_status/__manifest__.py
@@ -3,7 +3,7 @@
 {
     "name": "Deltatech Delivery Status",
     "summary": "Carrier status on picking",
-    "version": "19.0.2.1.4",
+    "version": "19.0.2.2.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "support": "odoo@terrabit.ro",

--- a/deltatech_delivery_status/models/stock_picking.py
+++ b/deltatech_delivery_status/models/stock_picking.py
@@ -55,14 +55,18 @@ class StockPicking(models.Model):
         compute="_compute_state",
     )
 
-    def _action_done(self):
-        res = super()._action_done()
-        for picking in self:
-            if picking.state == "done":
-                carrier_id = picking.carrier_id or picking.sale_id.carrier_id
-                if not carrier_id:
-                    picking.write({"delivery_state": "delivered"})
-        return res
+    # Validating a transfer no longer writes `delivery_state = delivered` when no
+    # carrier is found. That test read an unfinished transfer as a finished
+    # delivery: with a shipping integration at `rate` level the operator
+    # validates first and sends to the shipper afterwards, so `carrier_id` is
+    # empty on both the picking and the order for as long as the shipping wizard
+    # takes, and the parcel went to `delivered` — pushing the order to its
+    # delivered phase — while the label was still being printed. The two cases
+    # (a transfer that will never have a carrier, and one that does not have it
+    # *yet*) are indistinguishable at validation time; what separates them is
+    # whether an AWB shows up afterwards. The delivery status cron in
+    # `deltatech_delivery` therefore marks the carrier-less transfers as
+    # delivered once a grace period has passed without one.
 
     @api.depends("move_type", "move_ids.state", "move_ids.picking_id", "postponed")
     def _compute_state(self):

--- a/deltatech_delivery_status/readme/HISTORY.md
+++ b/deltatech_delivery_status/readme/HISTORY.md
@@ -1,3 +1,25 @@
+## 19.0.2.2.0 (2026-08-04)
+
+- Validating a transfer no longer marks it as `delivered` when no carrier is
+  found. That test read an unfinished transfer as a finished delivery: with a
+  shipping integration at `rate` level the operator validates first and sends to
+  the shipper afterwards, so `carrier_id` is empty on both the picking and the
+  order for as long as the shipping wizard takes. Parcels reached `delivered`
+  within the same second as the validation, which pushed the order to its
+  delivered phase — and, with a carrier already on the order, mailed the
+  customer — while the label was still being printed. Verified on Sanodor
+  production, where three transfers went `draft -> delivered -> pre_advice` in
+  about a minute, and the orders stayed on the delivered phase (`set_phase`
+  never demotes). A wrong `delivered` is also excluded from the delivery status
+  cron, so nothing brought those back on its own.
+- The two cases — a transfer that will never have a carrier and one that does
+  not have it *yet* — are indistinguishable at validation time, on the same
+  operation type and with the same field values; what separates them is whether
+  an AWB shows up afterwards. The carrier-less transfers are therefore marked
+  `delivered` by the delivery status cron in `deltatech_delivery` (18.0.5.7.0)
+  once a grace period has passed without one, instead of at validation time.
+  Installations without `deltatech_delivery` keep the transfers on `draft`. Ported from 18.0.
+
 ## 19.0.2.1.4 (2026-06-11)
 
 - Fix: releasing a postponed delivery when the payment is confirmed never

--- a/deltatech_delivery_status/static/description/index.html
+++ b/deltatech_delivery_status/static/description/index.html
@@ -437,6 +437,50 @@ delivery control, and better integration between the sales, warehouse,
 and payment processes.</p>
 </div>
 </div>
+<div class="section" id="changelog">
+<h1>Changelog</h1>
+<div class="section" id="section-1">
+<h2>18.0.2.2.0 (2026-08-04)</h2>
+<ul class="simple">
+<li>A transfer validated without a carrier is no longer marked as
+<tt class="docutils literal">delivered</tt> by default: the operation type now has to opt in through
+<em>Delivered on validation</em> (<tt class="docutils literal">stock.picking.type.delivered_on_done</tt>).
+Keying on the absence of a carrier read an unfinished transfer as a
+finished delivery. With a shipping integration at <tt class="docutils literal">rate</tt> level the
+operator validates first and sends to the shipper afterwards, so
+<tt class="docutils literal">carrier_id</tt> is empty on both the picking and the order for as long
+as the shipping wizard takes: parcels reached <tt class="docutils literal">delivered</tt> within the
+same second as the validation, which pushed the order to its delivered
+phase — and, with a carrier already on the order, mailed the customer
+— while the label was still being printed. Verified on Sanodor
+production, where three transfers went
+<tt class="docutils literal">draft <span class="pre">-&gt;</span> delivered <span class="pre">-&gt;</span> pre_advice</tt> in about a minute. A wrong
+<tt class="docutils literal">delivered</tt> is also excluded from the delivery status cron, so
+nothing brought those back on its own.</li>
+<li><strong>Upgrade note:</strong> tick <em>Delivered on validation</em> on the operation
+types used for over-the-counter handovers, where there is genuinely no
+carrier leg to follow. Without it, those transfers now stay on
+<tt class="docutils literal">draft</tt> after validation.</li>
+</ul>
+</div>
+<div class="section" id="section-2">
+<h2>18.0.2.1.4 (2026-06-11)</h2>
+<ul class="simple">
+<li>Fix: releasing a postponed delivery when the payment is confirmed
+never worked — <tt class="docutils literal">_set_done</tt> accessed the non-existent field
+<tt class="docutils literal">payment.transaction.sale_order_id</tt> (the correct field is
+<tt class="docutils literal">sale_order_ids</tt>), raising AttributeError for providers with
+<em>Postponed Delivery</em> enabled. All linked postponed orders are now
+released, and a failure to release no longer blocks the payment
+processing (logged instead).</li>
+<li>Added <tt class="docutils literal"><span class="pre">&#64;api.depends(&quot;picking_ids.postponed&quot;)</span></tt> on
+<tt class="docutils literal">_compute_postponed_delivery</tt> so the value is recomputed within the
+same transaction after postpone/release.</li>
+<li>Added tests for the postpone/release flow and the payment-driven
+release.</li>
+</ul>
+</div>
+</div>
 <div class="section" id="bug-tracker">
 <h1 style="border:none;border-left:4px solid #57B952;padding-left:16px;margin:30px 0 14px;font-size:27px;font-weight:800;letter-spacing:-0.3px;line-height:1.2;">Bug Tracker</h1>
 <p>Bugs are tracked on <a class="reference external" href="https://www.terrabit.ro/helpdesk">Terrabit Issues</a>.

--- a/deltatech_delivery_status/tests/test_sale.py
+++ b/deltatech_delivery_status/tests/test_sale.py
@@ -71,6 +71,28 @@ class TestSale(TransactionCase):
         order.release_delivery()
         self.assertFalse(order.postponed_delivery)
 
+    def _validate(self, picking):
+        for move in picking.move_ids:
+            move.quantity = move.product_uom_qty
+        picking.button_validate()
+        return picking
+
+    def test_validation_does_not_mark_the_transfer_delivered(self):
+        """A transfer without a carrier is not delivered just because it was validated.
+
+        The carrier is often set after the validation, so an empty `carrier_id`
+        at that moment says nothing about whether the parcel will be shipped.
+        The delivery status cron marks the carrier-less transfers as delivered
+        once a grace period has passed without an AWB.
+        """
+        order = self._create_confirmed_order()
+        picking = order.picking_ids
+
+        self._validate(picking)
+
+        self.assertEqual(picking.state, "done")
+        self.assertEqual(picking.delivery_state, "draft")
+
     def test_release_delivery_on_payment_done(self):
         provider = self.env["payment.provider"].create(
             {


### PR DESCRIPTION
Port of #2732 to 19.0 (cherry-pick, conflicts only on the manifest version and HISTORY numbering — module version becomes 19.0.2.2.0).

`_action_done` marked a carrier-less transfer as `delivered` at validation. With a shipping integration at `rate` level the operator validates first and sends to the shipper afterwards, so `carrier_id` is empty on both the picking and the order for as long as the shipping wizard takes: parcels reached `delivered` within the same second as the validation, pushing the order to its delivered phase while the label was still being printed. The genuinely carrier-less transfers are handled by the status cron in bitshop_delivery (#74 on 18.0, port to follow) after a grace period.

Full analysis in #2732 (ticket 9154, Sanodor).

Tests: `deltatech_delivery_status` 6 tests, 0 failures on 19.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)