### PR TITLE
[IMP] deltatech_sale_currency: traducere RO

### DIFF
--- a/deltatech_sale_currency/i18n/ro.po
+++ b/deltatech_sale_currency/i18n/ro.po
@@ -1,0 +1,52 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_sale_currency
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_sale_currency
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_account_move__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order__display_name
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order_line__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_sale_currency
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_account_move__id
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order__id
+#: model:ir.model.fields,field_description:deltatech_sale_currency.field_sale_order_line__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_sale_currency
+#: model:ir.model,name:deltatech_sale_currency.model_account_move
+msgid "Journal Entry"
+msgstr "Notă contabilă"
+
+#. module: deltatech_sale_currency
+#: model:ir.model,name:deltatech_sale_currency.model_sale_order
+msgid "Sales Order"
+msgstr "Comandă de vânzare"
+
+#. module: deltatech_sale_currency
+#: model:ir.model,name:deltatech_sale_currency.model_sale_order_line
+msgid "Sales Order Line"
+msgstr "Linie comandă vânzare"
+
+#. module: deltatech_sale_currency
+#. odoo-python
+#: code:addons/deltatech_sale_currency/models/account_move.py:0
+msgid "You cannot have multiple currencies in the same invoice line."
+msgstr "Nu puteți avea mai multe monede pe aceeași linie de factură."


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_sale_currency` — modulul nu avea folder `i18n`. **6/6 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)