### PR TITLE
[FIX] deltatech_sale_activity_report: nu mai jurnaliza conținutul câmpurilor binare

### DIFF
--- a/deltatech_sale_activity_report/__manifest__.py
+++ b/deltatech_sale_activity_report/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Sale Order Last Modified",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "author": "Terrabit, Voicu Stefan",
     "website": "https://www.terrabit.ro",
     "category": "Sales",

--- a/deltatech_sale_activity_report/models/sale_order.py
+++ b/deltatech_sale_activity_report/models/sale_order.py
@@ -7,6 +7,26 @@ from odoo import models
 
 _logger = logging.getLogger(__name__)
 
+# Tipurile de câmp care nu au ce căuta în jurnal: valoarea lor serializată e
+# conținutul brut al fișierului (eticheta AWB, semnătura), adică sute de kB de
+# base64 per scriere.
+SKIPPED_FIELD_TYPES = ("binary",)
+# Plafoane de siguranță: o valoare de câmp, un mesaj și jurnalul unei zile nu
+# pot depăși aceste dimensiuni, oricât de mare ar fi conținutul scris.
+MAX_VALUE_LENGTH = 200
+# Câmpurile x2many (liniile comenzii) sunt descrise linie cu linie, deci au
+# nevoie de un plafon mai larg — altfel s-ar pierde tocmai informația utilă.
+MAX_RELATION_LENGTH = 2000
+MAX_MESSAGE_LENGTH = 2000
+MAX_LOG_LENGTH = 65536
+
+
+def truncate(value, limit):
+    """Scurtează ``value`` la ``limit`` caractere, marcând cât s-a tăiat."""
+    if len(value) <= limit:
+        return value
+    return f"{value[:limit]}… (+{len(value) - limit} chars)"
+
 
 class SaleOrder(models.Model):
     _inherit = "sale.order"
@@ -16,7 +36,7 @@ class SaleOrder(models.Model):
             if self.env.user.has_group("base.group_user") and self.env.user.login != "__system__":
                 today = datetime.now().date()
                 now = datetime.now().strftime("%H:%M:%S")
-                full_log_msg = f"{now} - {log_msg}\n"
+                full_log_msg = f"{now} - {truncate(log_msg, MAX_MESSAGE_LENGTH)}\n"
                 for order in self:
                     # search with sudo to ensure we find records even if current user has limited access
                     order_id = order.id
@@ -57,6 +77,10 @@ class SaleOrder(models.Model):
                         self.env["sale.order.activity.record"].sudo().create(vals)
                     else:
                         new_log = (existing_record.activity_log or "") + full_log_msg
+                        if len(new_log) > MAX_LOG_LENGTH:
+                            # Păstrăm coada (activitatea recentă) și tăiem de la
+                            # prima linie completă, ca jurnalul să rămână lizibil.
+                            new_log = new_log[-MAX_LOG_LENGTH:].split("\n", 1)[-1]
                         vals["activity_log"] = new_log
                         if self.env.context.get("generated_awb", False):
                             vals["awb_generated"] = True
@@ -81,6 +105,11 @@ class SaleOrder(models.Model):
                     for field_name, new_val in vals.items():
                         field_label = fields_info.get(field_name, {}).get("string", field_name)
                         field_type = fields_info.get(field_name, {}).get("type")
+                        if field_type in SKIPPED_FIELD_TYPES:
+                            # Ieșim înainte de a citi valoarea veche: pentru un câmp
+                            # binar, `order[field_name]` ar încărca degeaba din
+                            # filestore un conținut pe care oricum nu-l jurnalizăm.
+                            continue
                         old_val = order[field_name]
 
                         if field_name == "stage" and new_val == "pre_advice":
@@ -191,8 +220,9 @@ class SaleOrder(models.Model):
                         if field_name == "shipment_info":
                             changes.append("Shipment Info updated")
                         else:
-                            old_val_str = format_val(old_val, field_type, field_name)
-                            new_val_str = format_val(new_val, field_type, field_name)
+                            limit = MAX_RELATION_LENGTH if field_type in ("one2many", "many2many") else MAX_VALUE_LENGTH
+                            old_val_str = truncate(format_val(old_val, field_type, field_name), limit)
+                            new_val_str = truncate(format_val(new_val, field_type, field_name), limit)
 
                             if old_val_str != new_val_str:
                                 changes.append(f"{field_label}: {old_val_str} -> {new_val_str}")

--- a/deltatech_sale_activity_report/readme/HISTORY.md
+++ b/deltatech_sale_activity_report/readme/HISTORY.md
@@ -1,0 +1,19 @@
+## 19.0.1.1.0 (2026-08-15)
+
+**Fix** — jurnalul de activitate nu mai stochează conținutul câmpurilor binare.
+
+Modificarea unui câmp binar al comenzii (eticheta AWB, semnătura) scria în
+`activity_log` întregul conținut base64 al fișierului. Aceeași problemă a
+umflat cu 1,7 GB baza unui client prin modulul echivalent pentru transferuri;
+aici măsura este preventivă — la scara actuală jurnalul comenzilor rămâne mic,
+dar `sale.order` are aceleași câmpuri binare.
+
+Acum:
+
+- câmpurile binare sunt ignorate complet la jurnalizare — nici nu mai sunt
+  citite din filestore, deci scrierea pe comandă este și mai rapidă;
+- valorile de câmp jurnalizate sunt scurtate la 200 de caractere (2000 pentru
+  câmpurile x2many, descrise linie cu linie), cu marcarea numărului de
+  caractere tăiate;
+- mesajele din chatter sunt scurtate la 2000 de caractere;
+- jurnalul unei zile este plafonat la 64 kB, păstrând activitatea recentă.

