### PR TITLE
[IMP] deltatech_website_breadcrumb: traducere RO

### DIFF
--- a/deltatech_website_breadcrumb/i18n/ro.po
+++ b/deltatech_website_breadcrumb/i18n/ro.po
@@ -1,0 +1,22 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* deltatech_website_breadcrumb
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 19.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-07-31 10:25+0000\n"
+"PO-Revision-Date: 2026-07-31 10:25+0000\n"
+"Last-Translator: \n"
+"Language: ro\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: deltatech_website_breadcrumb
+#: model_terms:ir.ui.view,arch_db:deltatech_website_breadcrumb.breadcrumb
+msgid "Products"
+msgstr "Produse"


### PR DESCRIPTION
## Ce face

Adaugă `i18n/ro.po` la `deltatech_website_breadcrumb` — modulul nu avea folder `i18n`. Generat din exportul `.pot` real al modulului, complet acoperit din corpusul local de traduceri.

## Verificare

- `msgfmt --check --check-format` — fără erori
- `scripts/i18n/po_normalize.py --check` — neschimbat
- `scripts/i18n/po_lint_terms.py` — terminologie curată

🤖 Generated with [Claude Code](https://claude.com/claude-code)