### PR TITLE
[IMP] deltatech_sms: traducere RO

### DIFF
--- a/deltatech_sms/i18n/ro.po
+++ b/deltatech_sms/i18n/ro.po
@@ -1,0 +1,64 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sms
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__display_name
+#: model:ir.model.fields,field_description:deltatech_sms.field_sms_sms__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_sms
+#: model:ir.model,name:deltatech_sms.model_iap_account
+msgid "IAP Account"
+msgstr "Cont IAP"
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__id
+#: model:ir.model.fields,field_description:deltatech_sms.field_sms_sms__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_sms
+#: model:ir.model,name:deltatech_sms.model_sms_sms
+msgid "Outgoing SMS"
+msgstr "Ieșiri SMS"
+
+#. module: deltatech_sms
+#: model:ir.model.fields.selection,name:deltatech_sms.selection__iap_account__sms_provider__4pay
+msgid "SMS 4Pay"
+msgstr "SMS 4Pay"
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__sms_gateway
+msgid "SMS Gateway"
+msgstr "Gateway SMS"
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__sms_provider
+msgid "SMS Provider"
+msgstr "Furnizor SMS"
+
+#. module: deltatech_sms
+#: model:ir.model.fields,field_description:deltatech_sms.field_iap_account__sms_secret
+msgid "SMS Secret"
+msgstr "Secret SMS"
+
+#. module: deltatech_sms
+#: model:ir.model.fields.selection,name:deltatech_sms.selection__iap_account__sms_provider__wapi
+msgid "SMS Wapi"
+msgstr "SMS Wapi"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_sms` (furnizori SMS: 4Pay, Wapi) — modulul nu avea folder `i18n`. **9/9 termeni traduși.**

Numele furnizorilor (`SMS 4Pay`, `SMS Wapi`) rămân netraduse — sunt nume proprii de servicii.

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)