### PR TITLE
[IMP] deltatech_discount_policy: traducere RO

### DIFF
--- a/deltatech_discount_policy/i18n/ro.po
+++ b/deltatech_discount_policy/i18n/ro.po
@@ -1,0 +1,61 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_discount_policy
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist__discount_policy
+msgid "Discount Policy"
+msgstr "Politică de discount"
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields.selection,name:deltatech_discount_policy.selection__product_pricelist__discount_policy__with_discount
+msgid "Discount included in the price"
+msgstr "Discount inclus în preț"
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist__display_name
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist_item__display_name
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist__id
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_product_pricelist_item__id
+#: model:ir.model.fields,field_description:deltatech_discount_policy.field_sale_order_line__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_discount_policy
+#: model:ir.model,name:deltatech_discount_policy.model_product_pricelist
+msgid "Pricelist"
+msgstr "Listă de prețuri"
+
+#. module: deltatech_discount_policy
+#: model:ir.model,name:deltatech_discount_policy.model_product_pricelist_item
+msgid "Pricelist Rule"
+msgstr "Regula listei de prețuri"
+
+#. module: deltatech_discount_policy
+#: model:ir.model,name:deltatech_discount_policy.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linie comandă vânzare"
+
+#. module: deltatech_discount_policy
+#: model:ir.model.fields.selection,name:deltatech_discount_policy.selection__product_pricelist__discount_policy__without_discount
+msgid "Show public price & discount to the customer"
+msgstr "Afișează prețul public și discountul clientului"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_discount_policy` (politică de afișare discount pe listă de prețuri) — modulul nu avea folder `i18n`. **8/8 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)