### PR TITLE
[IMP] deltatech_mrp_simple_barcode: traducere RO

### DIFF
--- a/deltatech_mrp_simple_barcode/i18n/ro.po
+++ b/deltatech_mrp_simple_barcode/i18n/ro.po
@@ -1,0 +1,79 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_mrp_simple_barcode
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,field_description:deltatech_mrp_simple_barcode.field_mrp_simple___barcode_scanned
+msgid "Barcode Scanned"
+msgstr "Cod de bare scanat"
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,field_description:deltatech_mrp_simple_barcode.field_mrp_simple__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "Error"
+msgstr "Eroare"
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,field_description:deltatech_mrp_simple_barcode.field_mrp_simple__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "Info"
+msgstr "Informații"
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model,name:deltatech_mrp_simple_barcode.model_mrp_simple
+msgid "MRP Simple"
+msgstr "MRP Simplu"
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "Status does not allow scanning"
+msgstr "Starea nu permite scanarea"
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "The %(product_name)s product quantity was set to %(product_qty)s"
+msgstr ""
+"Cantitatea produsului %(product_name)s a fost setată la %(product_qty)s"
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "The %s product was added"
+msgstr "Produsul %s a fost adăugat"
+
+#. module: deltatech_mrp_simple_barcode
+#. odoo-python
+#: code:addons/deltatech_mrp_simple_barcode/models/mrp_simple.py:0
+msgid "There is no product with barcode or internal reference %s"
+msgstr "Nu există niciun produs cu codul de bare sau referința internă %s"
+
+#. module: deltatech_mrp_simple_barcode
+#: model:ir.model.fields,help:deltatech_mrp_simple_barcode.field_mrp_simple___barcode_scanned
+msgid "Value of the last barcode scanned."
+msgstr "Valoarea ultimului cod de bare scanat."


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_mrp_simple_barcode` (scanare cod de bare pentru MRP Simplu) — modulul nu avea folder `i18n`. **11/11 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)