### PR TITLE
[FIX] deltatech_image_optimize: register Pillow's WebP plugin

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "images": ["static/description/main_screenshot.png"],
     "name": "Image Optimizer",
-    "version": "19.0.1.5.1",
+    "version": "19.0.1.7.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -9,21 +9,68 @@ _logger = logging.getLogger(__name__)
 
 try:
     from PIL import Image
-
-    # features.check("webp") can report True while the encoder still fails at
-    # save time on some builds, so probe with a real encode.
-    try:
-        _probe = io.BytesIO()
-        Image.new("RGBA", (1, 1)).save(_probe, format="WEBP")
-        WEBP_OK = True
-    except Exception:  # noqa: BLE001
-        WEBP_OK = False
 except ImportError:  # pragma: no cover
     Image = None
-    WEBP_OK = False
 
 DEFAULT_TARGET_FIELDS = "image_1920,image_variant_1920"
 DEFAULT_VARIANT_FIELDS = "image_1024,image_512,image_256,image_128"
+
+# Resolved on first use by _webp_available(), never at import time: see below.
+_WEBP_OK = None
+
+
+def _ensure_pillow_webp():
+    """Register Pillow's WebP plugin, which Odoo leaves out.
+
+    ``odoo/tools/image.py`` runs ``Image.preinit()`` and then sets
+    ``Image._initialized = 2``. preinit registers only BMP/GIF/JPEG/PPM/PNG, and
+    the flag tells Pillow that ``init()`` already ran, so ``save()`` never loads
+    the remaining plugins: ``save(format="WEBP")`` raises ``KeyError: 'WEBP'``
+    even on a Pillow built with libwebp (``features.check("webp")`` is True).
+
+    Importing the plugin registers the format directly, which is what actually
+    fixes it -- ``Image.init()`` alone returns early on ``_initialized >= 2``.
+    Same approach as ``deltatech_website_watermark``.
+    """
+    if Image is None:  # pragma: no cover
+        return
+    try:
+        from PIL import WebPImagePlugin as _webp_plugin  # noqa: F401
+    except Exception as exc:  # noqa: BLE001
+        _logger.warning("Pillow WebP plugin import failed (WEBP unavailable): %s", exc)
+    try:
+        Image.preinit()
+        Image.init()
+    except Exception as exc:  # noqa: BLE001 - init is best effort
+        _logger.debug("Pillow Image.init() raised: %s", exc)
+
+
+def _webp_available():
+    """Whether this process can encode WebP, resolved lazily and cached.
+
+    Deliberately not a module-level constant. The answer depends on whether the
+    WebP plugin is registered, which in turn depends on module import order --
+    so a constant computed at import time made the module behave differently
+    from one database to another (WebP where a module registering the plugin
+    happened to be imported first, PNG everywhere else), silently.
+
+    ``features.check("webp")`` is not enough on its own: it can report True
+    while ``save()`` still fails, so probe with a real encode.
+    """
+    global _WEBP_OK
+    if _WEBP_OK is None:
+        _ensure_pillow_webp()
+        try:
+            probe = io.BytesIO()
+            Image.new("RGBA", (1, 1)).save(probe, format="WEBP")
+            _WEBP_OK = True
+        except Exception as exc:  # noqa: BLE001
+            _WEBP_OK = False
+            _logger.info(
+                "WebP encoding unavailable (%s); transparent images keep optimized PNG.",
+                exc,
+            )
+    return _WEBP_OK
 
 
 class IrAttachment(models.Model):
@@ -113,7 +160,7 @@ class IrAttachment(models.Model):
         if real_alpha:
             # Preserve transparency: WebP if available, otherwise optimized PNG
             # (never JPEG, which would fill transparent areas).
