### PR TITLE
[19.0][FIX] deltatech_no_quick_create: patch Many2One in loc de Many2OneField

### DIFF
--- a/deltatech_no_quick_create/__manifest__.py
+++ b/deltatech_no_quick_create/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "No quick_create",
     "summary": "Disable quick_create",
-    "version": "19.0.2.0.0",
+    "version": "19.0.2.0.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Tools",

--- a/deltatech_no_quick_create/static/src/js/fields.esm.js
+++ b/deltatech_no_quick_create/static/src/js/fields.esm.js
@@ -1,24 +1,17 @@
-import {Many2OneField} from "@web/views/fields/many2one/many2one_field";
+import {Many2One} from "@web/views/fields/many2one/many2one";
 import {patch} from "@web/core/utils/patch";
 
-patch(Many2OneField.prototype, {
-    defaultProps: {
-        ...Many2OneField.defaultProps,
-        canQuickCreate: false,
-        quick_create: false,
-        no_quick_create: true,
-    },
-    setup() {
-        this.props.canQuickCreate = false;
+// Many2OneField, Many2OneBarcodeField, Many2OneAvatarField, ReferenceField, ...
+// all render through this shared Many2One component, so patching it here
+// disables quick-create everywhere regardless of which widget was used
+// (a per-widget patch, e.g. on Many2OneField, misses many2one_barcode and co.).
+patch(Many2One.prototype, {
+    get many2XAutocompleteProps() {
+        return {
+            ...super.many2XAutocompleteProps,
+            quickCreate: null,
+        };
         // Diabled create edit too
-        // this.props.canCreateEdit = false;
-        super.setup();
-    },
-    extractProps({attrs}) {
-        const props = super.extractProps(...arguments);
-        if (attrs.options.no_quick_create === undefined) props.canQuickCreate = false;
-        // Diabled create edit too
-        // if (attrs.options.no_create_edit === undefined) props.canCreateEdit = false;
-        return props;
+        // activeActions: {...super.activeActions, createEdit: false},
     },
 });


### PR DESCRIPTION
## Context / de ce

`deltatech_no_quick_create` nu mai funcționa pe Odoo 19: dezactivarea opțiunii "Create 'x'" din
dropdown-ul câmpurilor many2one nu mai avea niciun efect.

## Ce s-a schimbat

Modulul patch-uia metode de clasă pe `Many2OneField` (`setup()`, `extractProps()`,
`defaultProps`). În v19 componenta a fost rescrisă: nu mai are aceste metode ca membri de clasă —
extracția props-urilor s-a mutat într-o funcție standalone (`extractM2OFieldProps`), înregistrată
per-widget în `registry.category("fields")`. Patch-ul viza metode inexistente și devenise cod mort
(fără erori la încărcare, dar fără niciun efect).

O primă variantă suprascria doar entry-ul `"many2one"` din registry, dar câmpurile many2one din
proiect nu folosesc doar acel widget generic — `product_id` pe liniile de comandă, de exemplu,
folosește `many2one_barcode` / `ProductNameAndDescriptionField`, fiecare cu propriul
`extractProps`, deci fix-ul parțial nu le acoperea.

Soluția finală: `Many2OneField`, `Many2OneBarcodeField`, `ProductNameAndDescriptionField`,
`PartnerAutoCompleteMany2one` etc. randează toate prin componenta comună `Many2One`
(`@web/views/fields/many2one/many2one`), care decide în getter-ul `many2XAutocompleteProps` dacă
trimite o funcție `quickCreate` sau `null` spre autocomplete, pe baza `props.canQuickCreate`.
Modulul patch-uiește acum acest getter direct pe `Many2One.prototype`, forțând `quickCreate: null`
— dezactivare universală, indiferent de widget-ul concret folosit peste `Many2One`.

Am eliminat și vechea logică "dacă view-ul setează explicit `no_quick_create`, nu suprascrie" —
verificat cu grep în toate repo-urile Terrabit că nicăieri nu se folosește `no_quick_create: False`
explicit (doar `True`, pe alte widget-uri), deci acel escape-hatch nu era folosit de nimeni.

Fișiere schimbate:
- `deltatech_no_quick_create/static/src/js/fields.esm.js` — patch rescris pe `Many2One.prototype`.
- `deltatech_no_quick_create/__manifest__.py` — bump versiune `19.0.2.0.0` → `19.0.2.0.1`.

## Testare

Instalat modulul pe o bază de test curată (`test19att`), pornit serverul local și testat manual:

- Pe un Sales Order nou, în câmpul Product (widget `ProductNameAndDescriptionField`, peste
  `Many2One`), scriind un text fără potrivire → dropdown-ul arată **doar** `"Create and edit..."`,
  fără `"Create 'x'"` (verificat prin citirea DOM-ului, nu doar vizual).
- Verificat în cod că `PartnerMany2One` (folosit pentru câmpul Customer) extinde `Many2One` fără
  să-și suprascrie propriul `many2XAutocompleteProps`, deci moștenește patch-ul.
- Zero erori în consola browserului la încărcarea JS-ului patch-uit.
- `pre-commit run` pe fișierele modificate: toate hook-urile trec (lint, format, checks Odoo).

## Note / riscuri

Nu există teste automate Python pentru acest modul (e strict JS/frontend); verificarea a fost
manuală, în browser, pe o bază demo curată.

🤖 Generated with [Claude Code](https://claude.com/claude-code)