### PR TITLE
[IMP] deltatech_image_optimize: warn that force_jpeg is destructive

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "images": ["static/description/main_screenshot.png"],
     "name": "Image Optimizer",
-    "version": "19.0.1.5.1",
+    "version": "19.0.1.6.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_config_parameter.xml
+++ b/deltatech_image_optimize/data/ir_config_parameter.xml
@@ -62,9 +62,17 @@
         <field name="value">85</field>
     </record>
 
-    <!-- Set to 1 when product images are never really transparent (solid
-         colored background). Alpha is then ignored and everything goes to
-         JPEG (max savings, no WebP dependency). -->
+    <!-- DESTRUCTIVE. Set to 1 only on a catalog you have VERIFIED has no real
+         transparency. Alpha is then ignored and everything goes to JPEG (max
+         savings, no WebP dependency) - but JPEG has no transparency, so any
+         transparent area is flattened to BLACK, and the original is gone: the
+         image is written through the record, so the old attachment no longer
+         exists. There is no undo.
+         "The originals are stored elsewhere" is not a verification - that
+         covers resolution, not alpha. On a real deployment 32% of a 40-image
+         sample had real transparency on a catalog believed to have none.
+         Probe with _dt_image_recompress (writes nothing) before enabling;
+         see readme/DESCRIPTION.md for the snippet. -->
     <record id="cp_force_jpeg" model="ir.config_parameter">
         <field name="key">deltatech_image_optimize.force_jpeg</field>
         <field name="value">0</field>

--- a/deltatech_image_optimize/readme/DESCRIPTION.md
+++ b/deltatech_image_optimize/readme/DESCRIPTION.md
@@ -8,7 +8,8 @@ For each targeted image the module:
 - downscales it to a maximum side of ``max_dim`` pixels (default 1920);
 - re-encodes photos without transparency as progressive **JPEG** at the
   configured quality (default 85);
-- keeps images with transparency as optimized **PNG** (alpha preserved);
+- keeps genuinely transparent images as **WebP** (alpha preserved), or as
+  optimized **PNG** when the Pillow build has no WebP encoder;
 - skips animated GIFs (never flattens the animation);
 - keeps the result only when it is actually smaller.
 
@@ -29,8 +30,45 @@ System Parameters (Settings → Technical → System Parameters):
 | ``deltatech_image_optimize.quality`` | 85 | JPEG quality (1..95) |
 | ``deltatech_image_optimize.max_dim`` | 1920 | max side in pixels |
 | ``deltatech_image_optimize.min_size`` | 102400 | only images larger than this (bytes) |
-| ``deltatech_image_optimize.batch`` | 1000 | images per cron run |
-| ``deltatech_image_optimize.target_fields`` | image_1920,image_variant_1920 | fields to optimize |
+| ``deltatech_image_optimize.batch`` | 50 | images per cron run |
+| ``deltatech_image_optimize.flush_every`` | 20 | flush/invalidate the ORM cache every N images |
+| ``deltatech_image_optimize.target_fields`` | image_1920,image_variant_1920 | original fields to optimize |
+| ``deltatech_image_optimize.webp_quality`` | 85 | WebP quality for transparent images |
+| ``deltatech_image_optimize.force_jpeg`` | 0 | ignore alpha, always JPEG — **destructive, see below** |
+| ``deltatech_image_optimize.variant_fields`` | image_1024,image_512,image_256,image_128 | resized variants to recompress in place |
+| ``deltatech_image_optimize.variant_quality`` | 85 | quality for re-encoding the variants |
+| ``deltatech_image_optimize.variant_min_size`` | 20480 | only recompress variants larger than this (bytes) |
+
+### ⚠ ``force_jpeg`` is destructive — probe before enabling it
+
+``force_jpeg=1`` makes the optimizer ignore the alpha channel entirely. JPEG has
+no transparency, so every transparent area is **flattened to black**, and the
+original is gone: the optimized image is written through the record, so the
+previous attachment no longer exists. There is no undo — the images have to be
+re-imported from wherever they came from.
+
+Enable it only on a catalog you have *verified* has no real transparency. "The
+originals are stored elsewhere" is not that verification: it covers resolution,
+not the alpha channel. A catalog that looks like solid white product shots can
+still be a third transparent PNGs — this is what happened on a real deployment,
+where 32% of a 40-image sample turned out to have real alpha.
+
+Probe it first, without writing anything (``_dt_image_recompress`` is a pure
+function — it returns the bytes and the chosen format, and touches nothing):
+
+```python
+A = env["ir.attachment"].sudo()
+counts = {}
+for att in A.search([("res_field", "in", ["image_1920", "image_variant_1920"]),
+                     ("mimetype", "=", "image/png"), ("file_size", ">", 51200)], limit=40):
+    _data, fmt = A._dt_image_recompress(att.raw, 78, 1280, 85, False)
+    counts[fmt] = counts.get(fmt, 0) + 1
+print(counts)  # any WEBP/PNG result = images that force_jpeg would destroy
+```
+
+Every ``WEBP`` or ``PNG`` in that count is an image with real transparency. If
+there is even one, leave ``force_jpeg`` at ``0`` — the module already sends
+opaque images to JPEG on its own, so you lose almost nothing by keeping it off.
 
 ## Scheduled action
 

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,25 @@
 # Changelog
 
