### PR TITLE
[IMP] deltatech_gln: traducere RO

### DIFF
--- a/deltatech_gln/i18n/ro.po
+++ b/deltatech_gln/i18n/ro.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_gln
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_gln
+#: model:ir.model,name:deltatech_gln.model_res_partner
+msgid "Contact"
+msgstr "Contact"
+
+#. module: deltatech_gln
+#: model:ir.model,website_form_label:deltatech_gln.model_res_partner
+msgid "Create a Customer"
+msgstr "Creează un client"
+
+#. module: deltatech_gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_partner__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_partner__gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_users__gln
+msgid "GLN"
+msgstr "GLN"
+
+#. module: deltatech_gln
+#: model:ir.model.fields,help:deltatech_gln.field_res_partner__gln
+#: model:ir.model.fields,help:deltatech_gln.field_res_users__gln
+msgid "Global Location Number"
+msgstr "Global Location Number (cod locație globală)"
+
+#. module: deltatech_gln
+#: model:ir.model.fields,field_description:deltatech_gln.field_res_partner__id
+msgid "ID"
+msgstr "ID"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_gln` (câmp GLN — Global Location Number — pe partener) — modulul nu avea folder `i18n`. **6/6 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)