### PR TITLE
[IMP] deltatech_mrp_concentration: traducere RO

### DIFF
--- a/deltatech_mrp_concentration/i18n/ro.po
+++ b/deltatech_mrp_concentration/i18n/ro.po
@@ -1,0 +1,100 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_concentration
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model,name:deltatech_mrp_concentration.model_mrp_bom
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__bom_id
+msgid "Bill of Material"
+msgstr "Listă de materiale"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model,name:deltatech_mrp_concentration.model_mrp_bom_line
+msgid "Bill of Material Line"
+msgstr "Linie Factură Materiale"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_production__bom_id
+msgid ""
+"Bills of Materials, also called recipes, are used to autocomplete components"
+" and work order instructions."
+msgstr ""
+"Listele de materiale, numite și rețete, sunt folosite pentru a completa "
+"automat componentele și instrucțiunile comenzilor de lucru."
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__concentration
+msgid "Concentration"
+msgstr "Concentrație"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__concentration_primary
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__concentration_primary
+msgid "Concentration Primary"
+msgstr "Concentrație primară"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_bom__concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_production__concentration
+msgid "Concentration of the final product"
+msgstr "Concentrația produsului final"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_bom__concentration_primary
+#: model:ir.model.fields,help:deltatech_mrp_concentration.field_mrp_production__concentration_primary
+msgid "Concentration of the main ingredient"
+msgstr "Concentrația ingredientului principal"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom_line__display_name
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom__id
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom_line__id
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_production__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields,field_description:deltatech_mrp_concentration.field_mrp_bom_line__ingredient_type
+msgid "Ingredient Type"
+msgstr "Tip ingredient"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model,name:deltatech_mrp_concentration.model_mrp_production
+msgid "Manufacturing Order"
+msgstr "Comanda de Producție"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields.selection,name:deltatech_mrp_concentration.selection__mrp_bom_line__ingredient_type__normal
+msgid "Normal"
+msgstr "Normal"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields.selection,name:deltatech_mrp_concentration.selection__mrp_bom_line__ingredient_type__primary
+msgid "Primary"
+msgstr "Primar"
+
+#. module: deltatech_mrp_concentration
+#: model:ir.model.fields.selection,name:deltatech_mrp_concentration.selection__mrp_bom_line__ingredient_type__secondary
+msgid "Secondary"
+msgstr "Secundar"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_mrp_concentration` (concentrația produsului final și a ingredientului principal, pe BOM și ordin de fabricație) — modulul nu avea folder `i18n`. **14/14 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)