### PR TITLE
[IMP] deltatech_project_price_list: traducere RO

### DIFF
--- a/deltatech_project_price_list/i18n/ro.po
+++ b/deltatech_project_price_list/i18n/ro.po
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_project_price_list
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_project_project__display_name
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_sale_order__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_project_project__id
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_sale_order__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,field_description:deltatech_project_price_list.field_project_project__pricelist_id
+msgid "Pricelist"
+msgstr "Listă de prețuri"
+
+#. module: deltatech_project_price_list
+#: model:ir.model.fields,help:deltatech_project_price_list.field_project_project__pricelist_id
+msgid ""
+"Pricelist to use by default when creating Sales Orders from this project."
+msgstr ""
+"Lista de prețuri folosită implicit la crearea comenzilor de vânzare din "
+"acest proiect."
+
+#. module: deltatech_project_price_list
+#: model:ir.model,name:deltatech_project_price_list.model_project_project
+msgid "Project"
+msgstr "Proiect"
+
+#. module: deltatech_project_price_list
+#: model:ir.model,name:deltatech_project_price_list.model_sale_order
+msgid "Sales Order"
+msgstr "Comandă de vânzare"
+
+#. module: deltatech_project_price_list
+#: model_terms:ir.ui.view,arch_db:deltatech_project_price_list.project_project_view_edit_inherit_pricelist
+msgid "The pricelist to use for billable tasks and timesheets."
+msgstr ""
+"Lista de prețuri de folosit pentru sarcinile și pontajele facturabile."


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_project_price_list` (listă de prețuri implicită pe proiect, pentru comenzi de vânzare și pontaje facturabile) — modulul nu avea folder `i18n`. **7/7 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)