### PR TITLE
[IMP] deltatech_generic_partner_restriction: traducere RO

### DIFF
--- a/deltatech_generic_partner_restriction/i18n/ro.po
+++ b/deltatech_generic_partner_restriction/i18n/ro.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_generic_partner_restriction
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_journal__display_name
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_payment__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_journal__restriction
+msgid "Generic Restriction"
+msgstr "Restricție generică"
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_journal__id
+#: model:ir.model.fields,field_description:deltatech_generic_partner_restriction.field_account_payment__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model,name:deltatech_generic_partner_restriction.model_account_journal
+msgid "Journal"
+msgstr "Jurnal"
+
+#. module: deltatech_generic_partner_restriction
+#: model:ir.model,name:deltatech_generic_partner_restriction.model_account_payment
+msgid "Payments"
+msgstr "Plăți"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_generic_partner_restriction` — modulul nu avea folder `i18n`. **5/5 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)