### PR TITLE
[IMP] deltatech_transport_change: traducere RO

### DIFF
--- a/deltatech_transport_change/i18n/ro.po
+++ b/deltatech_transport_change/i18n/ro.po
@@ -1,0 +1,371 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_transport_change
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_needaction
+msgid "Action Needed"
+msgstr "Intervenție necesară"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_ids
+msgid "Activities"
+msgstr "Activități"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_exception_decoration
+msgid "Activity Exception Decoration"
+msgstr "Activitate Excepție Decorare"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_state
+msgid "Activity State"
+msgstr "Stare activitate"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_type_icon
+msgid "Activity Type Icon"
+msgstr "Pictograma tipului de activitate"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_attachment_count
+msgid "Attachment Count"
+msgstr "Număr atașamente"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__repo_branch
+msgid "Branch"
+msgstr "Ramură"
+
+#. module: deltatech_transport_change
+#: model:ir.ui.menu,name:deltatech_transport_change.menu_transport_config
+msgid "Configurations"
+msgstr "Configurări"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__create_uid
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__create_date
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__create_date
+msgid "Created on"
+msgstr "Creat în"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__credential_type
+msgid "Credential Type"
+msgstr "Tip credențiale"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__display_name
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__domain
+msgid "Domain"
+msgstr "Domeniu"
+
+#. module: deltatech_transport_change
+#: model:ir.actions.server,name:deltatech_transport_change.server_action_transport_config_export
+#: model_terms:ir.ui.view,arch_db:deltatech_transport_change.view_transport_config_form
+msgid "Export CSV"
+msgstr "Export CSV"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__domain
+msgid "Expression list, e.g. [('company_id','=',1)]"
+msgstr "Listă de expresii, ex. [('company_id','=',1)]"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__field_ids
+msgid "Fields"
+msgstr "Câmpuri"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_repo__module_name
+msgid "Folded module name from repository"
+msgstr "Numele scurt al modulului din repository"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_follower_ids
+msgid "Followers"
+msgstr "Persoane interesate"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_partner_ids
+msgid "Followers (Partners)"
+msgstr "Urmăritori (Parteneri)"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_type_icon
+msgid "Font awesome icon e.g. fa-tasks"
+msgstr "Pictogramă minunată pentru font, de ex. fa-sarcini"
+
+#. module: deltatech_transport_change
+#: model_terms:ir.ui.view,arch_db:deltatech_transport_change.view_transport_config_form
+msgid "Generate File"
+msgstr "Generează fișierul"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__repo_id
+msgid "Git Repository"
+msgstr "Repository Git"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__password
+msgid "Git Token / Password"
+msgstr "Token Git / Parolă"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__repo_url
+msgid "Git URL"
+msgstr "URL Git"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__username
+msgid "Git Username"
+msgstr "Utilizator Git"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields.selection,name:deltatech_transport_change.selection__transport_repo__credential_type__https
+msgid "HTTPS"
+msgstr "HTTPS"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__has_message
+msgid "Has Message"
+msgstr "Are mesaj"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__id
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_exception_icon
+msgid "Icon"
+msgstr "Pictogramă"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_exception_icon
+msgid "Icon to indicate an exception activity."
+msgstr "Pictograma pentru a indica o activitate de excepție."
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_needaction
+msgid "If checked, new messages require your attention."
+msgstr "Dacă este selectat, mesajele noi necesită atenția dumneavoastră."
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_has_error
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_has_sms_error
+msgid "If checked, some messages have a delivery error."
+msgstr "Dacă este bifată, unele mesaje au o eroare de livrare."
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_is_follower
+msgid "Is Follower"
+msgstr "Este urmăritor"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__last_export
+msgid "Last Export"
+msgstr "Ultimul export"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__write_uid
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare făcută de"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__write_date
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__repo_local_path
+msgid "Local Path"
+msgstr "Cale locală"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_has_error
+msgid "Message Delivery error"
+msgstr "Eroare livrare mesaj"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_ids
+msgid "Messages"
+msgstr "Mesaje"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__model_id
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__model_name
+msgid "Model"
+msgstr "Model"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__module_name
+msgid "Module Code"
+msgstr "Cod modul"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__my_activity_date_deadline
+msgid "My Activity Deadline"
+msgstr "Data limită a activității mele"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__name
+msgid "Name"
+msgstr "Nume"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_date_deadline
+msgid "Next Activity Deadline"
+msgstr "Data limită pentru următoarea activitate"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_summary
+msgid "Next Activity Summary"
+msgstr "Sumarul următoarei activități"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_type_id
+msgid "Next Activity Type"
+msgstr "Tip de activitate urmatoare"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_needaction_counter
+msgid "Number of Actions"
+msgstr "Număr de acțiuni"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_has_error_counter
+msgid "Number of errors"
+msgstr "Numărul de erori"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_needaction_counter
+msgid "Number of messages requiring action"
+msgstr "Număr de mesaje care necesită acțiune"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__message_has_error_counter
+msgid "Number of messages with delivery error"
+msgstr "Numărul de mesaje cu eroare de livrare"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__rating_ids
+msgid "Ratings"
+msgstr "Evaluări"
+
+#. module: deltatech_transport_change
+#: model:ir.ui.menu,name:deltatech_transport_change.menu_transport_repo
+msgid "Repositories"
+msgstr "Repository-uri"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__name
+msgid "Repository Name"
+msgstr "Nume repository"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__activity_user_id
+msgid "Responsible User"
+msgstr "Utilizator responsabil"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__message_has_sms_error
+msgid "SMS Delivery error"
+msgstr "Eroare livrare SMS"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields.selection,name:deltatech_transport_change.selection__transport_repo__credential_type__ssh
+msgid "SSH Key"
+msgstr "Cheie SSH"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_repo__ssh_key
+msgid "SSH Private Key"
+msgstr "Cheie privată SSH"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_state
+msgid ""
+"Status based on activities\n"
+"Overdue: Due date is already passed\n"
+"Today: Activity date is today\n"
+"Planned: Future activities."
+msgstr ""
+"Stare bazată pe activități\n"
+"Întârziată: data scadentă este deja trecută\n"
+"Astăzi: activității pentru astăzi\n"
+"Planificate: activități viitoare."
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__field_ids
+msgid ""
+"The fields to export. Only fields from the selected model are available."
+msgstr ""
+"Câmpurile de exportat. Sunt disponibile doar câmpurile modelului selectat."
+
+#. module: deltatech_transport_change
+#: model:ir.ui.menu,name:deltatech_transport_change.menu_transport_root
+msgid "Transport"
+msgstr "Transport"
+
+#. module: deltatech_transport_change
+#: model:ir.actions.act_window,name:deltatech_transport_change.action_transport_config
+msgid "Transport Config"
+msgstr "Configurare transport"
+
+#. module: deltatech_transport_change
+#: model:ir.model,name:deltatech_transport_change.model_transport_config
+msgid "Transport Configuration Export"
+msgstr "Export configurare transport"
+
+#. module: deltatech_transport_change
+#: model:ir.actions.act_window,name:deltatech_transport_change.action_transport_repo
+msgid "Transport Repos"
+msgstr "Repository-uri transport"
+
+#. module: deltatech_transport_change
+#: model:ir.model,name:deltatech_transport_change.model_transport_repo
+msgid "Transport Repository Configuration"
+msgstr "Configurare repository transport"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__activity_exception_decoration
+msgid "Type of the exception activity on record."
+msgstr "Tipul activității de excepție din înregistrare."
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,field_description:deltatech_transport_change.field_transport_config__website_message_ids
+msgid "Website Messages"
+msgstr "Mesaje Website"
+
+#. module: deltatech_transport_change
+#: model:ir.model.fields,help:deltatech_transport_change.field_transport_config__website_message_ids
+msgid "Website communication history"
+msgstr "Istoric comunicare website"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_transport_change` (transport/export de configurări între medii, prin repository Git) — modulul nu avea folder `i18n`. **67/67 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)