### PR TITLE
[IMP] deltatech_tc: job http_request — apel HTTP în rețeaua clientului

### DIFF
--- a/deltatech_tc/__manifest__.py
+++ b/deltatech_tc/__manifest__.py
@@ -3,8 +3,8 @@
 
 {
     "name": "Terrabit Connect - Base",
-    "summary": "Base for Terrabit Connect: station registry, outbound job queue and REST endpoints (X-Station-Key).",
-    "version": "19.0.1.0.0",
+    "summary": "Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the customer's local network.",
+    "version": "19.0.1.1.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Technical",

--- a/deltatech_tc/models/deltatech_tc_job.py
+++ b/deltatech_tc/models/deltatech_tc_job.py
@@ -1,9 +1,20 @@
 import json
 import logging
+from urllib.parse import urlparse
 
 from odoo import api, fields, models
+from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
+
+# A callback is a method name stored in the database, so it must never be able to
+# reach arbitrary ORM methods (``unlink``, ``write``, ``sudo``...). Only methods
+# carrying this prefix may be called back, which makes "callable from a job" an
+# explicit, greppable property of the method rather than an accident.
+CALLBACK_PREFIX = "_tc_"
+
+ALLOWED_SCHEMES = ("http", "https")
+ALLOWED_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE", "HEAD")
 
 
 class DeltatechTcJob(models.Model):
@@ -15,7 +26,10 @@ class DeltatechTcJob(models.Model):
     to the :meth:`_process_result` hook, which feature modules extend per
     ``job_type``.
 
-    Feature modules add their job types with ``selection_add`` on ``job_type``.
+    Two job types ship here: ``ping`` (round-trip check) and ``http_request``,
+    which has the station call a device reachable only inside the customer's
+    network. Feature modules add device-specific types with ``selection_add`` on
+    ``job_type``.
     """
 
     _name = "deltatech.tc.job"
@@ -26,7 +40,7 @@ class DeltatechTcJob(models.Model):
     station_id = fields.Many2one("deltatech.tc.station", required=True, ondelete="cascade", index=True)
     company_id = fields.Many2one("res.company", required=True, default=lambda self: self.env.company)
     job_type = fields.Selection(
-        selection=[("ping", "Ping")],
+        selection=[("ping", "Ping"), ("http_request", "HTTP request (LAN)")],
         required=True,
         default="ping",
     )
@@ -47,6 +61,18 @@ class DeltatechTcJob(models.Model):
     error = fields.Text(copy=False)
     claimed_at = fields.Datetime(readonly=True, copy=False)
     done_at = fields.Datetime(readonly=True, copy=False)
+    callback_model = fields.Char(
+        readonly=True,
+        help="Model whose method is called once the station reports the response.",
+    )
+    callback_res_id = fields.Integer(
+        readonly=True,
+        help="Record the callback is executed on. 0 calls the method on the model.",
+    )
+    callback_method = fields.Char(
+        readonly=True,
+        help=f"Method invoked with the finished job. Must start with '{CALLBACK_PREFIX}'.",
+    )
 
     @api.depends("job_type")
     def _compute_name(self):
@@ -54,12 +80,146 @@ class DeltatechTcJob(models.Model):
             label = dict(self._fields["job_type"].selection).get(rec.job_type, rec.job_type or "")
             rec.name = f"#{rec.id} {label}"
 
+    @api.constrains("job_type", "payload")
+    def _check_http_payload(self):
+        for job in self.filtered(lambda j: j.job_type == "http_request"):
+            payload = job.payload_dict()
+            url = (payload.get("url") or "").strip()
+            if not url:
+                raise ValidationError(self.env._("An HTTP job needs a 'url' in its payload."))
+            parsed = urlparse(url)
+            if parsed.scheme not in ALLOWED_SCHEMES:
+                raise ValidationError(
+                    self.env._(
+                        "Unsupported URL scheme %(scheme)s - only http and https are allowed.",
+                        scheme=parsed.scheme or "(none)",
+                    )
+                )
+            if not parsed.netloc:
+                raise ValidationError(self.env._("The URL %(url)s has no host.", url=url))
+            method = (payload.get("method") or "GET").upper()
+            if method not in ALLOWED_METHODS:
+                raise ValidationError(self.env._("Unsupported HTTP method %(method)s.", method=method))
+
+    @api.constrains("callback_method")
+    def _check_callback_method(self):
+        for job in self.filtered("callback_method"):
+            if not job.callback_method.startswith(CALLBACK_PREFIX):
+                raise ValidationError(
+                    self.env._(
+                        "The callback method %(method)s must start with '%(prefix)s'.",
+                        method=job.callback_method,
+                        prefix=CALLBACK_PREFIX,
+                    )
+                )
+
     def payload_dict(self):
         self.ensure_one()
         try:
             return json.loads(self.payload) if self.payload else {}
         except ValueError:
             return {}
+
+    # ------------------------------------------------------------------
+    # http_request: queue an HTTP call the station performs on the local network
+    # ------------------------------------------------------------------
+    @api.model
+    def _tc_enqueue_http(
+        self,
+        station,
+        url,
+        method="GET",
+        headers=None,
+        body=None,
+        timeout=30,
+        callback=None,
+        company=None,
+    ):
+        """Queue an HTTP call for the station to perform locally.
+
+        Odoo runs in the cloud while the device (a sorting line, a scale, a PLC)
+        answers only inside the customer's network. The station already polls
+        Odoo, so routing the call through it keeps the direction outbound-only:
+        no inbound port, no VPN, no fixed IP.
+
+        **The allow-list of reachable hosts lives in the agent, not here.** Odoo
+        says which URL it wants called; the workstation decides whether it is
+        willing to call it. Anything else would turn a compromised Odoo account
+        into a foothold inside the customer's network.
+
+        :param callback: ``(record, method_name)`` invoked with the finished job
+            once the station reports back. The name must start with ``_tc_``.
+        :returns: the created job.
+        """
+        if not station:
+            raise UserError(self.env._("No Terrabit Connect station given for the HTTP job."))
+        vals = {
+            "station_id": station.id,
+            "company_id": (company or station.company_id or self.env.company).id,
+            "job_type": "http_request",
+            "payload": json.dumps(
+                {
+                    "url": url,
+                    "method": (method or "GET").upper(),
+                    "headers": headers or {},
+                    "body": body,
+                    "timeout": timeout,
+                }
+            ),
+        }
+        if callback:
+            record, method_name = callback
+            if not method_name.startswith(CALLBACK_PREFIX):
+                raise UserError(
+                    self.env._(
+                        "The callback method %(method)s must start with '%(prefix)s'.",
+                        method=method_name,
+                        prefix=CALLBACK_PREFIX,
+                    )
+                )
+            if not hasattr(record, method_name):
+                raise UserError(
+                    self.env._(
+                        "%(model)s has no method %(method)s.",
+                        model=record._name,
+                        method=method_name,
+                    )
+                )
+            vals.update(
+                {
+                    "callback_model": record._name,
+                    "callback_res_id": record.id if record else 0,
+                    "callback_method": method_name,
+                }
+            )
+        return self.create(vals)
+
+    def response_dict(self):
+        """The agent's answer to an ``http_request``: ``{status, headers, body, truncated}``.
+
+        Returns an empty dict when there is no usable result yet, so callers can
+        branch on ``status`` without guarding every access.
+        """
+        self.ensure_one()
+        if not self.result:
+            return {}
+        try:
+            data = json.loads(self.result)
+        except ValueError:
+            _logger.warning("Job %s: result is not valid JSON", self.id)
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def response_json(self):
+        """The response body parsed as JSON, or ``None`` if it is not JSON."""
+        self.ensure_one()
+        body = self.response_dict().get("body")
+        if body in (None, ""):
+            return None
+        try:
+            return json.loads(body)
+        except (ValueError, TypeError):
+            return None
 
     # ------------------------------------------------------------------
     # API used by the controller (called by Terrabit Connect)
@@ -100,9 +260,35 @@ class DeltatechTcJob(models.Model):
         return True
 
     def _process_result(self):
-        """Hook extended by feature modules per ``job_type``.
+        """Turn the station's result into business records.
 
-        Default: no-op for ``ping``. Feature modules (ANAF messages, fiscal,
-        labels) override this to turn the station's result into business records.
+        Handles the callback of finished ``http_request`` jobs; feature modules
+        (ANAF messages, fiscal, labels) extend this per ``job_type``.
+
+        A failing callback is deliberately left to propagate: ``_store_result``
+        catches it and flips the job to ``error`` with the message, so swallowing
+        it here would hide a real failure.
         """
+        for job in self.filtered(lambda j: j.job_type == "http_request" and j.callback_method):
+            target = job.env[job.callback_model]
+            if job.callback_res_id:
+                target = target.browse(job.callback_res_id).exists()
+                if not target:
+                    _logger.warning(
+                        "Job %s: callback target %s,%s no longer exists",
+                        job.id,
+                        job.callback_model,
+                        job.callback_res_id,
+                    )
+                    continue
+            # re-checked at call time: the stored value could have been tampered with
+            if not job.callback_method.startswith(CALLBACK_PREFIX):
+                raise UserError(
+                    self.env._(
+                        "Refusing to call %(method)s - callbacks must start with '%(prefix)s'.",
+                        method=job.callback_method,
+                        prefix=CALLBACK_PREFIX,
+                    )
+                )
+            getattr(target, job.callback_method)(job)
         return True

--- a/deltatech_tc/readme/CONFIGURE.md
+++ b/deltatech_tc/readme/CONFIGURE.md
@@ -50,6 +50,21 @@ timing (Terrabit Connect reads them at startup):
 | `TERRABIT_POLL_SEC` | 30 | Seconds between `/tc/poll` calls |
 | `TERRABIT_HEARTBEAT_SEC` | 300 | Seconds between automatic heartbeats |
 
+## Hosts reachable by `http_request` (workstation side)
+
+`http_request` jobs are refused unless the target host is allow-listed **on the
+workstation**. The list is deliberately not manageable from Odoo: it is the last
+line of defence if an Odoo account is compromised.
+
+```
+TERRABIT_HTTP_ALLOW=192.168.1.50:8080,unisorter.local
+```
+
+Comma-separated `host` or `host:port` entries. An entry without a port allows any
+port on that host; with a port, the match is exact. **The default is empty — until
+a host is listed there, every `http_request` job comes back as an error.** Keep it
+as narrow as the job actually needs.
+
 The server applies a 60-second throttle on `last_seen` writes to reduce database
 load when many stations are polling frequently; online detection remains accurate
 within the throttle window.

--- a/deltatech_tc/readme/DESCRIPTION.md
+++ b/deltatech_tc/readme/DESCRIPTION.md
@@ -4,8 +4,9 @@ directly from the cloud: the ANAF token (PKCS#11 / mTLS to SPV), fiscal printers
 (Datecs), label printers (Zebra ZPL) and declaration validation (DUKIntegrator).
 
 This module is the **generic foundation** every Terrabit Connect feature builds
-on. It does not, by itself, talk to any device — it provides the connection
-layer and the job protocol.
+on: the connection layer, the job protocol, and the one job type that is pure
+transport rather than a specific device — an HTTP call inside the customer's
+network.
 
 **What it gives you**
 
@@ -17,11 +18,28 @@ layer and the job protocol.
   (`done` / `error`).
 - **REST endpoints** authenticated with the `X-Station-Key` header:
   `/tc/heartbeat`, `/tc/poll`, `/tc/result`, `/tc/config/<id>`.
+- **`http_request` job type** — Odoo asks the station to call a device that
+  answers only inside the local network (a sorting line, a scale, a PLC, a label
+  server) and reports the response back. Queue it with `_tc_enqueue_http()` and
+  read the answer with `response_dict()` / `response_json()`.
 
 **Cloud model — no inbound ports.** The station always initiates the connection
 to Odoo; Odoo never connects back to the workstation. The same agent works with
 on-premise and cloud deployments without opening any port on the client side.
 
-**Extensible.** Feature modules add their own job types (`selection_add` on
-`job_type`) and turn the station's result into business records by overriding the
+**Extensible.** Feature modules add device-specific job types (`selection_add` on
+`job_type`) and turn the station's result into business records by extending the
 `_process_result` hook — keeping the registry, queue and transport in one place.
+
+**Security of `http_request` — read this before using it.** The allow-list of
+reachable hosts is configured **in the agent, on the workstation**, never from
+Odoo. Without that rule, a job saying "call this URL" would let anyone able to
+create a job in Odoo reach any address inside the customer's network. Odoo only
+validates the shape of the request (scheme, host present, known method); the
+decision to actually place the call belongs to the machine sitting in that
+network.
+
+Callbacks are restricted to methods whose name starts with **`_tc_`**. The method
+name is stored in the database, so without that rule a modified record could call
+any ORM method. The prefix also makes "reachable from a job" a property you can
+grep for.

--- a/deltatech_tc/readme/HISTORY.md
+++ b/deltatech_tc/readme/HISTORY.md
@@ -1,0 +1,16 @@
+## 19.0.1.1.0 (2026-08-11)
+
+- **New job type `http_request`** — the station performs an HTTP call inside the customer's local
+  network on Odoo's behalf, so cloud-hosted Odoo can reach devices that answer only on the LAN
+  (sorting lines, scales, PLCs, label servers) without a VPN, a fixed IP or an inbound port.
+- `_tc_enqueue_http()` helper, `response_dict()` / `response_json()` readers, payload validation
+  (scheme, host, HTTP method).
+- Callbacks: `_process_result` now invokes `(record, method)` registered on the job. Only methods
+  prefixed `_tc_` may be called, checked both when queuing and at call time.
+- The allow-list of reachable hosts is configured on the workstation
+  (`TERRABIT_HTTP_ALLOW`), never from Odoo.
+
+## 19.0.1.0.0
+
+- Station registry, outbound job queue, REST endpoints (`/tc/heartbeat`, `/tc/poll`, `/tc/result`,
+  `/tc/config/<id>`) and the `ping` job type.

--- a/deltatech_tc/readme/USAGE.md
+++ b/deltatech_tc/readme/USAGE.md
@@ -46,6 +46,41 @@ If a station key is compromised:
 3. Download the updated `station.conf` and deploy it to the workstation.
    Terrabit Connect will fail to authenticate until it is reconfigured with the new key.
 
+## Calling a device on the local network
+
+Queue the call from a feature module:
+
+```python
+station = self.env["deltatech.tc.station"].search([("company_id", "=", self.env.company.id)], limit=1)
+self.env["deltatech.tc.job"]._tc_enqueue_http(
+    station,
+    "http://192.168.1.50/api/Lines/1/Lots",
+    headers={"X-API-KEY": self.api_key},
+    timeout=30,
+    callback=(self, "_tc_apply_lots"),
+)
+```
+
+Handle the response on the record that asked for it:
+
+```python
+def _tc_apply_lots(self, job):
+    response = job.response_dict()
+    if response.get("status") != 200:
+        raise UserError(self.env._("The device answered %(code)s.", code=response.get("status")))
+    for payload in job.response_json() or []:
+        ...
+```
+
+The callback method **must** start with `_tc_` — see DESCRIPTION. Before the first
+job can succeed, the target host has to be allow-listed on the workstation (see
+CONFIGURE).
+
+**The call is asynchronous.** It runs when the station next polls, not when the
+job is created. Interactive buttons must therefore show a pending state and let
+the result arrive later; do not queue a job and read its result in the same
+transaction.
+
 ## Adding feature modules
 
 This base module does not talk to any device by itself. Install the relevant

--- a/deltatech_tc/tests/__init__.py
+++ b/deltatech_tc/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_tc
+from . import test_tc_http

--- a/deltatech_tc/tests/test_tc_http.py
+++ b/deltatech_tc/tests/test_tc_http.py
@@ -1,0 +1,135 @@
+import json
+from unittest.mock import patch
+
+from odoo.exceptions import UserError, ValidationError
+from odoo.tests import TransactionCase, tagged
+
+
+def _tc_store_status(self, job):
+    """Stand-in callback: records what came back, so the test can assert on it.
+
+    Writes to `ref` (Char) rather than `comment` (Html), which would wrap it in <p>.
+    """
+    self.ref = str(job.response_dict().get("status"))
+
+
+@tagged("post_install", "-at_install")
+class TestTcHttp(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.station = cls.env["deltatech.tc.station"].create({"name": "Test Station"})
+        cls.Job = cls.env["deltatech.tc.job"]
+
+    def _enqueue(self, **kw):
+        kw.setdefault("url", "http://192.168.1.50/api/Lines")
+        return self.Job._tc_enqueue_http(self.station, **kw)
+
+    def _with_callback(self):
+        """Attach the stand-in callback to res.partner for the duration of a test.
+
+        Injected rather than shipped: a `_tc_` method in the module would be dead
+        code, and using a real one would tie the test to another module.
+        """
+        return patch.object(type(self.env["res.partner"]), "_tc_test_store_status", _tc_store_status, create=True)
+
+    # ------------------------------------------------------------------
+    def test_enqueue_builds_payload(self):
+        job = self._enqueue(headers={"X-API-KEY": "k"}, timeout=15)
+        self.assertEqual(job.job_type, "http_request")
+        self.assertEqual(job.state, "pending")
+        self.assertEqual(job.station_id, self.station)
+        payload = job.payload_dict()
+        self.assertEqual(payload["url"], "http://192.168.1.50/api/Lines")
+        self.assertEqual(payload["method"], "GET", "the method defaults to GET, upper-cased")
+        self.assertEqual(payload["headers"], {"X-API-KEY": "k"})
+        self.assertEqual(payload["timeout"], 15)
+
+    def test_station_claims_the_job(self):
+        job = self._enqueue()
+        claimed = self.Job._claim_for_station(self.station)
+        self.assertIn(job, claimed)
+        self.assertEqual(job.state, "claimed")
+
+    def test_rejects_unusable_requests(self):
+        """Odoo validates the shape only — the host allow-list belongs to the agent."""
+        with self.assertRaises(ValidationError):
+            self._enqueue(url="ftp://192.168.1.50/x")
+        with self.assertRaises(ValidationError):
+            self._enqueue(url="not-a-url")
+        with self.assertRaises(ValidationError):
+            self._enqueue(method="TRACE")
+
+    def test_response_helpers(self):
+        job = self._enqueue()
+        job._store_result(
+            "done",
+            result=json.dumps({"status": 200, "headers": {}, "body": '[{"line":"1"}]'}),
+        )
+        self.assertEqual(job.state, "done")
+        self.assertEqual(job.response_dict()["status"], 200)
+        self.assertEqual(job.response_json(), [{"line": "1"}])
+
+    def test_response_helpers_survive_garbage(self):
+        """A device that answers HTML must not raise — callers branch on status."""
+        job = self._enqueue()
+        job._store_result("done", result="<html>oops</html>")
+        self.assertEqual(job.response_dict(), {})
+        self.assertIsNone(job.response_json())
+
+        other = self._enqueue()
+        other._store_result("done", result=json.dumps({"status": 200, "body": "plain text"}))
+        self.assertIsNone(other.response_json(), "a non-JSON body yields None, not an exception")
+
+    def test_error_from_station_is_kept(self):
+        job = self._enqueue()
+        job._store_result("error", error="host not allowed")
+        self.assertEqual(job.state, "error")
+        self.assertEqual(job.error, "host not allowed")
+
+    # ------------------------------------------------------------------
+    # callbacks
+    # ------------------------------------------------------------------
+    def test_callback_runs_on_result(self):
+        with self._with_callback():
+            partner = self.env["res.partner"].create({"name": "Callback target"})
+            job = self._enqueue(callback=(partner, "_tc_test_store_status"))
+            self.assertEqual(job.callback_model, "res.partner")
+            self.assertEqual(job.callback_res_id, partner.id)
+
+            job._store_result("done", result=json.dumps({"status": 200, "body": '{"ok": true}'}))
+            self.assertEqual(job.state, "done")
+            self.assertEqual(partner.ref, "200")
+
+    def test_callback_must_carry_the_prefix(self):
+        """The method name lives in the database, so anything else is refused."""
+        partner = self.env["res.partner"].create({"name": "Callback target"})
+        with self.assertRaises(UserError):
+            self._enqueue(callback=(partner, "unlink"))
+        with self.assertRaises(UserError):
+            self._enqueue(callback=(partner, "_tc_does_not_exist"))
+
+    def test_tampered_callback_is_refused_at_call_time(self):
+        with self._with_callback():
+            partner = self.env["res.partner"].create({"name": "Callback target"})
+            job = self._enqueue(callback=(partner, "_tc_test_store_status"))
+            # bypass the constraint the way a direct SQL write or a broken migration would
+            self.env.cr.execute("UPDATE deltatech_tc_job SET callback_method = 'unlink' WHERE id = %s", (job.id,))
+            job.invalidate_recordset()
+            job._store_result("done", result=json.dumps({"status": 200, "body": "{}"}))
+            self.assertEqual(job.state, "error", "the job must fail instead of calling unlink")
+            self.assertTrue(partner.exists(), "the target must still be there")
+
+    def test_callback_target_deleted_meanwhile(self):
+        with self._with_callback():
+            partner = self.env["res.partner"].create({"name": "Gone by then"})
+            job = self._enqueue(callback=(partner, "_tc_test_store_status"))
+            partner.unlink()
+            job._store_result("done", result=json.dumps({"status": 200, "body": "{}"}))
+            self.assertEqual(job.state, "done", "a vanished target is skipped, not an error")
+
+    def test_ping_still_works(self):
+        """The base job type must be unaffected by this module."""
+        job = self.Job.create({"station_id": self.station.id, "job_type": "ping"})
+        job._store_result("done", result="pong")
+        self.assertEqual(job.state, "done")

--- a/deltatech_tc/views/deltatech_tc_job_views.xml
+++ b/deltatech_tc/views/deltatech_tc_job_views.xml
@@ -37,6 +37,9 @@
                         <group>
                             <field name="claimed_at"/>
                             <field name="done_at"/>
+                            <field name="callback_model" invisible="not callback_model"/>
+                            <field name="callback_res_id" invisible="not callback_model"/>
+                            <field name="callback_method" invisible="not callback_model"/>
                         </group>
                     </group>
                     <notebook>


### PR DESCRIPTION
## Ce face

Odoo rulează în cloud, echipamentul răspunde doar în LAN-ul clientului — o linie de sortare, un cântar, un PLC, un server de etichete. Stația cheamă deja Odoo periodic, deci refolosim canalul pentru apeluri HTTP: **sensul rămâne exclusiv de ieșire**, fără port deschis spre client, fără VPN, fără IP fix.

Cazul care a cerut-o: integrarea liniei de sortare Unitec la Pro Inedit (Odoo pe odoo.sh, linia la depozit).

## De ce în modulul de bază, nu într-unul separat

Prima variantă a fost un `deltatech_tc_http` separat, urmând ce declară baza despre sine („does not, by itself, talk to any device"). Argumentul se întoarce însă: spre deosebire de fiscal/Zebra/ANAF, care vorbesc cu un dispozitiv anume, **un apel HTTP e transport pur** — exact ce face `deltatech_tc`. Un modul în plus pentru ~200 de linii, cu manifest, README și ciclu propriu de versiuni, nu se justifica.

## Conținut

- `job_type = "http_request"` + `_tc_enqueue_http()` ca API pentru module consumatoare
- `response_dict()` / `response_json()` pentru citirea răspunsului
- validare de payload: schemă (`http`/`https`), gazdă prezentă, metodă cunoscută
- callback `(record, metodă)`, rulat de `_process_result` la primirea răspunsului

## Securitate — două reguli care nu sunt opționale

1. **Lista albă de gazde se configurează în agent** (`TERRABIT_HTTP_ALLOW`), niciodată din Odoo. Altfel un cont Odoo compromis ar putea cere stației să lovească orice adresă din rețeaua clientului. Odoo validează doar forma cererii; decizia de a plasa apelul aparține mașinii din acea rețea. Implicit lista e goală: fără configurare, niciun apel nu trece.
2. **Callback-urile sunt limitate la metode cu prefixul `_tc_`.** Numele metodei stă în baza de date, deci fără regula asta un rând modificat ar putea apela `unlink`/`write`. Verificat și la creare, și la apel.

## Verificare

- **22 teste pe modul, 0 eșecuri** — inclusiv unul care falsifică prin SQL `callback_method = 'unlink'` și verifică refuzul, cu ținta intactă
- instalare curată pe bază nouă, verificată
- lanțul probat cap-coadă contra unui API real: Odoo pune jobul → stația îl revendică → agentul interoghează → Odoo citește răspunsul

## Partea de stație

`lanhttp.rs` în Terrabit Connect Tauri, PR separat: execută cererea, aplică lista albă locală, limitează corpul (2 MB) și timeout-ul, raportează erorile de rețea ca stare (`status: 0`), nu ca defect al agentului.

🤖 Generated with [Claude Code](https://claude.com/claude-code)