### PR TITLE
[IMP] deltatech_product_visibility: traducere RO

### DIFF
--- a/deltatech_product_visibility/i18n/ro.po
+++ b/deltatech_product_visibility/i18n/ro.po
@@ -1,0 +1,241 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_visibility
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__active
+msgid "Active"
+msgstr "Activ"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__good
+msgid "Bun"
+msgstr "Bun"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_public_category
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__public_category
+msgid "Categorie publică"
+msgstr "Categorie publică"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_default_code
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__default_code
+msgid "Cod produs (SKU)"
+msgstr "Cod produs (SKU)"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__code
+msgid "Code"
+msgstr "Cod"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__create_date
+msgid "Created on"
+msgstr "Creat în"
+
+#. module: deltatech_product_visibility
+#: model:ir.actions.act_window,name:deltatech_product_visibility.visibility_criterion_action
+msgid "Criterii vizibilitate produs"
+msgstr "Criterii vizibilitate produs"
+
+#. module: deltatech_product_visibility
+#: model:ir.model,name:deltatech_product_visibility.model_deltatech_product_visibility_criterion
+msgid "Criteriu de vizibilitate a produsului"
+msgstr "Criteriu de vizibilitate a produsului"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_detail
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_detail
+msgid "Defalcare vizibilitate"
+msgstr "Defalcare vizibilitate"
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.actions.act_window,help:deltatech_product_visibility.visibility_criterion_action
+msgid "Definește criteriile și ponderile scorului de vizibilitate"
+msgstr "Definește criteriile și ponderile scorului de vizibilitate"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_ecommerce_description
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__ecommerce_description
+msgid "Descriere eCommerce (scurtă)"
+msgstr "Descriere eCommerce (scurtă)"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_website_description
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__website_description
+msgid "Descriere website (amplă)"
+msgstr "Descriere website (amplă)"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__display_name
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_gallery
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__gallery
+msgid "Galerie de imagini (≥ 2)"
+msgstr "Galerie de imagini (≥ 2)"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__id
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_main_image
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__main_image
+msgid "Imagine principală"
+msgstr "Imagine principală"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__hidden
+msgid "Invizibil"
+msgstr "Invizibil"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare făcută de"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__name
+msgid "Name"
+msgstr "Nume"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_level
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_level
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_search_visibility
+msgid "Nivel vizibilitate"
+msgstr "Nivel vizibilitate"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__optimal
+msgid "Optim"
+msgstr "Optim"
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.actions.act_window,help:deltatech_product_visibility.visibility_criterion_action
+msgid ""
+"Ponderile pot fi ajustate fără cod. După modificare, folosește butonul "
+"„Recalculează scorurile”."
+msgstr ""
+"Ponderile pot fi ajustate fără cod. După modificare, folosește butonul "
+"„Recalculează scorurile”."
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_sale_price
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__sale_price
+msgid "Preț de vânzare setat"
+msgstr "Preț de vânzare setat"
+
+#. module: deltatech_product_visibility
+#: model:ir.model,name:deltatech_product_visibility.model_product_template
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,help:deltatech_product_visibility.field_deltatech_product_visibility_criterion__weight
+msgid "Punctele acordate când criteriul este îndeplinit."
+msgstr "Punctele acordate când criteriul este îndeplinit."
+
+#. module: deltatech_product_visibility
+#: model:ir.actions.server,name:deltatech_product_visibility.visibility_recompute_action
+msgid "Recalculează scorurile de vizibilitate"
+msgstr "Recalculează scorurile de vizibilitate"
+
+#. module: deltatech_product_visibility
+#: model:deltatech.product.visibility.criterion,name:deltatech_product_visibility.criterion_seo
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__deltatech_product_visibility_criterion__code__seo
+msgid "SEO complet (titlu + descriere + cuvinte cheie)"
+msgstr "SEO complet (titlu + descriere + cuvinte cheie)"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,help:deltatech_product_visibility.field_product_product__website_visibility_score
+#: model:ir.model.fields,help:deltatech_product_visibility.field_product_template__website_visibility_score
+msgid ""
+"Scor 0-100: cât de complet/optimizat este produsul pentru catalogul de pe "
+"website."
+msgstr ""
+"Scor 0-100: cât de complet/optimizat este produsul pentru catalogul de pe "
+"website."
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_score
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_score
+msgid "Scor vizibilitate"
+msgstr "Scor vizibilitate"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__sequence
+msgid "Sequence"
+msgstr "Secvență"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields.selection,name:deltatech_product_visibility.selection__product_template__website_visibility_level__weak
+msgid "Slab"
+msgstr "Slab"
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.visibility_criterion_view_list
+msgid "Total"
+msgstr "Total"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_product__website_visibility_badge
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_product_template__website_visibility_badge
+msgid "Vizibilitate"
+msgstr "Vizibilitate"
+
+#. module: deltatech_product_visibility
+#: model:ir.ui.menu,name:deltatech_product_visibility.menu_visibility_criterion
+msgid "Vizibilitate produs"
+msgstr "Vizibilitate produs"
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_form_visibility_detail
+msgid "Vizibilitate website"
+msgstr "Vizibilitate website"
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_search_visibility
+msgid "Vizibilitate: invizibil"
+msgstr "Vizibilitate: invizibil"
+
+#. module: deltatech_product_visibility
+#: model_terms:ir.ui.view,arch_db:deltatech_product_visibility.product_template_search_visibility
+msgid "Vizibilitate: necesită atenție"
+msgstr "Vizibilitate: necesită atenție"
+
+#. module: deltatech_product_visibility
+#: model:ir.model.fields,field_description:deltatech_product_visibility.field_deltatech_product_visibility_criterion__weight
+msgid "Weight"
+msgstr "Masă"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_product_visibility` — modulul nu avea folder `i18n`. **40/40 termeni traduși.**

Modulul e scris deja în română în cod (câmpuri precum „Scor vizibilitate", „Nivel vizibilitate", „Defalcare vizibilitate") — traducerea e identitate pe majoritatea termenilor, verificată direct în sursă.

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)