### PR TITLE
[IMP] deltatech_website_sale_portal: traducere RO

### DIFF
--- a/deltatech_website_sale_portal/i18n/ro.po
+++ b/deltatech_website_sale_portal/i18n/ro.po
@@ -1,0 +1,53 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_sale_portal
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Client Reference"
+msgstr "Referință client"
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Order Name"
+msgstr "Nume comandă"
+
+#. module: deltatech_website_sale_portal
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_portal.portal_my_orders
+#: model_terms:ir.ui.view,arch_db:deltatech_website_sale_portal.portal_my_quotations
+msgid "Reference"
+msgstr "Referință"
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Search in All"
+msgstr "Caută în toate"
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Search in Client Reference"
+msgstr "Caută în referința clientului"
+
+#. module: deltatech_website_sale_portal
+#. odoo-python
+#: code:addons/deltatech_website_sale_portal/controllers/portal.py:0
+msgid "Search in Name"
+msgstr "Caută în Nume"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_website_sale_portal` (căutare comenzi în portal după referința clientului) — modulul nu avea folder `i18n`. **6/6 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)