### PR TITLE
[TEST] deltatech_website_city: cover the carrier city filter

### DIFF
--- a/deltatech_website_city/__manifest__.py
+++ b/deltatech_website_city/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Website City",
     "category": "Website/Website",
     "summary": "City extension",
-    "version": "18.0.1.2.0",
+    "version": "18.0.1.2.1",
     "author": "Terrabit, Dorin Hongu",
     "license": "LGPL-3",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_city/readme/HISTORY.md
+++ b/deltatech_website_city/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 18.0.1.2.1 (2026-08-13)
+
+- Test: the carrier city filter at checkout is covered end to end -- filtered on the delivery address, whole on a billing address, whole again when no carrier is chosen, when the carrier has no catalog, or when its catalog covers nothing in that county, and a locality outside the catalog refused on submit.
+
 ## 18.0.1.2.0 (2026-08-13)
 
 - Imp: on the checkout delivery address, the locality list is limited to the localities known by the selected carrier, when that carrier ships with its own locality catalog (`delivery.carrier._get_city_domain()`). Both the initial rendering and the `/shop/state_infos` lookup apply the filter, and a submitted locality outside the catalog is rejected server side. The filter is skipped when no carrier is selected yet, when the carrier has no catalog, or when its catalog holds no locality in that state, so the customer is never left with an empty list.

--- a/deltatech_website_city/tests/__init__.py
+++ b/deltatech_website_city/tests/__init__.py
@@ -7,3 +7,5 @@
 
 # from . import test_shop_checkout_city
 # from . import test_portal_city
+
+from . import test_carrier_city_filter