-            if WEBP_OK:
+            if _webp_available():
                 try:
                     buf = io.BytesIO()
                     img.convert("RGBA").save(buf, format="WEBP", quality=webp_quality, method=6)

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 19.0.1.7.0 (2026)
+
+- **Transparent images now really become WebP.** They were silently falling back
+  to optimized PNG on most databases. `odoo/tools/image.py` runs
+  `Image.preinit()` and then sets `Image._initialized = 2`; preinit registers
+  only BMP/GIF/JPEG/PPM/PNG, and the flag makes Pillow believe `init()` already
+  ran, so `save(format="WEBP")` raises `KeyError: 'WEBP'` even where Pillow is
+  built with libwebp and `features.check("webp")` returns True. The module now
+  imports `PIL.WebPImagePlugin` explicitly, which registers the format —
+  `Image.init()` alone does not help, it returns early on `_initialized >= 2`.
+  Same approach already used by `deltatech_website_watermark`.
+- `WEBP_OK` (a constant computed at import time) is replaced by
+  `_webp_available()`, resolved on first use and cached. The old constant made
+  the module behave **differently from one database to another**: where another
+  module registering the WebP plugin happened to be imported first, transparent
+  images became WebP; everywhere else the identical code produced PNG, with no
+  error anywhere. Import order is not something a result should depend on.
+- The test suite asks the module for WebP support instead of probing at import,
+  so `test_transparent_image_becomes_webp` actually runs. It had been skipping
+  itself with "Pillow build lacks WebP support" — on builds that encode WebP
+  fine.
+
+Impact: on catalogs with real transparency, those images now compress as WebP
+(typically ~70% smaller than the PNG fallback) instead of staying nearly
+uncompressed. No change for opaque images.
+
 ## 19.0.1.5.1 (2026)
 
 - Migration to Odoo 19.0. No functional change: the module only relies on

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -7,12 +7,13 @@ from odoo.tests import TransactionCase, tagged
 try:
     from PIL import Image
 
-    try:
-        _probe = io.BytesIO()
-        Image.new("RGBA", (1, 1)).save(_probe, format="WEBP")
-        WEBP_OK = True
-    except Exception:
-        WEBP_OK = False
+    # Ask the module itself instead of probing here: it registers Pillow's WebP
+    # plugin first, which Odoo's preinit() leaves out. Probing directly at
+    # import time reports "no WebP" on a Pillow that encodes WebP perfectly
+    # well, and the test then skips itself for a reason that is not true.
+    from odoo.addons.deltatech_image_optimize.models.ir_attachment import _webp_available
+
+    WEBP_OK = _webp_available()
 except ImportError:
     Image = None
     WEBP_OK = False


### PR DESCRIPTION
Transparent images were silently falling back to optimized PNG on most
databases, instead of becoming WebP.

## Cause

`odoo/tools/image.py` does:

```python
Image.preinit()
Image._initialized = 2
```

`preinit()` registers only BMP/GIF/JPEG/PPM/PNG. Setting `_initialized = 2`
tells Pillow that `init()` already ran, so `save()` never loads the remaining
plugins, and `save(format="WEBP")` raises **`KeyError: 'WEBP'`** — even where
Pillow is built with libwebp and `features.check("webp")` returns `True`. It is
deliberate on Odoo's side (smaller decoder surface), and it applies to every
Odoo process.

Reproduced in three steps:

| step | result |
| --- | --- |
| plain Pillow | `save(format="WEBP")` works |
| after `import odoo.tools.image` | `KeyError: 'WEBP'` |
| after `from PIL import WebPImagePlugin` | works again |

Importing the plugin is what fixes it. `Image.init()` on its own does not — it
returns early on `_initialized >= 2`. This is the same approach
`deltatech_website_watermark` already uses (`_ensure_pillow_webp`).

## The worse half: the result depended on module import order

`WEBP_OK` was a module-level constant, probed once at import. So the module
produced **different output on different databases**: where another module
registering the WebP plugin happened to be imported first, transparent images
became WebP; everywhere else identical code produced PNG. Nothing failed, and
nothing was logged.

That is exactly what happened here: on the database where
`deltatech_website_watermark` is installed the path worked; on the one where it
is not (PTC), it did not.

It is now `_webp_available()`, resolved on first use and cached, after ensuring
registration.

## Testing

`test_transparent_image_becomes_webp` had been skipping itself with "Pillow
build lacks WebP support" — on builds that encode WebP fine, because the test
probed at import too. It now asks the module, and **actually runs**:

```
6 post-tests in 22.44s
0 failed, 0 error(s) of 6 tests
```

(The suite goes from ~3.5s to ~22s because WebP encoding at `method=6` on the
2000×2000 noise images the test builds is genuinely slow. Worth noting that
`deltatech_website_watermark` encodes at `method=4`; tuning that is a separate
question from this fix.)

## Impact

On catalogs with real transparency, those images now compress as WebP —
typically ~70% smaller than the PNG fallback — instead of staying nearly
uncompressed. On PTC that is roughly 4 000 images. No change for opaque images.

Note: version bumped to `19.0.1.7.0`, assuming #2819 (documentation) merges
first. If it merges after, that one needs a rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)