### PR TITLE
[IMP] deltatech: traducere RO

### DIFF
--- a/deltatech/i18n/ro.po
+++ b/deltatech/i18n/ro.po
@@ -1,0 +1,37 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:22+0000\n"
+"PO-Revision-Date: 2026-07-31 10:22+0000\n"
+"Last-Translator: \n"
+"Language: ro\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech
+#: model:ir.model.fields,field_description:deltatech.field_ir_rule__display_name
+msgid "Display Name"
+msgstr "Nume afișat"
+
+#. module: deltatech
+#: model:ir.model.fields,field_description:deltatech.field_ir_rule__id
+msgid "ID"
+msgstr "ID"
+
+#. module: deltatech
+#: model:ir.model.fields,field_description:deltatech.field_ir_rule__model_name
+msgid "Model Name"
+msgstr "Nume model"
+
+#. module: deltatech
+#: model:ir.model,name:deltatech.model_ir_rule
+msgid "Record Rule"
+msgstr "Înregistrare regulă"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech` — modulul nu avea folder `i18n`. Generat din exportul `.pot` real al modulului, complet acoperit din corpusul local de traduceri.

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)