--- a/deltatech_website_city/tests/test_carrier_city_filter.py
+++ b/deltatech_website_city/tests/test_carrier_city_filter.py
@@ -1,0 +1,160 @@
+# ©  2026 Deltatech
+# See README.rst file on addons root folder for license details
+"""The locality list offered at checkout follows the carrier's own catalog.
+
+The carrier modules are not a dependency here -- what this module knows is the
+seam, ``delivery.carrier._get_city_domain()``. So the tests stand in for a
+carrier catalog by patching that method, which is exactly what DPD, Sameday,
+Cargus and Fan Curier implement on their side.
+"""
+
+import json
+import re
+from unittest.mock import patch
+
+from odoo.tests import HttpCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestCarrierCityFilter(HttpCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.country = cls.env["res.country"].create(
+            {"name": "Carrierland", "code": "XC", "enforce_cities": True, "state_required": True}
+        )
+        cls.state = cls.env["res.country.state"].create(
+            {"name": "Served County", "code": "SC", "country_id": cls.country.id}
+        )
+        # A county the carrier knows nothing about, to cover the fallback.
+        cls.other_state = cls.env["res.country.state"].create(
+            {"name": "Unknown County", "code": "UC", "country_id": cls.country.id}
+        )
+        cls.served_city, cls.unserved_city = cls.env["res.city"].create(
+            [
+                {"name": "Served City", "state_id": cls.state.id, "country_id": cls.country.id, "zipcode": "10000"},
+                {"name": "Unserved City", "state_id": cls.state.id, "country_id": cls.country.id, "zipcode": "10001"},
+            ]
+        )
+        cls.other_city = cls.env["res.city"].create(
+            {"name": "Far City", "state_id": cls.other_state.id, "country_id": cls.country.id}
+        )
+
+        cls.carrier = cls.env["delivery.carrier"].create(
+            {
+                "name": "Test Carrier",
+                "delivery_type": "fixed",
+                "fixed_price": 10.0,
+                "product_id": cls.env["product.product"].create({"name": "Test Delivery", "type": "service"}).id,
+            }
+        )
+        cls.product = cls.env["product.product"].create(
+            {"name": "Test Product", "list_price": 100.0, "sale_ok": True, "website_published": True}
+        )
+
+    def _fill_cart(self):
+        """Create a cart for the anonymous session and return it."""
+        self._rpc("/shop/cart/update_json", {"product_id": self.product.id, "add_qty": 1})
+        order = self.env["sale.order"].search([("website_id", "!=", False)], order="id desc", limit=1)
+        self.assertTrue(order, "the cart was not created")
+        return order
+
+    def _rpc(self, url, params=None):
+        response = self.url_open(
+            url,
+            data=json.dumps({"jsonrpc": "2.0", "method": "call", "params": params or {}}),
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        self.assertNotIn("error", payload, payload.get("error"))
+        return payload["result"]
+
+    def _csrf_token(self, url):
+        """The form posts one, and the request is refused without it."""
+        page = self.url_open(url)
+        page.raise_for_status()
+        match = re.search(r'name="csrf_token"[^>]*value="([^"]+)"', page.text)
+        self.assertTrue(match, "no csrf token on the address page")
+        return match.group(1)
+
+    def _city_names(self, state, **params):
+        result = self._rpc(f"/shop/state_infos/{state.id}", params)
+        return {city[1] for city in result["cities"]}
+
+    def _catalog(self, cities):
+        """Stand in for a carrier that knows exactly these localities."""
+        return patch.object(
+            type(self.env["delivery.carrier"]),
+            "_get_city_domain",
+            lambda carrier: [("id", "in", cities.ids)],
+            create=True,
+        )
+
+    def test_delivery_address_offers_only_the_localities_the_carrier_serves(self):
+        self._fill_cart().carrier_id = self.carrier
+        with self._catalog(self.served_city):
+            names = self._city_names(self.state, address_type="delivery")
+        self.assertEqual(names, {self.served_city.display_name})
+
+    def test_billing_address_is_not_restricted_by_the_carrier(self):
+        """Where the parcel is billed is no business of the courier."""
+        self._fill_cart().carrier_id = self.carrier
+        with self._catalog(self.served_city):
+            names = self._city_names(self.state, address_type="billing")
+        self.assertEqual(names, {self.served_city.display_name, self.unserved_city.display_name})
+
+    def test_billing_address_used_as_delivery_is_restricted(self):
+        self._fill_cart().carrier_id = self.carrier
+        with self._catalog(self.served_city):
+            names = self._city_names(self.state, address_type="billing", use_delivery_as_billing="True")
+        self.assertEqual(names, {self.served_city.display_name})
+
+    def test_no_carrier_chosen_yet_leaves_the_list_whole(self):
+        """The address page is reached before the delivery step."""
+        self._fill_cart()
+        with self._catalog(self.served_city):
+            names = self._city_names(self.state, address_type="delivery")
+        self.assertEqual(names, {self.served_city.display_name, self.unserved_city.display_name})
+
+    def test_a_county_the_carrier_does_not_cover_leaves_the_list_whole(self):
+        """Rather than hand the customer an empty dropdown."""
+        self._fill_cart().carrier_id = self.carrier
+        with self._catalog(self.served_city):
+            names = self._city_names(self.other_state, address_type="delivery")
+        self.assertEqual(names, {self.other_city.display_name})
+
+    def test_a_carrier_without_a_catalog_leaves_the_list_whole(self):
+        """Packeta and the like ship anywhere: an empty domain, and no filter."""
+        self._fill_cart().carrier_id = self.carrier
+        no_catalog = patch.object(
+            type(self.env["delivery.carrier"]), "_get_city_domain", lambda carrier: [], create=True
+        )
+        with no_catalog:
+            names = self._city_names(self.state, address_type="delivery")
+        self.assertEqual(names, {self.served_city.display_name, self.unserved_city.display_name})
+
+    def test_a_locality_outside_the_catalog_is_refused_on_submit(self):
+        """The dropdown can be stale, and the form can be posted directly."""
+        self._fill_cart().carrier_id = self.carrier
+        form_data = {
+            "address_type": "delivery",
+            "name": "Test Customer",
+            "email": "test.customer@example.com",
+            "street": "Test Street 1",
+            "city_id": self.unserved_city.id,
+            "city": self.unserved_city.name,
+            "zip": "10001",
+            "state_id": self.state.id,
+            "country_id": self.country.id,
+        }
+        form_data["csrf_token"] = self._csrf_token("/shop/address?address_type=delivery")
+        with self._catalog(self.served_city):
+            response = self.url_open("/shop/address/submit", data=form_data)
+        response.raise_for_status()
+        feedback = response.json()
+        self.assertIn("city_id", feedback.get("invalid_fields", []))
+        self.assertTrue(
+            any("not served" in message for message in feedback.get("messages", [])),
+            feedback,
+        )


### PR DESCRIPTION
Follow-up to #2802 — the filter merged there had no automated coverage; `codecov/patch` passed only because this branch's target is 10%.

Seven `HttpCase` tests over the real checkout flow: a cart is filled through `/shop/cart/update_json`, a carrier is put on it, and the carrier catalog is stood in for by patching `delivery.carrier._get_city_domain()` — the carrier modules are not a dependency of this one, and that method is exactly the seam they implement.

| Case | Expected |
| --- | --- |
| delivery address, carrier with catalog | only the localities in the catalog |
| billing address | whole list |
| billing used as delivery | filtered |
| no carrier chosen yet | whole list |
| carrier without a catalog | whole list |
| county the carrier does not cover | whole list |
| locality outside the catalog, posted to `/shop/address/submit` | refused, `city_id` flagged |

Run locally on a copy of a client database (`ptc18`): 7 tests, 0 failed, 0 errors.

Note: `tests/__init__.py` on this branch has every existing test commented out. This PR only adds the import for the new file and leaves the others as they were — enabling them is a separate matter.

The same suite ported to 19.0 is in #2804, where it caught a real regression: `website.sale_get_order()` no longer exists there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)