### PR TITLE
[IMP] deltatech_warehouse_map: traducere RO

### DIFF
--- a/deltatech_warehouse_map/i18n/ro.po
+++ b/deltatech_warehouse_map/i18n/ro.po
@@ -1,0 +1,83 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_warehouse_map
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "<small class=\"text-muted\">Vizualizare ierarhică depozit</small>"
+msgstr "<small class=\"text-muted\">Vizualizare ierarhică depozit</small>"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Cantitate Disponibilă"
+msgstr "Cantitate Disponibilă"
+
+#. module: deltatech_warehouse_map
+#: model:ir.model.fields,field_description:deltatech_warehouse_map.field_stock_location__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Hartă Depozit -"
+msgstr "Hartă Depozit -"
+
+#. module: deltatech_warehouse_map
+#: model:ir.model.fields,field_description:deltatech_warehouse_map.field_stock_location__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_warehouse_map
+#: model:ir.model,name:deltatech_warehouse_map.model_stock_location
+msgid "Inventory Locations"
+msgstr "Locații inventar"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.location_recursive_node
+msgid ""
+"Locație: {{0}} \n"
+"Grad Ocupare: {{1}}% \n"
+"Stoc: {{2}} / {{3}}"
+msgstr ""
+"Locație: {{0}} \n"
+"Grad Ocupare: {{1}}% \n"
+"Stoc: {{2}} / {{3}}"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_stock_location_tree_inherit_deltatech_map
+msgid "Map"
+msgstr "Hartă"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_stock_location_form_inherit_deltatech_map
+msgid "Open Map"
+msgstr "Deschide harta"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Produse în această locație"
+msgstr "Produse în această locație"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "Referință / Produs"
+msgstr "Referință / Produs"
+
+#. module: deltatech_warehouse_map
+#: model_terms:ir.ui.view,arch_db:deltatech_warehouse_map.view_location_generic
+msgid "← Înapoi la Părinte"
+msgstr "← Înapoi la Părinte"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_warehouse_map` — modulul nu avea folder `i18n`. **12/12 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)