### PR TITLE
[IMP] deltatech_putaway_strategy: status Production/Stable

### DIFF
--- a/deltatech_putaway_strategy/__manifest__.py
+++ b/deltatech_putaway_strategy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Deltatech Putaway Strategy",
-    "version": "18.0.1.0.5",
+    "version": "18.0.1.0.6",
     "summary": "Location capacities and enhanced putaway strategy for Inventory",
     "author": "Deltatech, Terrabit",
     "website": "https://www.terrabit.ro",
@@ -11,7 +11,7 @@
         "views/stock_location_views.xml",
         "views/stock_picking_type_views.xml",
     ],
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "maintainers": ["dhongu"],
     "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_putaway_strategy/readme/HISTORY.md
+++ b/deltatech_putaway_strategy/readme/HISTORY.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 18.0.1.0.6 (2026-08-04)
+
+- Development status raised from *Beta* to *Production/Stable*. The module is consumed by
+  `deltatech_stock_barcode`, which is itself published as *Production/Stable*; `manifestoo
+  check-dev-status` rejects a module that is more mature than one of its dependencies, and
+  that check blocked the whole test job on the 18.0 branch. No functional change.


### PR DESCRIPTION
Deblochează pasul `Check development status` din CI-ul lui `bitshop_ent` pe branch-ul 18.0.

`manifestoo check-dev-status` respinge un modul declarat mai matur decât o dependență a lui:

    deltatech_stock_barcode (Production/Stable) depends on deltatech_putaway_strategy (Beta)

Pasul e înaintea lui `Initialize test db` / `Run tests`, deci pe 18.0 nu rula niciun test.
Aceeași violare există și pe 19.0, unde e doar tolerată (`continue-on-error: true`).

Ridicăm dependența la *Production/Stable* în loc să coborâm modulul consumator, care e publicat
pe Apps Store. Fără schimbare funcțională: doar `development_status`, versiune și HISTORY.md.

**De reținut la review:** modulul a primit recent două corecții de fond — `19.0.1.0.6` un
`AccessError` care împiedica un simplu utilizator de stoc să valideze transferuri într-o locație
cu capacitate configurată, iar `19.0.1.0.5` restaurarea opțiunii *Avoid Root Location on
Reservation*, pierdută la migrarea 18→19. Eticheta *Beta* nu era pură inerție; ridicarea e o
decizie asumată, semnalată explicit înainte de a fi aplicată.

Aplicat identic pe 19.0 (PR separat în același repo), ca statusul să nu divergă între versiuni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)