### PR TITLE
[IMP] deltatech_team_logo: traducere RO

### DIFF
--- a/deltatech_team_logo/i18n/ro.po
+++ b/deltatech_team_logo/i18n/ro.po
@@ -1,0 +1,58 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_team_logo
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language: ro\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_crm_team__display_name
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_stock_picking__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,help:deltatech_team_logo.field_stock_picking__team_id
+msgid ""
+"Echipa de vânzare a comenzii sursă, folosită pentru logo-ul din rapoarte."
+msgstr "Echipa de vânzare a comenzii sursă, folosită pentru logo-ul din rapoarte."
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_crm_team__id
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_stock_picking__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_crm_team__logo
+msgid "Logo"
+msgstr "Sigla"
+
+#. module: deltatech_team_logo
+#: model:ir.model.fields,help:deltatech_team_logo.field_crm_team__logo
+msgid ""
+"Logo afișat în rapoartele (factură, ofertă, aviz) emise pentru această "
+"echipă de vânzare. Dacă este gol, se folosește logo-ul firmei."
+msgstr "Logo afișat în rapoartele (factură, ofertă, aviz) emise pentru această echipă de vânzare. Dacă este gol, se folosește logo-ul firmei."
+
+#. module: deltatech_team_logo
+#: model:ir.model,name:deltatech_team_logo.model_crm_team
+#: model:ir.model.fields,field_description:deltatech_team_logo.field_stock_picking__team_id
+msgid "Sales Team"
+msgstr "Echipa de vânzări"
+
+#. module: deltatech_team_logo
+#: model:ir.model,name:deltatech_team_logo.model_stock_picking
+msgid "Transfer"
+msgstr "Transfer"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_team_logo` — modulul nu avea folder `i18n`. **7/7 termeni traduși**, toți acoperiți din corpusul local (fără termeni de tradus manual).

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)