+## 19.0.1.6.0 (2026)
+
+- Document that `force_jpeg` is **destructive**, in both places where it is read:
+  `readme/DESCRIPTION.md` and the comment above the parameter in
+  `data/ir_config_parameter.xml`. It flattens transparency to black and the
+  original cannot be recovered, because the optimized image is written through
+  the record and the previous attachment is gone.
+- Add a probe snippet that measures how much of a catalog has real transparency
+  *before* the parameter is enabled, using `_dt_image_recompress` (a pure
+  function — it returns bytes and format, writes nothing).
+- The rationale is a real deployment: `force_jpeg=1` was enabled on a catalog
+  believed to have no transparency, and 32% of a 40-image sample turned out to
+  have real alpha. The first 20 optimized images were destroyed before it was
+  caught.
+- Bring the configuration table in `DESCRIPTION.md` up to date: it was missing
+  `flush_every`, `force_jpeg`, `webp_quality` and the three `variant_*` keys, and
+  still advertised the old `batch` default of 1000. Also state that transparent
+  images go to WebP, with PNG as the fallback when the Pillow build has no WebP
+  encoder.
+
 ## 19.0.1.5.1 (2026)
 
 - Migration to Odoo 19.0. No functional change: the module only relies on


### PR DESCRIPTION
`force_jpeg=1` makes the optimizer ignore the alpha channel. JPEG has no
transparency, so every transparent area is flattened to **black** — and the
original is gone, because the optimized image is written through the record and
the previous attachment no longer exists. There is no undo.

The module documented the option, but not that it is destructive.

## Why now

On a real deployment (PTC) the parameter was enabled on a catalog believed to
have solid-background images only. It destroyed the first 20 optimized images
before it was caught. Measured afterwards on a 40-image sample of original PNGs:
**13 (32%) had real transparency**. Across the 11 952 image-field PNGs above
50 KB in that database, a full run would have destroyed on the order of 4 000
images.

The reasoning that led there was "the originals are stored elsewhere, so we can
be aggressive" — which covers *resolution*, not the alpha channel. The docs now
name that mistake explicitly, because it is the plausible one.

## Changes

- `readme/DESCRIPTION.md`: a dedicated warning section, plus a probe snippet that
  measures how much of a catalog has real transparency **before** enabling the
  parameter. The probe uses `_dt_image_recompress`, which is a pure function —
  it returns the bytes and the chosen format and writes nothing.
- `data/ir_config_parameter.xml`: the same warning in the comment above the
  parameter, for whoever changes it directly in System Parameters.
- `readme/DESCRIPTION.md` config table brought up to date: it was missing
  `flush_every`, `force_jpeg`, `webp_quality` and the three `variant_*` keys, and
  still advertised the old `batch` default of 1000. It also still claimed
  transparent images are kept as PNG, from before WebP support was added.
- Version `19.0.1.5.1` → `19.0.1.6.0`.

Documentation only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)