### PR TITLE
[IMP] deltatech_followup: traducere RO

### DIFF
--- a/deltatech_followup/i18n/ro.po
+++ b/deltatech_followup/i18n/ro.po
@@ -1,0 +1,448 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_followup
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_needaction
+msgid "Action Needed"
+msgstr "Intervenție necesară"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__active
+msgid "Active"
+msgstr "Activ"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_ids
+msgid "Activities"
+msgstr "Activități"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr "Activitate Excepție Decorare"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_state
+msgid "Activity State"
+msgstr "Stare activitate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_type_icon
+msgid "Activity Type Icon"
+msgstr "Pictograma tipului de activitate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__with_refunds
+msgid "Also get refund invoices"
+msgstr "Preia și facturile storno"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__amount_margin
+msgid "Amount margin"
+msgstr "Marjă sumă"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__amount_margin
+msgid ""
+"Amount margin. If total due debit is lower than this margin, the followup "
+"will be skipped"
+msgstr ""
+"Marjă sumă. Dacă totalul debitului scadent este sub această marjă, urmărirea"
+" este omisă"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_attachment_count
+msgid "Attachment Count"
+msgstr "Număr atașamente"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__code
+msgid "Code"
+msgstr "Cod"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__code
+msgid "Code. Can be used in cron job to run only selected followups"
+msgstr "Cod. Poate fi folosit în cron pentru a rula doar urmăririle selectate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__match
+msgid "Comparator"
+msgstr "Comparator"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__match
+msgid ""
+"Comparator operator. If equal, only the invoices with the exact date will be"
+" processed. If greater or equal, all theinvoices with date grater or equal "
+"with the computed datewill be processed"
+msgstr ""
+"Operator de comparație. La egal, se procesează doar facturile cu data "
+"exactă. La mai mare sau egal, se procesează toate facturile cu data mai mare"
+" sau egală cu data calculată"
+
+#. module: deltatech_followup
+#: model:ir.model,name:deltatech_followup.model_res_partner
+msgid "Contact"
+msgstr "Contact"
+
+#. module: deltatech_followup
+#: model:ir.model,website_form_label:deltatech_followup.model_res_partner
+msgid "Create a Customer"
+msgstr "Creează un client"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__create_uid
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__create_date
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__create_date
+msgid "Created on"
+msgstr "Creat în"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__date_field
+msgid "Date field to use"
+msgstr "Câmpul de dată de folosit"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__relative_days
+msgid "Days from"
+msgstr "Zile de la"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__display_name
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__display_name
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__date_field__due_date
+msgid "Due date"
+msgstr "Data scadentă"
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__match__=
+msgid "Equal"
+msgstr "Egal"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_follower_ids
+msgid "Followers"
+msgstr "Persoane interesate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_partner_ids
+msgid "Followers (Partners)"
+msgstr "Urmăritori (Parteneri)"
+
+#. module: deltatech_followup
+#: model:ir.model,name:deltatech_followup.model_followup_send_wizard
+msgid "Followup Send Wizard"
+msgstr "Asistent trimitere urmărire"
+
+#. module: deltatech_followup
+#: model:res.groups,name:deltatech_followup.group_manage_followups
+msgid "Followup manager"
+msgstr "Administrator urmăriri"
+
+#. module: deltatech_followup
+#: model:ir.ui.menu,name:deltatech_followup.menu_invoice_followup
+msgid "Followups"
+msgstr "Urmăriri"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Pictogramă minunată pentru font, de ex. fa-sarcini"
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__match__>=
+msgid "Greater or equal"
+msgstr "Mai mare sau egal"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__has_message
+msgid "Has Message"
+msgstr "Are mesaj"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__id
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__id
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_partner__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_exception_icon
+msgid "Icon"
+msgstr "Pictogramă"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr "Pictograma pentru a indica o activitate de excepție."
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr "Dacă este selectat, mesajele noi necesită atenția dumneavoastră."
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_has_error
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr "Dacă este bifată, unele mesaje au o eroare de livrare."
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__use_customer_currency
+msgid ""
+"If checked, the currency of the customer will be used, otherwise the "
+"currency of the company"
+msgstr ""
+"Dacă este bifat, se folosește moneda clientului, altfel moneda companiei"
+
+#. module: deltatech_followup
+#: model:ir.actions.act_window,name:deltatech_followup.action_invoice_followup
+#: model:ir.model,name:deltatech_followup.model_account_invoice_followup
+#: model_terms:ir.ui.view,arch_db:deltatech_followup.view_followups_form
+msgid "Invoice Followup"
+msgstr "Urmărire factură"
+
+#. module: deltatech_followup
+#: model:ir.model.fields.selection,name:deltatech_followup.selection__account_invoice_followup__date_field__invoice_date
+msgid "Invoice date"
+msgstr "Data factura"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__invoice_html
+msgid "Invoices placeholder"
+msgstr "Substituent facturi"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_is_follower
+msgid "Is Follower"
+msgstr "Este urmăritor"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__write_uid
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare făcută de"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__write_date
+#: model:ir.model.fields,field_description:deltatech_followup.field_followup_send_wizard__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__mail_template
+msgid "Mail Template"
+msgstr "Șablon de e-mail"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__mail_template
+msgid "Mail template to use. You have to use a Partner model template."
+msgstr ""
+"Șablonul de e-mail de folosit. Trebuie folosit un șablon pe modelul "
+"Partener."
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_has_error
+msgid "Message Delivery error"
+msgstr "Eroare livrare mesaj"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_ids
+msgid "Messages"
+msgstr "Mesaje"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr "Data limită a activității mele"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__name
+msgid "Name"
+msgstr "Nume"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__name
+msgid "Name of the followup"
+msgstr "Numele urmăririi"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr "Data limită pentru următoarea activitate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_summary
+msgid "Next Activity Summary"
+msgstr "Sumarul următoarei activități"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_type_id
+msgid "Next Activity Type"
+msgstr "Tip de activitate urmatoare"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_needaction_counter
+msgid "Number of Actions"
+msgstr "Număr de acțiuni"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_has_error_counter
+msgid "Number of errors"
+msgstr "Numărul de erori"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr "Număr de mesaje care necesită acțiune"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr "Numărul de mesaje cu eroare de livrare"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__only_open
+msgid "Only open (unpaid) invoices will be processed"
+msgstr "Se procesează doar facturile neachitate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__only_open
+msgid "Only open invoices"
+msgstr "Doar facturile neachitate"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__with_refunds
+msgid "Parse refund invoices"
+msgstr "Include facturile storno"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__rating_ids
+msgid "Ratings"
+msgstr "Evaluări"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__relative_days
+msgid ""
+"Relative days from date field. Can be negative if you want to send this "
+"followup before the given date"
+msgstr ""
+"Zile relative față de câmpul de dată. Poate fi negativ dacă doriți "
+"trimiterea acestei urmăriri înainte de data dată"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__activity_user_id
+msgid "Responsible User"
+msgstr "Utilizator responsabil"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr "Eroare livrare SMS"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_partner__send_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_res_users__send_followup
+msgid "Send followup e-mails"
+msgstr "Trimite e-mailuri de urmărire"
+
+#. module: deltatech_followup
+#: model:ir.actions.server,name:deltatech_followup.action_send_followup
+msgid "Send now"
+msgstr "Trimite acum"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+"Stare bazată pe activități\n"
+"Întârziată: data scadentă este deja trecută\n"
+"Astăzi: activității pentru astăzi\n"
+"Planificate: activități viitoare."
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__date_field
+msgid ""
+"The date field from the invoices from which the send date will be computed"
+msgstr "Câmpul de dată din facturi din care se calculează data trimiterii"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__invoice_html
+msgid ""
+"This code will be inserted into the mail, replacing the[invoices] key string. The following placeholders canbe used:\n"
+"$number=invoice.number,\n"
+"$payment_term_id=invoice.payment_term_id,\n"
+"$date_invoice=invoice.date_invoice,\n"
+"$date_due=invoice.date_due,\n"
+"$amount_untaxed=invoice.amount_untaxed,\n"
+"$amount_tax=invoice.amount_tax,\n"
+"$amount_total=invoice.amount_total,\n"
+"$amount_due=invoice.residual,\n"
+"$total_debit=total amount to pay,\n"
+"$currency=invoice.currency\n"
+"$total_all_debit=all partner debit\n"
+"$total_due_debit=all due debit"
+msgstr ""
+"Acest cod va fi inserat în e-mail, înlocuind cheia [invoices]. Se pot folosi următorii substituenți:\n"
+"$number=numărul facturii,\n"
+"$payment_term_id=termenul de plată al facturii,\n"
+"$date_invoice=data facturii,\n"
+"$date_due=data scadentă a facturii,\n"
+"$amount_untaxed=suma fără TVA,\n"
+"$amount_tax=suma TVA,\n"
+"$amount_total=suma totală,\n"
+"$amount_due=suma de plată (rest),\n"
+"$total_debit=suma totală de plată,\n"
+"$currency=moneda facturii\n"
+"$total_all_debit=tot debitul partenerului\n"
+"$total_due_debit=tot debitul scadent"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr "Tipul activității de excepție din înregistrare."
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__use_customer_currency
+msgid "Use customer currency"
+msgstr "Folosește moneda clientului"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,field_description:deltatech_followup.field_account_invoice_followup__website_message_ids
+msgid "Website Messages"
+msgstr "Mesaje Website"
+
+#. module: deltatech_followup
+#: model:ir.model.fields,help:deltatech_followup.field_account_invoice_followup__website_message_ids
+msgid "Website communication history"
+msgstr "Istoric comunicare website"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_followup` (urmărire automată facturi neîncasate, cu wizard de trimitere e-mail) — modulul nu avea folder `i18n`. **73/73 termeni traduși.**

Generat din exportul `.pot` real al modulului.

## Terminologie

Evit deliberat familia „deschis/deschidere" pentru `open invoices` — rezervată exercițiului financiar (cont 891, OMFP 1802/2014): `Only open invoices` → „Doar facturile neachitate", nu „facturi deschise".

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)