### PR TITLE
[IMP] deltatech_putaway_strategy: status Production/Stable

### DIFF
--- a/deltatech_putaway_strategy/__manifest__.py
+++ b/deltatech_putaway_strategy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Deltatech Putaway Strategy",
-    "version": "19.0.1.0.6",
+    "version": "19.0.1.0.7",
     "summary": "Location capacities and enhanced putaway strategy for Inventory",
     "author": "Deltatech, Terrabit",
     "website": "https://www.terrabit.ro",
@@ -11,7 +11,7 @@
         "views/stock_location_views.xml",
         "views/stock_picking_type_views.xml",
     ],
-    "development_status": "Beta",
+    "development_status": "Production/Stable",
     "maintainers": ["dhongu"],
     "images": ["static/description/main_screenshot.png"],
 }

--- a/deltatech_putaway_strategy/readme/HISTORY.md
+++ b/deltatech_putaway_strategy/readme/HISTORY.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 19.0.1.0.7 (2026-08-04)
+
+- Development status raised from *Beta* to *Production/Stable*. The module is consumed by
+  `deltatech_stock_barcode`, which is itself published as *Production/Stable*; `manifestoo
+  check-dev-status` rejects a module that is more mature than one of its dependencies. No
+  functional change.
+
 ## 19.0.1.0.6 (2026-08-04)
 
 - Fix: a plain stock user (`stock.group_stock_user`) could not validate a transfer into a


### PR DESCRIPTION
Aliniere cu branch-ul 18.0 (PR #2744 în acest repo), ca `development_status` să nu divergă
între versiuni.

`manifestoo check-dev-status` respinge un modul declarat mai matur decât o dependență a lui:

    deltatech_stock_barcode (Production/Stable) depends on deltatech_putaway_strategy (Beta)

Pe 19.0 violarea există deja, dar pasul e tolerat în CI-ul lui `bitshop_ent`
(`continue-on-error: true`), deci nu bloca nimic; pe 18.0 bloca rularea testelor.

Fără schimbare funcțională: doar `development_status`, versiune și HISTORY.md.

**De reținut la review:** modulul a primit chiar recent două corecții de fond — `19.0.1.0.6` un
`AccessError` care împiedica un simplu utilizator de stoc să valideze transferuri într-o locație
cu capacitate configurată, iar `19.0.1.0.5` restaurarea opțiunii *Avoid Root Location on
Reservation*, pierdută la migrarea 18→19. Eticheta *Beta* nu era pură inerție; ridicarea e o
decizie asumată, semnalată explicit înainte de a fi aplicată.

🤖 Generated with [Claude Code](https://claude.com/claude-code)