### PR TITLE
[FIX] deltatech_stock_picking_activity_report: nu mai jurnaliza conținutul câmpurilor binare

### DIFF
--- a/deltatech_stock_picking_activity_report/__manifest__.py
+++ b/deltatech_stock_picking_activity_report/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Stock Picking Activity Report",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "author": "Terrabit, Voicu Stefan",
     "website": "https://www.terrabit.ro",
     "category": "Inventory",

--- a/deltatech_stock_picking_activity_report/models/stock_picking.py
+++ b/deltatech_stock_picking_activity_report/models/stock_picking.py
@@ -13,6 +13,9 @@ SKIPPED_FIELD_TYPES = ("binary",)
 # Plafoane de siguranță: o valoare de câmp, un mesaj și jurnalul unei zile nu
 # pot depăși aceste dimensiuni, oricât de mare ar fi conținutul scris.
 MAX_VALUE_LENGTH = 200
+# Câmpurile x2many (operațiile transferului) sunt descrise linie cu linie, deci
+# au nevoie de un plafon mai larg — altfel s-ar pierde tocmai informația utilă.
+MAX_RELATION_LENGTH = 2000
 MAX_MESSAGE_LENGTH = 2000
 MAX_LOG_LENGTH = 65536
 
@@ -211,8 +214,9 @@ class StockPicking(models.Model):
 
                             return str(val)
 
-                        old_val_str = truncate(format_val(old_val, field_type, field_name), MAX_VALUE_LENGTH)
-                        new_val_str = truncate(format_val(new_val, field_type, field_name), MAX_VALUE_LENGTH)
+                        limit = MAX_RELATION_LENGTH if field_type in ("one2many", "many2many") else MAX_VALUE_LENGTH
+                        old_val_str = truncate(format_val(old_val, field_type, field_name), limit)
+                        new_val_str = truncate(format_val(new_val, field_type, field_name), limit)
 
                         if old_val_str != new_val_str:
                             changes.append(f"{field_label}: {old_val_str} -> {new_val_str}")

--- a/deltatech_stock_picking_activity_report/models/stock_picking.py
+++ b/deltatech_stock_picking_activity_report/models/stock_picking.py
@@ -6,6 +6,23 @@ from odoo import models
 
 _logger = logging.getLogger(__name__)
 
+# Tipurile de câmp care nu au ce căuta în jurnal: valoarea lor serializată e
+# conținutul brut al fișierului (eticheta AWB, semnătura), adică sute de kB de
+# base64 per scriere.
+SKIPPED_FIELD_TYPES = ("binary",)
+# Plafoane de siguranță: o valoare de câmp, un mesaj și jurnalul unei zile nu
+# pot depăși aceste dimensiuni, oricât de mare ar fi conținutul scris.
+MAX_VALUE_LENGTH = 200
+MAX_MESSAGE_LENGTH = 2000
+MAX_LOG_LENGTH = 65536
+
+
+def truncate(value, limit):
+    """Scurtează ``value`` la ``limit`` caractere, marcând cât s-a tăiat."""
+    if len(value) <= limit:
+        return value
+    return f"{value[:limit]}… (+{len(value) - limit} chars)"
+
 
 class StockPicking(models.Model):
     _inherit = "stock.picking"
@@ -15,7 +32,7 @@ class StockPicking(models.Model):
             if self.env.user.has_group("base.group_user") and self.env.user.login != "__system__":
                 today = datetime.now().date()
                 now = datetime.now().strftime("%H:%M:%S")
