### PR TITLE
[IMP] deltatech_website_city: filter checkout cities by carrier catalog

### DIFF
--- a/deltatech_website_city/__manifest__.py
+++ b/deltatech_website_city/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Website City",
     "category": "Website/Website",
     "summary": "City extension",
-    "version": "18.0.1.1.4",
+    "version": "18.0.1.2.0",
     "author": "Terrabit, Dorin Hongu",
     "license": "LGPL-3",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_city/controller/website_sale.py
+++ b/deltatech_website_city/controller/website_sale.py
@@ -2,7 +2,7 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
-from odoo import http
+from odoo import _, http
 from odoo.http import request
 
 from odoo.addons.website_sale.controllers.main import WebsiteSale
@@ -35,16 +35,61 @@ class WebsiteSaleCity(WebsiteSale):
             form_data["city"] = request.env["res.city"].sudo().browse(int(city_id)).name
         return super()._parse_form_data(form_data)
 
+    def _get_carrier_city_domain(self, order_sudo, state, address_type="billing", use_delivery_as_billing=False):
+        """Restrict the offered localities to the catalog of the chosen carrier.
+
+        Only the delivery address is concerned: where the parcel is billed is
+        no business of the courier. The restriction is skipped when no carrier
+        is selected yet, when the carrier has no locality catalog of its own,
+        or when its catalog holds no locality at all in that state (catalog not
+        imported yet, or state not covered by the carrier) - otherwise the
+        customer would be left with an empty list.
+        """
+        if address_type != "delivery" and not use_delivery_as_billing:
+            return []
+        carrier = order_sudo.carrier_id if order_sudo else None
+        if not carrier or not state:
+            return []
+        domain = carrier.sudo()._get_city_domain() if hasattr(carrier, "_get_city_domain") else []
+        if not domain:
+            return []
+        known_cities = request.env["res.city"].sudo().search_count([("state_id", "=", state.id)] + domain, limit=1)
+        return domain if known_cities else []
+
+    def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values, partner_sudo, address_type, *args, **kwargs
+        )
+        city_id = address_values.get("city_id")
+        if city_id:
+            city = request.env["res.city"].sudo().browse(int(city_id))
+            city_domain = self._get_carrier_city_domain(
+                request.website.sale_get_order(),
+                city.state_id,
+                address_type=address_type,
+                use_delivery_as_billing=args[0] if args else kwargs.get("use_delivery_as_billing", False),
+            )
+            if city_domain and not city.filtered_domain(city_domain):
+                invalid_fields.add("city_id")
+                error_messages.append(_("The selected city is not served by the chosen delivery method."))
+        return invalid_fields, missing_fields, error_messages
+
     def _prepare_address_form_values(self, order_sudo, partner_sudo, *args, **kwargs):
         rendering_values = super()._prepare_address_form_values(order_sudo, partner_sudo, *args, **kwargs)
         state = request.env["res.country.state"].browse(rendering_values["state_id"])
         city = partner_sudo.city_id
         ResCity = request.env["res.city"].sudo()
+        city_domain = self._get_carrier_city_domain(
+            order_sudo,
+            state,
+            address_type=rendering_values.get("address_type", "billing"),
+            use_delivery_as_billing=kwargs.get("use_delivery_as_billing", False),
+        )
 
         rendering_values.update(
             {
                 "state": state,
-                "state_cities": ResCity.search([("state_id", "=", state.id)]) if state else ResCity,
+                "state_cities": ResCity.search([("state_id", "=", state.id)] + city_domain) if state else ResCity,
                 "city": city,
                 "city_id": city.id if city else False,
             }
@@ -58,7 +103,14 @@ class WebsiteSaleCity(WebsiteSale):
         methods=["POST"],
         website=True,
     )
-    def state_infos(self, state, **kw):
+    def state_infos(self, state, address_type="billing", use_delivery_as_billing=False, **kw):
+        order_sudo = request.website.sale_get_order()
+        city_domain = self._get_carrier_city_domain(
+            order_sudo,
+            state,
+            address_type=address_type,
+            use_delivery_as_billing=use_delivery_as_billing in (True, "True", "true", "1"),
+        )
         return dict(
-            cities=[(st.id, st.display_name, st.zipcode or "") for st in state.get_website_sale_cities()],
+            cities=[(st.id, st.display_name, st.zipcode or "") for st in state.get_website_sale_cities(city_domain)],
         )

