### PR TITLE
[IMP] deltatech_website_short_description: traducere RO

### DIFF
--- a/deltatech_website_short_description/i18n/ro.po
+++ b/deltatech_website_short_description/i18n/ro.po
@@ -1,0 +1,53 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_short_description
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_template__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_template__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_website_short_description
+#: model:ir.model,name:deltatech_website_short_description.model_product_template
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_website_short_description
+#: model:ir.actions.server,name:deltatech_website_short_description.action_website_publish_product_template
+msgid "Publish on Website"
+msgstr "Publică pe website"
+
+#. module: deltatech_website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_product__website_short_description
+#: model:ir.model.fields,field_description:deltatech_website_short_description.field_product_template__website_short_description
+msgid "Short description for the website"
+msgstr "Descriere scurtă pentru website"
+
+#. module: deltatech_website_short_description
+#: model_terms:ir.ui.view,arch_db:deltatech_website_short_description.product_template_form_view
+msgid "Website description"
+msgstr "Descriere website"
+
+#. module: deltatech_website_short_description
+#: model_terms:ir.ui.view,arch_db:deltatech_website_short_description.product_template_form_view
+msgid "Website short description"
+msgstr "Descriere scurtă website"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_website_short_description` — modulul nu avea folder `i18n`. **7/7 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)