### PR TITLE
[IMP] deltatech_report_prn: traducere RO

### DIFF
--- a/deltatech_report_prn/i18n/ro.po
+++ b/deltatech_report_prn/i18n/ro.po
@@ -1,0 +1,54 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_report_prn
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:24+0000\n"
+"PO-Revision-Date: 2026-07-31 10:24+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,field_description:deltatech_report_prn.field_ir_actions_report__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,field_description:deltatech_report_prn.field_ir_actions_report__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields.selection,name:deltatech_report_prn.selection__ir_actions_report__report_type__qweb-prn
+msgid "PRN"
+msgstr "PRN"
+
+#. module: deltatech_report_prn
+#: model:ir.model,name:deltatech_report_prn.model_ir_actions_report
+msgid "Report Action"
+msgstr "Acțiune raport"
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,field_description:deltatech_report_prn.field_ir_actions_report__report_type
+msgid "Report Type"
+msgstr "Tip raport"
+
+#. module: deltatech_report_prn
+#: model:ir.model.fields,help:deltatech_report_prn.field_ir_actions_report__report_type
+msgid ""
+"The type of the report that will be rendered, each one having its own "
+"rendering method. HTML means the report will be opened directly in your "
+"browser PDF means the report will be rendered using Wkhtmltopdf and "
+"downloaded by the user."
+msgstr ""
+"Tipul raportului care va fi generat, fiecare având propria metodă de "
+"randare. HTML înseamnă că raportul se deschide direct în browser, PDF "
+"înseamnă că raportul e generat cu Wkhtmltopdf și descărcat de utilizator."


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_report_prn` (tip nou de raport PRN — ieșire brută de imprimantă) — modulul nu avea folder `i18n`. **6/6 termeni traduși.**

`PRN` rămâne netradus — codul tipului de raport, nu text de interfață.

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)