### PR TITLE
[FIX] deltatech_stock_inventory: inventory note back in the stock move reference

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "19.0.2.7.1",
+    "version": "19.0.2.7.2",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/i18n/ro.po
+++ b/deltatech_stock_inventory/i18n/ro.po
@@ -532,7 +532,7 @@ msgstr ""
 #. module: deltatech_stock_inventory
 #: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__inventory_note
 msgid "Inventory Note"
-msgstr ""
+msgstr "Notă inventar"
 
 #. module: deltatech_stock_inventory
 #: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__is_inventory_ok

--- a/deltatech_stock_inventory/models/stock_quant.py
+++ b/deltatech_stock_inventory/models/stock_quant.py
@@ -92,7 +92,9 @@ class StockQuant(models.Model):
                     values["name"] = sequence.next_by_id()
 
             inventory.write(values)
-        self.write({"inventory_id": False, "inventory_line_id": False})
+        # Nota a fost preluata in referinta mișcării; o golim ca sa nu fie refolosita tacit
+        # la o ajustare ulterioara a aceluiași quant (standardul nu o curata).
+        self.write({"inventory_id": False, "inventory_line_id": False, "inventory_note": False})
         return res
 
     def write(self, vals):
@@ -129,7 +131,11 @@ class StockQuant(models.Model):
             qty, location_id, location_dest_id, package_id=package_id, package_dest_id=package_dest_id
         )
         values["inventory_id"] = self.inventory_id.id
-        # values["name"] = self.inventory_note or values.get("name", False)
+        # Nota de pe linie devine referinta mișcării de stoc. In 19.0 standardul nu mai pune
+        # "name" in valori, ci "inventory_name" (din contextul inventory_name), care e sursa
+        # pentru stock.move.reference atunci cand is_inventory.
+        if self.inventory_note:
+            values["inventory_name"] = self.inventory_note
         return values
 
     @api.model

--- a/deltatech_stock_inventory/readme/HISTORY.md
+++ b/deltatech_stock_inventory/readme/HISTORY.md
@@ -1,3 +1,16 @@
+## 19.0.2.7.2 (2026-08-05)
+
+- **Inventory Note** is again carried over to the generated stock move, so the
+  reason of a quantity update stays visible in the product move history. The
+  18.0 code wrote it to `name`, but in 19.0 the standard no longer returns a
+  `name` key in `_get_inventory_move_values` — it uses `inventory_name`, which
+  feeds `stock.move.reference` for inventory moves. The line had been commented
+  out during a 19.0 cleanup, which silently dropped the per-line reason: the
+  note could be filled in, but was stored nowhere permanent.
+- The note is cleared when the adjustment is applied, so it is not silently
+  reused as the reason of a later adjustment on the same quant (the standard
+  `action_clear_inventory_quantity` does not reset custom fields).
+
 ## 19.0.2.7.1 (2026-08-04)
 
 - The **Inventory Note** column in the inventory adjustment list is now shown by

--- a/deltatech_stock_inventory/tests/__init__.py
+++ b/deltatech_stock_inventory/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_onchange_quantity_context
 from . import test_product_methods
 from . import test_stock_inventory_methods_extra
 from . import test_compute_warehouse_stocks
+from . import test_inventory_note

--- a/deltatech_stock_inventory/tests/test_inventory_note.py
+++ b/deltatech_stock_inventory/tests/test_inventory_note.py
@@ -1,0 +1,84 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests.common import TransactionCase
+
+
+class TestInventoryNote(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.stock_location = self.env["stock.location"].create({"name": "Test location", "usage": "internal"})
+        self.product = self.env["product.product"].create({"name": "Test note", "is_storable": True})
+
+    def _apply(self, quantity, note=False):
+        quant = self.env["stock.quant"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.stock_location.id,
+                "inventory_quantity": quantity,
+                "inventory_note": note,
+            }
+        )
+        quant.action_apply_inventory()
+        return quant
+
+    def _last_move(self):
+        return self.env["stock.move"].search(
+            [("product_id", "=", self.product.id), ("is_inventory", "=", True)], order="id desc", limit=1
+        )
+
+    def test_note_becomes_move_reference(self):
+        """Nota de pe linie ajunge in referinta mișcării de stoc generate."""
+        self._apply(7, note="Marfa deteriorata la manipulare")
+        move = self._last_move()
+        self.assertEqual(move.inventory_name, "Marfa deteriorata la manipulare")
+        self.assertEqual(move.reference, "Marfa deteriorata la manipulare")
+
+    def test_note_cleared_after_apply(self):
+        """Nota se goleste dupa aplicare, ca sa nu fie refolosita la ajustarea urmatoare."""
+        quant = self._apply(7, note="Motiv prima ajustare")
+        self.assertFalse(quant.inventory_note)
+
+        quant.inventory_quantity = 9
+        quant.action_apply_inventory()
+        move = self._last_move()
+        self.assertNotEqual(move.reference, "Motiv prima ajustare")
+
+    def test_without_note_standard_reference_kept(self):
+        """Fara nota, referinta rămâne cea standard, cu utilizatorul care a operat ajustarea."""
+        user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Operator inventar",
+                    "login": "operator_inv_note",
+                    "group_ids": [
+                        (
+                            6,
+                            0,
+                            [
+                                self.env.ref("stock.group_stock_manager").id,
+                                self.env.ref("deltatech_stock_inventory.group_view_inventory_button").id,
+                            ],
+                        )
+                    ],
+                }
+            )
+        )
+        quant = (
+            self.env["stock.quant"]
+            .with_user(user)
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "location_id": self.stock_location.id,
+                    "inventory_quantity": 5,
+                }
+            )
+        )
+        quant.action_apply_inventory()
+        move = self._last_move()
+        self.assertFalse(move.inventory_name)
+        self.assertIn(user.display_name, move.reference)


### PR DESCRIPTION
## Context

Ticket #9156 (AGROAMAT): the customer asked to be able to add a comment whenever someone updates a product quantity, so the reason of the update stays visible.

PR #2729 made the per-line **Inventory Note** column visible by default. But the note was stored nowhere permanent — the line that carried it to the generated stock move had been commented out in the 19.0 cleanup commit `124db6d43`:

```python
# values["name"] = self.inventory_note or values.get("name", False)
```

## Root cause — a silent 18→19 regression

On 18.0 the note was written to `values["name"]`. In 19.0 the standard `_get_inventory_move_values` no longer returns a `name` key: it sets `inventory_name` (from the `inventory_name` context key), and `stock.move._compute_reference` uses `inventory_name` as the reference for inventory moves. The 18.0 code therefore raised a `KeyError` and was disabled rather than ported — so the note could be typed in, but disappeared on apply.

## Changes

- `_get_inventory_move_values` sets `inventory_name` from `inventory_note`, restoring the 18.0 behaviour: the reason stays visible in the product move history.
- The note is cleared on apply — the standard `action_clear_inventory_quantity` does not reset custom fields, so an old note would silently become the reason of a later adjustment on the same quant.
- Tests for both, plus the missing `ro.po` translation of the column label ("Notă inventar").

Note that the standard "Inventory Reason" wizard only shows up on **Apply All** and sets one common reason for the whole batch; the per-line note is the only way to record a reason per product.

## Test

`0 failed, 0 error(s) of 32 tests` for `deltatech_stock_inventory` on a real database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)