### PR TITLE
[IMP] deltatech_cron_monitor_webhook: traducere RO

### DIFF
--- a/deltatech_cron_monitor_webhook/i18n/ro.po
+++ b/deltatech_cron_monitor_webhook/i18n/ro.po
@@ -1,0 +1,185 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_cron_monitor_webhook
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Authentication Options (choose ONE):</strong>"
+msgstr "<strong>Opțiuni de autentificare (alegeți UNA):</strong>"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"<strong>Body (POST only):</strong> Send a JSON with token (requires "
+"<code>Content-Type: application/json</code>)"
+msgstr ""
+"<strong>Corp (doar POST):</strong> Trimiteți un JSON cu token-ul (necesită "
+"<code>Content-Type: application/json</code>)"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Header:</strong> Add <code>X-Access-Token: YOUR_TOKEN</code>"
+msgstr ""
+"<strong>Antet:</strong> Adăugați <code>X-Access-Token: YOUR_TOKEN</code>"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Method:</strong> POST or GET"
+msgstr "<strong>Metodă:</strong> POST sau GET"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "<strong>Schedule:</strong> Your desired interval"
+msgstr "<strong>Programare:</strong> intervalul dorit"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"<strong>URL Parameter:</strong> Append <code>?token=YOUR_TOKEN</code> to the"
+" URL"
+msgstr ""
+"<strong>Parametru URL:</strong> Adăugați <code>?token=YOUR_TOKEN</code> la "
+"URL"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"<strong>URL:</strong> Copy from the Cron Job (Webhook Configuration tab)\n"
+"                                                <br/>\n"
+"                                                <small class=\"text-muted\">Or use the global token: <code>https://your-domain.com/cron/webhook/YOUR_CODE?token=GLOBAL_TOKEN</code></small>"
+msgstr ""
+"<strong>URL:</strong> Copiați din jobul Cron (fila Configurare Webhook)\n"
+"                                                <br/>\n"
+"                                                <small class=\"text-muted\">Sau folosiți token-ul global: <code>https://your-domain.com/cron/webhook/YOUR_CODE?token=GLOBAL_TOKEN</code></small>"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model,name:deltatech_cron_monitor_webhook.model_res_config_settings
+msgid "Config Settings"
+msgstr "Setări de configurare"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Create a free account on"
+msgstr "Creați un cont gratuit pe"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Create a new cron job with these settings:"
+msgstr "Creați un job cron nou cu aceste setări:"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Cron Monitor"
+msgstr "Monitor Cron"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Cron Monitoring Settings"
+msgstr "Setări de monitorizare Cron"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__display_name
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_res_config_settings__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__enable_webhook
+msgid "Enable Webhook"
+msgstr "Activează webhook-ul"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Example Body for POST:"
+msgstr "Exemplu de corp pentru POST:"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Generate Token"
+msgstr "Generare token"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_res_config_settings__cron_webhook_token
+msgid "Global Webhook Token"
+msgstr "Token global webhook"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Global webhook security settings"
+msgstr "Setări de securitate globale pentru webhook"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__id
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_res_config_settings__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model,name:deltatech_cron_monitor_webhook.model_ir_cron
+msgid "Scheduled Actions"
+msgstr "Acțiuni planificate"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,help:deltatech_cron_monitor_webhook.field_ir_cron__webhook_code
+msgid "Unique code for this webhook"
+msgstr "Cod unic pentru acest webhook"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__webhook_code
+msgid "Webhook Code"
+msgstr "Cod webhook"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.constraint,message:deltatech_cron_monitor_webhook.constraint_ir_cron_webhook_code_unique
+msgid "Webhook Code must be unique!"
+msgstr "Codul webhook trebuie să fie unic!"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.ir_cron_view_form_inherit_monitoring
+msgid "Webhook Configuration"
+msgstr "Configurare Webhook"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "Webhook Security"
+msgstr "Securitate webhook"
+
+#. module: deltatech_cron_monitor_webhook
+#: model:ir.model.fields,field_description:deltatech_cron_monitor_webhook.field_ir_cron__webhook_url
+msgid "Webhook URL"
+msgstr "Webhook URL"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "cron-job.org"
+msgstr "cron-job.org"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid ""
+"{\n"
+"    \"token\": \"YOUR_TOKEN_HERE\"\n"
+"}"
+msgstr ""
+"{\n"
+"    \"token\": \"YOUR_TOKEN_HERE\"\n"
+"}"
+
+#. module: deltatech_cron_monitor_webhook
+#: model_terms:ir.ui.view,arch_db:deltatech_cron_monitor_webhook.res_config_settings_view_form
+msgid "🚀 External Cron Setup (cron-job.org)"
+msgstr "🚀 Configurare CRON extern (cron-job.org)"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_cron_monitor_webhook` (declanșare joburi CRON prin webhook extern, cu token de securitate) — modulul nu avea folder `i18n`. **29/29 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)