### PR TITLE
[IMP] deltatech_website_product_url_image: traducere RO

### DIFF
--- a/deltatech_website_product_url_image/i18n/ro.po
+++ b/deltatech_website_product_url_image/i18n/ro.po
@@ -1,0 +1,45 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_product_url_image
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_image__display_name
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_template__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_image__id
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_template__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_product__image_file_name
+#: model:ir.model.fields,field_description:deltatech_website_product_url_image.field_product_template__image_file_name
+msgid "Image File Name"
+msgstr "Nume fișier imagine"
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model,name:deltatech_website_product_url_image.model_product_template
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_website_product_url_image
+#: model:ir.model,name:deltatech_website_product_url_image.model_product_image
+msgid "Product Image"
+msgstr "Imagine produs"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_website_product_url_image` — modulul nu avea folder `i18n`. **5/5 termeni traduși.**

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)