-                full_log_msg = f"{now} - {log_msg}\n"
+                full_log_msg = f"{now} - {truncate(log_msg, MAX_MESSAGE_LENGTH)}\n"
                 for picking in self:
                     picking_id = picking.id
                     existing_record = (
@@ -59,6 +76,10 @@ class StockPicking(models.Model):
                         self.env["stock.picking.activity.record"].sudo().create(vals)
                     else:
                         new_log = (existing_record.activity_log or "") + full_log_msg
+                        if len(new_log) > MAX_LOG_LENGTH:
+                            # Păstrăm coada (activitatea recentă) și tăiem de la
+                            # prima linie completă, ca jurnalul să rămână lizibil.
+                            new_log = new_log[-MAX_LOG_LENGTH:].split("\n", 1)[-1]
                         vals["activity_log"] = new_log
                         if self.env.context.get("chatter_message", False):
                             vals.update({"chatter_message": True})
@@ -86,6 +107,11 @@ class StockPicking(models.Model):
                     for field_name, new_val in vals.items():
                         field_label = fields_info.get(field_name, {}).get("string", field_name)
                         field_type = fields_info.get(field_name, {}).get("type")
+                        if field_type in SKIPPED_FIELD_TYPES:
+                            # Ieșim înainte de a citi valoarea veche: pentru un câmp
+                            # binar, `picking[field_name]` ar încărca degeaba din
+                            # filestore un conținut pe care oricum nu-l jurnalizăm.
+                            continue
                         old_val = picking[field_name]
                         if field_name == "carrier_tracking_ref" and new_val is not False:
                             log_context["awb_generated"] = True
@@ -185,8 +211,8 @@ class StockPicking(models.Model):
 
                             return str(val)
 
-                        old_val_str = format_val(old_val, field_type, field_name)
-                        new_val_str = format_val(new_val, field_type, field_name)
+                        old_val_str = truncate(format_val(old_val, field_type, field_name), MAX_VALUE_LENGTH)
+                        new_val_str = truncate(format_val(new_val, field_type, field_name), MAX_VALUE_LENGTH)
 
                         if old_val_str != new_val_str:
                             changes.append(f"{field_label}: {old_val_str} -> {new_val_str}")

--- a/deltatech_stock_picking_activity_report/readme/HISTORY.md
+++ b/deltatech_stock_picking_activity_report/readme/HISTORY.md
@@ -1,0 +1,17 @@
+## 19.0.1.1.0 (2026-08-15)
+
+**Fix** — jurnalul de activitate nu mai stochează conținutul câmpurilor binare.
+
+Modificarea unui câmp binar de pe transfer (eticheta AWB, semnătura) scria în
+`activity_log` întregul conținut base64 al fișierului. Pe o instanță de
+producție asta însemna o medie de 32 kB per înregistrare, cu vârfuri de 1,7 MB,
+și circa 1,7 GB în baza de date la doar două luni de activitate păstrată.
+
+Acum:
+
+- câmpurile binare sunt ignorate complet la jurnalizare — nici nu mai sunt
+  citite din filestore, deci scrierea pe transfer este și mai rapidă;
+- valorile de câmp jurnalizate sunt scurtate la 200 de caractere, cu marcarea
+  numărului de caractere tăiate;
+- mesajele din chatter sunt scurtate la 2000 de caractere;
+- jurnalul unei zile este plafonat la 64 kB, păstrând activitatea recentă.

--- a/deltatech_stock_picking_activity_report/readme/HISTORY.md
+++ b/deltatech_stock_picking_activity_report/readme/HISTORY.md
@@ -11,7 +11,8 @@ Acum:
 
 - câmpurile binare sunt ignorate complet la jurnalizare — nici nu mai sunt
   citite din filestore, deci scrierea pe transfer este și mai rapidă;
-- valorile de câmp jurnalizate sunt scurtate la 200 de caractere, cu marcarea
-  numărului de caractere tăiate;
+- valorile de câmp jurnalizate sunt scurtate la 200 de caractere (2000 pentru
+  câmpurile x2many, descrise linie cu linie), cu marcarea numărului de
+  caractere tăiate;
 - mesajele din chatter sunt scurtate la 2000 de caractere;
 - jurnalul unei zile este plafonat la 64 kB, păstrând activitatea recentă.

--- a/deltatech_stock_picking_activity_report/tests/test_stock_picking_activity_report.py
+++ b/deltatech_stock_picking_activity_report/tests/test_stock_picking_activity_report.py
@@ -1,8 +1,17 @@
 # Copyright (C) 2025 Terrabit
 # License OPL-1 (https://www.odoo.com/documentation/user/legal/licenses.html#odoo-apps).
+import base64
+import io
 from datetime import date
 
+from PIL import Image
+
 from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.deltatech_stock_picking_activity_report.models.stock_picking import (
+    MAX_LOG_LENGTH,
+    MAX_VALUE_LENGTH,
+)
 
 
 @tagged("post_install", "-at_install")
@@ -84,6 +93,12 @@ class TestStockPickingActivityReport(TransactionCase):
             }
         )
 
+    def _binary_payload(self):
+        """Conținut binar valid pentru un câmp de tip imagine (semnătura)."""
+        buffer = io.BytesIO()
+        Image.new("RGB", (400, 400), "#123456").save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue())
+
     def _records(self, picking):
         return self.Record.search([("picking_id", "=", picking.id), ("user_id", "=", self.stock_user.id)])
 
@@ -119,6 +134,61 @@ class TestStockPickingActivityReport(TransactionCase):
             len([line for line in log.splitlines() if line.strip()]),
             2,
         )
