### PR TITLE
[IMP] deltatech_mrp_bom: traducere RO

### DIFF
--- a/deltatech_mrp_bom/i18n/ro.po
+++ b/deltatech_mrp_bom/i18n/ro.po
@@ -1,0 +1,105 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_bom
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom_line__bom_product_template_attribute_value_ids
+msgid "Apply on Variants"
+msgstr "Aplicați pe variante"
+
+#. module: deltatech_mrp_bom
+#. odoo-python
+#: code:addons/deltatech_mrp_bom/models/mrp_bom.py:0
+msgid "BOM"
+msgstr "BOM"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_report_mrp_report_bom_structure
+msgid "BOM Overview Report"
+msgstr "Raport general LDM"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,help:deltatech_mrp_bom.field_mrp_bom_line__bom_product_template_attribute_value_ids
+msgid "BOM Product Variants needed to apply this line."
+msgstr "Variantele de produs LdM necesare pentru a aplica această linie."
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields.selection,name:deltatech_mrp_bom.selection__mrp_bom__base_type__base
+msgid "Base"
+msgstr "Baza"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom__base_type
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_production__bom_base_type
+msgid "Base Type"
+msgstr "Tip bază"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_mrp_bom
+msgid "Bill of Material"
+msgstr "Listă de materiale"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_mrp_bom_line
+msgid "Bill of Material Line"
+msgstr "Linie Factură Materiale"
+
+#. module: deltatech_mrp_bom
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_bom.mrp_production_form_view
+msgid "Compute Derived BoM"
+msgstr "Calculează BOM derivat"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields.selection,name:deltatech_mrp_bom.selection__mrp_bom__base_type__derived
+msgid "Derived"
+msgstr "Derivat"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom_line__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_production__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_report_mrp_report_bom_structure__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom__id
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_bom_line__id
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_mrp_production__id
+#: model:ir.model.fields,field_description:deltatech_mrp_bom.field_report_mrp_report_bom_structure__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model,name:deltatech_mrp_bom.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Comanda de Producție"
+
+#. module: deltatech_mrp_bom
+#: model:ir.model.fields.selection,name:deltatech_mrp_bom.selection__mrp_bom__base_type__normal
+msgid "Normal"
+msgstr "Normal"
+
+#. module: deltatech_mrp_bom
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_bom.mrp_bom_form_view
+msgid "Recompute Components"
+msgstr "Recalculează componentele"
+
+#. module: deltatech_mrp_bom
+#: model_terms:ir.ui.view,arch_db:deltatech_mrp_bom.mrp_bom_form_view
+msgid "Show"
+msgstr "Afișează"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_mrp_bom` (BOM derivat, calculat automat din BOM de bază pentru ordinele de fabricație) — modulul nu avea folder `i18n`. **16/16 termeni traduși.**

`BOM` rămâne netradus (acronim consacrat, folosit ca atare și în README-ul modulului).

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)