### PR TITLE
[IMP] deltatech_sale_add_extra_line: hook for the product of the extra line

### DIFF
--- a/deltatech_sale_add_extra_line/__manifest__.py
+++ b/deltatech_sale_add_extra_line/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Sale Add Extra Line",
     "summary": "Sale Add Extra Line",
-    "version": "18.0.1.1.0",
+    "version": "18.0.1.2.0",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_add_extra_line/models/sale.py
+++ b/deltatech_sale_add_extra_line/models/sale.py
@@ -60,9 +60,19 @@ class SaleOrderLine(models.Model):
         "A unit price that differs from it was set by the user and is kept as is.",
     )
 
+    def _get_extra_product(self):
+        """Return the product the extra line of this line must carry.
+
+        By default the one set on the product itself, but a module can decide it
+        from the line instead - the extra product then no longer has to be filled
+        in on every product for the line to appear.
+        """
+        self.ensure_one()
+        return self.product_id.extra_product_id
+
     def unlink(self):
         for line in self:
-            if line.product_id.extra_product_id:
+            if line._get_extra_product():
                 extra_line_id = self.order_id.order_line.filtered(
                     lambda li, line_uuid=line.line_uuid, line_id=line.id: li.line_uuid is not False
                     and li.line_uuid == line_uuid
@@ -91,7 +101,8 @@ class SaleOrderLine(models.Model):
 
     def check_extra_product(self):
         for line in self:
-            if line.product_id.extra_product_id:
+            extra_product = line._get_extra_product()
+            if extra_product:
                 extra_line_id = self.order_id.order_line.filtered(
                     lambda li, line_uuid=line.line_uuid, line_id=line.id: li.line_uuid is not False
                     and li.line_uuid == line_uuid
@@ -102,7 +113,7 @@ class SaleOrderLine(models.Model):
                     new_uuid = str(uuid.uuid4())
                     values = {
                         "product_uom_qty": line.product_uom_qty * (line.product_id.extra_qty or 1.0),
-                        "product_id": line.product_id.extra_product_id.id,
+                        "product_id": extra_product.id,
                         "state": "draft",
                         "order_id": line.order_id.id,
                         "sequence": line.sequence + 1,

--- a/deltatech_sale_add_extra_line/readme/HISTORY.md
+++ b/deltatech_sale_add_extra_line/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 18.0.1.2.0
+
+- [IMP] the product of the extra line goes through a hook, `SaleOrderLine._get_extra_product()`, instead of being read from `product_id.extra_product_id` in place. A module can now decide the extra product from the order line, so the line no longer requires the field to be filled in on every product. The default behaviour is unchanged
+
 ## 18.0.1.1.0
 
 - [IMP] a unit price typed in on the extra line is kept: the price computed from the main line (percent or list price) is no longer written back over it. The quantity keeps following the main line. Deleting the extra line is the way back to the computed price — it is regenerated on the next change of the order lines


### PR DESCRIPTION
Port of dhongu/deltatech#2800 to 18.0.

`check_extra_product` read `product_id.extra_product_id` in place, so a module could decide the *price* of the extra line but never its *existence*: a product without the field set got no line at all. The product now goes through `SaleOrderLine._get_extra_product()`, which defaults to the same field — behaviour unchanged.

Needed by `deltatech_ptc` 18.0.2.7.0 (terrabit-ro/ptc, PTC ticket #9128).

🤖 Generated with [Claude Code](https://claude.com/claude-code)