### PR TITLE
[IMP] deltatech_markdown_field: traducere RO

### DIFF
--- a/deltatech_markdown_field/i18n/ro.po
+++ b/deltatech_markdown_field/i18n/ro.po
@@ -1,0 +1,137 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_markdown_field
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.esm.js:0
+msgid "Adresă link (URL):"
+msgstr "Adresă link (URL):"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Bold"
+msgstr "Îngroșat"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Bullet list"
+msgstr "Listă cu marcatori"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Clear formatting"
+msgstr "Șterge formatarea"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Code block"
+msgstr "Bloc de cod"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "H1"
+msgstr "H1"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "H2"
+msgstr "H2"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "H3"
+msgstr "H3"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Heading 1"
+msgstr "Titlu 1"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Heading 2"
+msgstr "Titlu 2"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Heading 3"
+msgstr "Titlu 3"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Italic"
+msgstr "Înclinat"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Link"
+msgstr "Link"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.esm.js:0
+msgid "Markdown"
+msgstr "Markdown"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Markdown toolbar"
+msgstr "Bară de instrumente Markdown"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.esm.js:0
+msgid "Minimum height"
+msgstr "Înălțime minimă"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Numbered list"
+msgstr "Listă numerotată"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Paragraph"
+msgstr "Paragraf"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Quote"
+msgstr "Ofertă"
+
+#. module: deltatech_markdown_field
+#. odoo-javascript
+#: code:addons/deltatech_markdown_field/static/src/fields/markdown_field.xml:0
+msgid "Strikethrough"
+msgstr "Tăiat"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_markdown_field` (widget de câmp Markdown cu bară de instrumente) — modulul nu avea folder `i18n`. **20/20 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)