### PR TITLE
[19.0][IMP] deltatech_website_city: filter checkout cities by carrier catalog

### DIFF
--- a/deltatech_website_city/__manifest__.py
+++ b/deltatech_website_city/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Website City",
     "category": "Website/Website",
     "summary": "City extension",
-    "version": "19.0.1.1.2",
+    "version": "19.0.1.2.0",
     "author": "Terrabit, Dorin Hongu",
     "support": "odoo@terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_website_city/controller/portal.py
+++ b/deltatech_website_city/controller/portal.py
@@ -9,6 +9,30 @@ from odoo.addons.portal.controllers.portal import CustomerPortal
 
 
 class CustomerPortalCity(CustomerPortal):
+    def _get_carrier_city_domain(self, state, address_type="billing", use_delivery_as_billing=False, order_sudo=None):
+        """Restrict the offered localities to the catalog of the chosen carrier.
+
+        Only the delivery address is concerned: where the parcel is billed is
+        no business of the courier. The restriction is skipped when no carrier
+        is selected yet, when the carrier has no locality catalog of its own,
+        or when its catalog holds no locality in that state - catalog not
+        imported yet, or state not covered by the carrier - otherwise the
+        customer would be left with an empty list.
+        """
+        if not state or (address_type != "delivery" and not use_delivery_as_billing):
+            return []
+        if order_sudo is None:
+            website = getattr(request, "website", None)
+            order_sudo = website.sale_get_order() if website else None
+        carrier = order_sudo.carrier_id if order_sudo else None
+        if not carrier or not hasattr(carrier, "_get_city_domain"):
+            return []
+        domain = carrier.sudo()._get_city_domain()
+        if not domain:
+            return []
+        known_cities = request.env["res.city"].sudo().search_count([("state_id", "=", state.id)] + domain, limit=1)
+        return domain if known_cities else []
+
     def _prepare_address_form_values(self, partner_sudo, *args, **kwargs):
         rendering_values = super()._prepare_address_form_values(partner_sudo, *args, **kwargs)
 
@@ -16,10 +40,16 @@ class CustomerPortalCity(CustomerPortal):
         state = request.env["res.country.state"].browse(rendering_values.get("state_id"))
         city = partner_sudo.city_id
         ResCity = request.env["res.city"].sudo()
+        city_domain = self._get_carrier_city_domain(
+            state,
+            address_type=rendering_values.get("address_type", "billing"),
+            use_delivery_as_billing=kwargs.get("use_delivery_as_billing", False),
+            order_sudo=kwargs.get("order_sudo") or None,
+        )
         rendering_values.update(
             {
                 "state": state,
-                "state_cities": ResCity.search([("state_id", "=", state.id)]) if state else ResCity,
+                "state_cities": ResCity.search([("state_id", "=", state.id)] + city_domain) if state else ResCity,
                 "city": city,
             }
         )
@@ -34,6 +64,23 @@ class CustomerPortalCity(CustomerPortal):
                 mandatory_fields.remove("city")
         return mandatory_fields
 
+    def _validate_address_values(self, address_values, partner_sudo, address_type, *args, **kwargs):
+        invalid_fields, missing_fields, error_messages = super()._validate_address_values(
+            address_values, partner_sudo, address_type, *args, **kwargs
+        )
+        city_id = address_values.get("city_id")
+        if city_id:
+            city = request.env["res.city"].sudo().browse(int(city_id))
+            city_domain = self._get_carrier_city_domain(
+                city.state_id,
+                address_type=address_type,
+                use_delivery_as_billing=args[0] if args else kwargs.get("use_delivery_as_billing", False),
+            )
+            if city_domain and not city.filtered_domain(city_domain):
+                invalid_fields.add("city_id")
+                error_messages.append(request.env._("The selected city is not served by the chosen delivery method."))
+        return invalid_fields, missing_fields, error_messages
+
     @route(
         '/portal/state_infos/<model("res.country.state"):state>',
         type="jsonrpc",
@@ -41,7 +88,12 @@ class CustomerPortalCity(CustomerPortal):
         methods=["POST"],
         website=True,
     )
-    def state_infos(self, state, **kw):
-        cities = request.env["res.city"].sudo().search([("state_id", "=", state.id)])
+    def state_infos(self, state, address_type="billing", use_delivery_as_billing=False, **kw):
+        city_domain = self._get_carrier_city_domain(
+            state,
+            address_type=address_type,
+            use_delivery_as_billing=use_delivery_as_billing in (True, "True", "true", "1"),
+        )
+        cities = request.env["res.city"].sudo().search([("state_id", "=", state.id)] + city_domain)
         # Return similar tuple structure as website_sale: (id, display_name, zipcode or "")
         return {"cities": [(c.id, c.display_name, c.zipcode or "") for c in cities]}

