### PR TITLE
[IMP] deltatech_sale_add_extra_line: hook for the product of the extra line

### DIFF
--- a/deltatech_sale_add_extra_line/__manifest__.py
+++ b/deltatech_sale_add_extra_line/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Add Extra Line",
     "summary": "Sale Add Extra Line",
-    "version": "19.0.1.3.1",
+    "version": "19.0.1.4.0",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_add_extra_line/models/sale.py
+++ b/deltatech_sale_add_extra_line/models/sale.py
@@ -46,9 +46,19 @@ class SaleOrderLine(models.Model):
         "A unit price that differs from it was set by the user and is kept as is.",
     )
 
+    def _get_extra_product(self):
+        """Return the product the extra line of this line must carry.
+
+        By default the one set on the product itself, but a module can decide it
+        from the line instead - the extra product then no longer has to be filled
+        in on every product for the line to appear.
+        """
+        self.ensure_one()
+        return self.product_id.extra_product_id
+
     def unlink(self):
         for line in self:
-            if line.product_id.extra_product_id:
+            if line._get_extra_product():
                 extra_line_id = self.order_id.order_line.filtered(
                     lambda li, line_uuid=line.line_uuid, line_id=line.id: li.line_uuid is not False
                     and li.line_uuid == line_uuid
@@ -77,7 +87,8 @@ class SaleOrderLine(models.Model):
 
     def check_extra_product(self):
         for line in self:
-            if line.product_id.extra_product_id:
+            extra_product = line._get_extra_product()
+            if extra_product:
                 extra_line_id = self.order_id.order_line.filtered(
                     lambda li, line_uuid=line.line_uuid, line_id=line.id: li.line_uuid is not False
                     and li.line_uuid == line_uuid
@@ -88,7 +99,7 @@ class SaleOrderLine(models.Model):
                     new_uuid = str(uuid.uuid4())
                     values = {
                         "product_uom_qty": line.product_uom_qty * (line.product_id.extra_qty or 1.0),
-                        "product_id": line.product_id.extra_product_id.id,
+                        "product_id": extra_product.id,
                         "state": "draft",
                         "order_id": line.order_id.id,
                         "sequence": line.sequence + 1,

--- a/deltatech_sale_add_extra_line/readme/HISTORY.md
+++ b/deltatech_sale_add_extra_line/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 19.0.1.4.0
+
+- [IMP] the product of the extra line goes through a hook, `SaleOrderLine._get_extra_product()`, instead of being read from `product_id.extra_product_id` in place. A module can now decide the extra product from the order line, so the line no longer requires the field to be filled in on every product. The default behaviour is unchanged
+
 ## 19.0.1.3.1
 
 - [FIX] the field tooltips are now IDENTICAL to the ones in `deltatech_purchase_add_extra_line`: both modules declare the same three fields on `product.template`, so with both installed the last one loaded wins and divergent wording made the tooltip depend on the load order. They are neutral as to the kind of document ("ordered") and mention both the price list and the vendor price


### PR DESCRIPTION
`check_extra_product` read `product_id.extra_product_id` in place, so a module could decide the *price* of the extra line but never its *existence*: a product without the field set got no line at all.

The product now goes through `SaleOrderLine._get_extra_product()`, which defaults to the same field — behaviour unchanged for every existing installation.

`deltatech_ptc` overrides it to supply an eco-tax product for tires held as non-EU stock, where the amount comes from the tire weight and there is no per-dimension product to link (PTC ticket #9128, order S186540). Paired PR: terrabit-ro/ptc.

Tested with the `deltatech_ptc` eco-tax suite (22 tests, 0 failures) on a copy of the customer database.

🤖 Generated with [Claude Code](https://claude.com/claude-code)