### PR TITLE
[IMP] deltatech_website_sale_cost_price: traducere RO

### DIFF
--- a/deltatech_website_sale_cost_price/i18n/ro.po
+++ b/deltatech_website_sale_cost_price/i18n/ro.po
@@ -1,0 +1,75 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_cost_price
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_res_config_settings
+msgid "Config Settings"
+msgstr "Setări de configurare"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__cost_price_include_tax
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__cost_price_include_tax
+msgid "Cost Price Includes Tax"
+msgstr "Prețul de cost include TVA"
+
+#. module: deltatech_website_sale_cost_price
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_cost_price.res_config_settings_view_form
+msgid "Cost Price Margin %"
+msgstr "Marjă preț de cost %"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__cost_price_margin_percentage
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__cost_price_margin_percentage
+msgid "Cost Price Margin Percentage"
+msgstr "Procent marjă preț de cost"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_template__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__display_name
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_product_template__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_res_config_settings__id
+#: model:ir.model.fields,field_description:deltatech_website_sale_cost_price.field_website__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_product_template
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_product_product
+msgid "Product Variant"
+msgstr "Variantă produs"
+
+#. module: deltatech_website_sale_cost_price
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_cost_price.res_config_settings_view_form
+msgid "The cost price is kept with taxes included in the product"
+msgstr "Prețul de cost este păstrat cu taxele incluse pe produs"
+
+#. module: deltatech_website_sale_cost_price
+#: model:ir.model,name:deltatech_website_sale_cost_price.model_website
+msgid "Website"
+msgstr "Pagină web"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_website_sale_cost_price` (afișare preț de cost pe website, cu marjă și TVA opțional inclus) — modulul nu avea folder `i18n`. **10/10 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)