--- a/deltatech_website_city/i18n/deltatech_website_city.pot
+++ b/deltatech_website_city/i18n/deltatech_website_city.pot
@@ -40,3 +40,9 @@ msgstr ""
 #: model:ir.model.fields,field_description:deltatech_website_city.field_res_country_state__id
 msgid "ID"
 msgstr ""
+
+#. module: deltatech_website_city
+#. odoo-python
+#: code:addons/deltatech_website_city/controller/portal.py:0
+msgid "The selected city is not served by the chosen delivery method."
+msgstr ""

--- a/deltatech_website_city/i18n/ro.po
+++ b/deltatech_website_city/i18n/ro.po
@@ -30,3 +30,9 @@ msgstr "Localitate"
 #: model:ir.model,name:deltatech_website_city.model_res_country_state
 msgid "Country state"
 msgstr "Județ"
+
+#. module: deltatech_website_city
+#. odoo-python
+#: code:addons/deltatech_website_city/controller/portal.py:0
+msgid "The selected city is not served by the chosen delivery method."
+msgstr "Localitatea selectată nu este deservită de metoda de livrare aleasă."

--- a/deltatech_website_city/readme/HISTORY.md
+++ b/deltatech_website_city/readme/HISTORY.md
@@ -1,0 +1,3 @@
+## 19.0.1.2.0 (2026-08-13)
+
+- Imp: on the checkout delivery address, the locality list is limited to the localities known by the selected carrier, when that carrier ships with its own locality catalog (`delivery.carrier._get_city_domain()`). Both the rendering and the `/portal/state_infos` lookup apply the filter, and a locality submitted outside the catalog is rejected server side. Only the delivery address is concerned. The filter is skipped when no carrier is selected yet, when the carrier has no catalog, or when its catalog holds no locality in that state, so the customer is never left with an empty list.

--- a/deltatech_website_city/static/src/interactions/address.esm.js
+++ b/deltatech_website_city/static/src/interactions/address.esm.js
@@ -54,7 +54,14 @@ patch(CustomerAddress.prototype, {
         const stateId = this.elementState.value;
         let choices = [];
         if (stateId) {
-            const data = await this.waitFor(rpc(`/portal/state_infos/${stateId}`, {}));
+            // The address type tells the server whether the courier's locality
+            // catalog applies: it only restricts the delivery address.
+            const data = await this.waitFor(
+                rpc(`/portal/state_infos/${stateId}`, {
+                    address_type: this.addressForm.address_type?.value || "billing",
+                    use_delivery_as_billing: this.addressForm.use_delivery_as_billing?.value || false,
+                })
+            );
             choices = data.cities;
         }
         this._changeOption(this.elementCities, choices);


### PR DESCRIPTION
Port of dhongu/deltatech#2802 to 19.0. Depends on terrabit-solutions/bitshop_delivery#90.

## What

On the checkout **delivery** address, the locality dropdown offers only the localities known by the selected carrier, when that carrier ships with its own locality catalog (`delivery.carrier._get_city_domain()`).

- applied on the rendering (`_prepare_address_form_values`) and on the `/portal/state_infos/<state>` lookup;
- the interaction forwards `address_type` / `use_delivery_as_billing` to that route, so billing addresses — and the same form reached from **My Account** — stay unfiltered;
- `_validate_address_values` rejects a locality submitted outside the catalog with an error on `city_id`.

## Adaptation to 19.0

The 18.0 change lives in the `website_sale` controller. On 19.0 the address form and its city route moved to `portal` (`CustomerPortalCity`, `/portal/state_infos`), shared between the shop and My Account — hence the explicit `address_type` gating, which matters more here than on 18.0. The cart is read from the `order_sudo` kwarg that `website_sale` forwards, falling back to `request.website.sale_get_order()` for the JSON route.

## Safety net

The filter is skipped when the address is billing-only, when no carrier is selected yet, when the carrier has no catalog of its own, or when its catalog holds no locality in that county (not imported yet, or country not covered). So the customer is never left with an empty list.

## Test

Not run on 19.0 — no client database on hand with a carrier locality catalog imported. The equivalent 18.0 code was verified end to end on a copy of a client database (see dhongu/deltatech#2802): filtered on `address_type=delivery` (5 of 444 Cluj localities), unfiltered on `billing`, filtered again with `use_delivery_as_billing`, unfiltered fallback on a county the carrier does not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)