### PR TITLE
[IMP] deltatech_line_counter: traducere RO

### DIFF
--- a/deltatech_line_counter/i18n/ro.po
+++ b/deltatech_line_counter/i18n/ro.po
@@ -1,0 +1,79 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_line_counter
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_line_counter
+#: model_terms:ir.ui.view,arch_db:deltatech_line_counter.view_line_counter_wizard_form
+msgid "Cancel"
+msgstr "Anulează"
+
+#. module: deltatech_line_counter
+#: model_terms:ir.ui.view,arch_db:deltatech_line_counter.view_line_counter_wizard_form
+msgid "Count Lines"
+msgstr "Numără liniile"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__create_date
+msgid "Created on"
+msgstr "Creat în"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare făcută de"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_line_counter
+#: model:ir.actions.act_window,name:deltatech_line_counter.action_line_counter_wizard
+#: model:ir.ui.menu,name:deltatech_line_counter.menu_line_counter_wizard
+#: model_terms:ir.ui.view,arch_db:deltatech_line_counter.view_line_counter_wizard_form
+msgid "Line Counter"
+msgstr "Numărător linii"
+
+#. module: deltatech_line_counter
+#: model:ir.model,name:deltatech_line_counter.model_line_counter_wizard
+msgid "Module Line Counter Wizard"
+msgstr "Asistent numărare linii modul"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__module_ids
+msgid "Modules"
+msgstr "Module"
+
+#. module: deltatech_line_counter
+#: model:ir.model.fields,field_description:deltatech_line_counter.field_line_counter_wizard__result
+msgid "Result"
+msgstr "Rezultat"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_line_counter` (numărare linii de cod per modul) — modulul nu avea folder `i18n`. **12/12 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)