+
+    def test_binary_field_is_not_logged(self):
+        """Câmpurile binare (semnătură, etichetă AWB) nu ajung în jurnal.
+
+        Serializarea lor scria în ``activity_log`` conținutul base64 al
+        fișierului — sute de kB per scriere, ajunși în baza clientului.
+        """
+        picking = self._new_picking().with_user(self.stock_user)
+        payload = self._binary_payload()
+
+        picking.write({"signature": payload})
+
+        # Semnarea postează un mesaj în chatter ("Order signed"), deci o
+        # înregistrare tot apare — dar fără urmă din conținutul binar.
+        log = self._records(picking).activity_log or ""
+        self.assertNotIn(payload.decode()[:50], log)
+        self.assertLess(len(log), 1000)
+
+    def test_binary_field_skipped_but_others_logged(self):
+        """Un binar scris împreună cu alte câmpuri nu contaminează jurnalul."""
+        picking = self._new_picking().with_user(self.stock_user)
+        payload = self._binary_payload()
+
+        picking.write({"origin": "SRC-BIN", "signature": payload})
+
+        records = self._records(picking)
+        self.assertEqual(len(records), 1)
+        self.assertIn("SRC-BIN", records.activity_log)
+        self.assertNotIn(payload.decode()[:50], records.activity_log)
+        self.assertLess(len(records.activity_log), 1000)
+
+    def test_long_value_is_truncated(self):
+        """Valorile text lungi sunt scurtate, cu marcarea restului tăiat."""
+        picking = self._new_picking().with_user(self.stock_user)
+
+        picking.write({"origin": "A" * 5000})
+
+        log = self._records(picking).activity_log
+        self.assertIn("A" * MAX_VALUE_LENGTH, log)
+        self.assertNotIn("A" * (MAX_VALUE_LENGTH + 1), log)
+        self.assertIn("chars)", log)
+
+    def test_activity_log_is_capped(self):
+        """Jurnalul unei zile nu depășește plafonul, păstrând activitatea recentă."""
+        picking = self._new_picking().with_user(self.stock_user)
+        picking.write({"origin": "FIRST"})
+
+        record = self._records(picking)
+        record.sudo().activity_log = "old line\n" * (MAX_LOG_LENGTH // 9)
+
+        picking.write({"origin": "LAST"})
+
+        log = self._records(picking).activity_log
+        self.assertLessEqual(len(log), MAX_LOG_LENGTH)
+        self.assertIn("LAST", log)
 
     def test_action_confirm_logs_button(self):
         picking = self._new_picking().with_user(self.stock_user)


### PR DESCRIPTION
## Problema

`format_val()` din `write()` se termina cu `return str(val)` pentru orice tip de câmp. Pentru un câmp binar asta însemna conținutul base64 al fișierului scris în `activity_log` — eticheta AWB (`label_attachment`) și semnătura ajungeau integral în jurnal.

Măsurat pe instanța PTC (2 luni de activitate, restul șters de regula `data_recycle`):

| linie de jurnal | nr. | volum | medie |
|---|---|---|---|
| `Updated: Referință urmărire…` | 12.442 | **1.535 MB** | 129 kB |
| `Updated: Etichetă…` | 1.563 | 123 MB | 83 kB |
| tot restul (butoane, mesaje, stări) | ~230.000 | ~38 MB | ~60 B |

Liniile de „Referință urmărire" erau uriașe pentru că AWB-ul și eticheta se scriu în același `write()`, deci PDF-ul base64 ajungea concatenat în aceeași linie. **97,8% din cele 1694 MB ale tabelului era conținut base64**, cu vârf de 1,7 MB per înregistrare.

## Soluția

- câmpurile `binary` sunt sărite **înainte** de `picking[field_name]` — altfel valoarea veche se citea degeaba din filestore la fiecare scriere, deci e și un câștig de performanță pe write;
- valorile jurnalizate trunchiate la 200 de caractere, cu marcarea numărului de caractere tăiate;
- mesajele din chatter trunchiate la 2000 de caractere;
- jurnalul unei zile plafonat la 64 kB, păstrând activitatea recentă.

Comportamentul util al modulului rămâne neschimbat: ce câmp s-a schimbat, când și de către cine.

## Teste

4 teste noi — binar scris singur, binar împreună cu alte câmpuri, trunchierea valorilor lungi, plafonul jurnalului. Toate cele 13 teste ale modulului trec local.

Un detaliu apărut la testare: scrierea semnăturii tot produce o înregistrare, fiindcă Odoo postează „Order signed" în chatter. Corect, și fără urmă de base64 — testul verifică exact asta.

## Curățarea datelor existente

Fix-ul oprește creșterea, dar nu curăță retroactiv. Scriptul de curățare (în repo-ul de lucru, `scripts/truncate_picking_activity_log.sql`) înlocuiește blobul base64 cu primele 60 de caractere plus un marcaj. Rulat pe copia bazei PTC: `UPDATE 11723` în 29 s, jurnal **1694 MB → 38 MB**. După el e nevoie de `VACUUM FULL ANALYZE stock_picking_activity_record` (sau `pg_repack`) ca spațiul să fie efectiv eliberat.

## De urmărit separat

`deltatech_sale_activity_report` are exact același `return str(val)`. Impactul e mult mai mic (`sale.order` are doar `signature`), dar fix-ul e identic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)