### PR TITLE
[IMP] deltatech_product_mpn: traducere RO

### DIFF
--- a/deltatech_product_mpn/i18n/ro.po
+++ b/deltatech_product_mpn/i18n/ro.po
@@ -1,0 +1,44 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_product_mpn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_template__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_template__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_product__mpn
+#: model:ir.model.fields,field_description:deltatech_product_mpn.field_product_template__mpn
+msgid "MPN"
+msgstr "MPN"
+
+#. module: deltatech_product_mpn
+#: model:ir.model.fields,help:deltatech_product_mpn.field_product_product__mpn
+#: model:ir.model.fields,help:deltatech_product_mpn.field_product_template__mpn
+msgid "Manufacturer Part Number"
+msgstr "Cod de piesă al producătorului (MPN)"
+
+#. module: deltatech_product_mpn
+#: model:ir.model,name:deltatech_product_mpn.model_product_template
+msgid "Product"
+msgstr "Produs"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_product_mpn` (câmp MPN — Manufacturer Part Number — pe produs) — modulul nu avea folder `i18n`. **5/5 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)