--- a/deltatech_sale_activity_report/tests/test_sale_activity_report.py
+++ b/deltatech_sale_activity_report/tests/test_sale_activity_report.py
@@ -1,8 +1,17 @@
 # Copyright (C) 2025 Terrabit
 # License OPL-1 (https://www.odoo.com/documentation/user/legal/licenses.html#odoo-apps).
+import base64
+import io
 from datetime import date
 
+from PIL import Image
+
 from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.deltatech_sale_activity_report.models.sale_order import (
+    MAX_LOG_LENGTH,
+    MAX_VALUE_LENGTH,
+)
 
 
 @tagged("post_install", "-at_install")
@@ -69,6 +78,61 @@ class TestSaleActivityReport(TransactionCase):
     def _records(self, order=None):
         order = order or self.order
         return self.Record.search([("sale_order_id", "=", order.id), ("user_id", "=", self.salesman.id)])
+
+    def _binary_payload(self):
+        """Conținut binar valid pentru un câmp de tip imagine (semnătura)."""
+        buffer = io.BytesIO()
+        Image.new("RGB", (400, 400), "#123456").save(buffer, format="PNG")
+        return base64.b64encode(buffer.getvalue())
+
+    def test_binary_field_is_not_logged(self):
+        """Câmpurile binare (semnătură, etichetă AWB) nu ajung în jurnal.
+
+        Serializarea lor scria în ``activity_log`` conținutul base64 al
+        fișierului — sute de kB per scriere, ajunși în baza clientului.
+        """
+        payload = self._binary_payload()
+
+        self.order.with_user(self.salesman).write({"signature": payload})
+
+        log = self._records().activity_log or ""
+        self.assertNotIn(payload.decode()[:50], log)
+        self.assertLess(len(log), 1000)
+
+    def test_binary_field_skipped_but_others_logged(self):
+        """Un binar scris împreună cu alte câmpuri nu contaminează jurnalul."""
+        payload = self._binary_payload()
+
+        self.order.with_user(self.salesman).write({"client_order_ref": "PO-BIN", "signature": payload})
+
+        records = self._records()
+        self.assertEqual(len(records), 1)
+        self.assertIn("PO-BIN", records.activity_log)
+        self.assertNotIn(payload.decode()[:50], records.activity_log)
+        self.assertLess(len(records.activity_log), 1000)
+
+    def test_long_value_is_truncated(self):
+        """Valorile text lungi sunt scurtate, cu marcarea restului tăiat."""
+        self.order.with_user(self.salesman).write({"client_order_ref": "A" * 5000})
+
+        log = self._records().activity_log
+        self.assertIn("A" * MAX_VALUE_LENGTH, log)
+        self.assertNotIn("A" * (MAX_VALUE_LENGTH + 1), log)
+        self.assertIn("chars)", log)
+
+    def test_activity_log_is_capped(self):
+        """Jurnalul unei zile nu depășește plafonul, păstrând activitatea recentă."""
+        order = self.order.with_user(self.salesman)
+        order.write({"client_order_ref": "FIRST"})
+
+        record = self._records()
+        record.sudo().activity_log = "old line\n" * (MAX_LOG_LENGTH // 9)
+
+        order.write({"client_order_ref": "LAST"})
+
+        log = self._records().activity_log
+        self.assertLessEqual(len(log), MAX_LOG_LENGTH)
+        self.assertIn("LAST", log)
 
     def test_create_does_not_log(self):
         """Creating an order must not create an activity record on its own."""


### PR DESCRIPTION
Aceeași cauză ca în #2816, aplicată pe modulul echivalent pentru comenzi.

## Problema

`format_val()` din `write()` se termina cu `return str(val)` pentru orice tip de câmp. Scrierea unui câmp binar punea în `activity_log` conținutul base64 al fișierului. Pe `sale.order` există `label_attachment`, `signature` și `tax_totals` — toate binare.

Pe transferuri acest defect a produs 1,7 GB de jurnal în două luni. Pe comenzi impactul e deocamdată mic — pe instanța PTC jurnalul comenzilor are 15 MB, cu doar 5 înregistrări contaminate cu base64, pentru că eticheta se scrie pe transfer, nu pe comandă. Fix-ul e deci preventiv, dar structura problemei e identică.

## Soluția

- câmpurile `binary` sunt sărite **înainte** de `order[field_name]`, ca valoarea veche să nu fie citită degeaba din filestore;
- valorile jurnalizate trunchiate la 200 de caractere, **2000 pentru x2many** — liniile comenzii sunt descrise linie cu linie și sunt tocmai informația utilă a modulului: pe PTC, 6.730 din 7.528 de linii de „Linii de comandă" depășesc 200 de caractere, dar doar 97 depășesc 2000;
- mesajele din chatter trunchiate la 2000 de caractere;
- jurnalul unei zile plafonat la 64 kB, păstrând activitatea recentă.

Tratamentul special existent pentru `shipment_info` („Shipment Info updated") rămâne neschimbat.

## Teste

4 teste noi, simetrice cu cele din #2816 — binar scris singur, binar împreună cu alte câmpuri, trunchierea valorilor lungi, plafonul jurnalului. Toate cele 12 teste ale modulului trec local (`0 failed, 0 error(s) of 12 tests`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)