### PR TITLE
[IMP] deltatech_download: traducere RO

### DIFF
--- a/deltatech_download/i18n/ro.po
+++ b/deltatech_download/i18n/ro.po
@@ -1,0 +1,74 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_download
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__create_uid
+msgid "Created by"
+msgstr "Creat de"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__create_date
+msgid "Created on"
+msgstr "Creat în"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_ir_actions_report__direct_download
+msgid "Direct Download"
+msgstr "Descărcare directă"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_ir_actions_report__display_name
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_download
+#: model:ir.model,name:deltatech_download.model_wizard_download_file
+msgid "Download Wizard"
+msgstr "Asistent descărcare"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__data_file
+msgid "File"
+msgstr "Fișier"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__file_name
+msgid "File Name"
+msgstr "Nume fișier"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_ir_actions_report__id
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__write_uid
+msgid "Last Updated by"
+msgstr "Ultima actualizare făcută de"
+
+#. module: deltatech_download
+#: model:ir.model.fields,field_description:deltatech_download.field_wizard_download_file__write_date
+msgid "Last Updated on"
+msgstr "Ultima actualizare pe"
+
+#. module: deltatech_download
+#: model:ir.model,name:deltatech_download.model_ir_actions_report
+msgid "Report Action"
+msgstr "Acțiune raport"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_download` — modulul nu avea folder `i18n`. **11/11 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)