--- a/deltatech_website_city/i18n/ro.po
+++ b/deltatech_website_city/i18n/ro.po
@@ -51,3 +51,9 @@ msgstr "Județ"
 #: model_terms:ir.ui.view,arch_db:deltatech_website_city.portal_my_details_fields
 msgid "State / Province"
 msgstr "Județ"
+
+#. module: deltatech_website_city
+#. odoo-python
+#: code:addons/deltatech_website_city/controller/website_sale.py:0
+msgid "The selected city is not served by the chosen delivery method."
+msgstr "Localitatea selectată nu este deservită de metoda de livrare aleasă."

--- a/deltatech_website_city/models/res_country.py
+++ b/deltatech_website_city/models/res_country.py
@@ -10,5 +10,8 @@ class CountryState(models.Model):
 
     city_ids = fields.One2many("res.city", "state_id")
 
-    def get_website_sale_cities(self):
-        return self.sudo().city_ids
+    def get_website_sale_cities(self, domain=None):
+        cities = self.sudo().city_ids
+        if domain:
+            cities = cities.filtered_domain(domain)
+        return cities

--- a/deltatech_website_city/readme/HISTORY.md
+++ b/deltatech_website_city/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 18.0.1.2.0 (2026-08-13)
+
+- Imp: on the checkout delivery address, the locality list is limited to the localities known by the selected carrier, when that carrier ships with its own locality catalog (`delivery.carrier._get_city_domain()`). Both the initial rendering and the `/shop/state_infos` lookup apply the filter, and a submitted locality outside the catalog is rejected server side. The filter is skipped when no carrier is selected yet, when the carrier has no catalog, or when its catalog holds no locality in that state, so the customer is never left with an empty list.
+
 ## 18.0.1.1.4 (2026-06-10)
 
 - Fix `TypeError` (500 Internal Server Error) on `/shop/address`: `_prepare_address_form_values()` now uses a tolerant `*args, **kwargs` signature, compatible with newer Odoo 18 builds that pass `use_delivery_as_billing` positionally.

--- a/deltatech_website_city/static/src/js/website_sale.esm.js
+++ b/deltatech_website_city/static/src/js/website_sale.esm.js
@@ -75,7 +75,12 @@ websiteSaleAddress.include({
         const stateId = this.elementState.value;
         let choices = [];
         if (stateId) {
-            const data = await rpc(`/shop/state_infos/${this.elementState.value}`, {});
+            // The address type tells the server whether the courier's locality
+            // catalog applies: it only restricts the delivery address.
+            const data = await rpc(`/shop/state_infos/${this.elementState.value}`, {
+                address_type: this.addressForm.address_type?.value || "billing",
+                use_delivery_as_billing: this.addressForm.use_delivery_as_billing?.value || false,
+            });
             choices = data.cities;
         }
         this.elementCities.options.length = 1;


### PR DESCRIPTION
## What

On the checkout **delivery** address, the locality dropdown now offers only the localities known by the selected carrier, when that carrier ships with its own locality catalog (`delivery.carrier._get_city_domain()`, added in terrabit-solutions/bitshop_delivery#89).

- applied on the initial rendering (`_prepare_address_form_values`) and on the `/shop/state_infos/<state>` lookup called when the county changes;
- the JS forwards `address_type` / `use_delivery_as_billing` to that route, so a billing address is never restricted — where the parcel is billed is no business of the courier;
- `_validate_address_values` rejects a locality submitted outside the catalog (stale page, direct POST) with an error on `city_id`.

## Safety net

The filter is skipped entirely when:

- the address being edited is a billing-only address;
- no carrier is selected yet (`/shop/address` reached before the delivery step);
- the carrier has no catalog of its own (`_get_city_domain()` returns `[]`, or `deltatech_delivery` is not installed);
- the carrier's catalog holds no locality in that county — catalog not imported yet, or country not covered (DPD, for instance, only has real data for a few countries).

So the customer is never left with an empty list.

## Test

Verified on a local copy of a client database (`ptc18`), with FAN Courier selected on the order and 5 Cluj localities temporarily flagged in the catalog:

| Request | Result |
| --- | --- |
| `/shop/state_infos/<Cluj>`, `address_type=delivery` | 5 localities — exactly the ones in the catalog |
| `/shop/state_infos/<Cluj>`, `address_type=billing` | 444 localities — unfiltered |
| `/shop/state_infos/<Cluj>`, billing + `use_delivery_as_billing` | 5 localities |
| `/shop/state_infos/<Brașov>` (county not covered) | 175 localities — unfiltered fallback |
| `/shop/state_infos/<Cluj>`, no carrier on the order | full list |

🤖 Generated with [Claude Code](https://claude.com/claude-code)