### PR TITLE
imp: index stock.inventory.line.partner_id

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "19.0.2.7.2",
+    "version": "19.0.2.7.3",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/models/stock_inventory.py
+++ b/deltatech_stock_inventory/models/stock_inventory.py
@@ -447,7 +447,9 @@ class InventoryLine(models.Model):
     )
     inventory_id = fields.Many2one("stock.inventory", "Inventory", check_company=True, index=True, ondelete="cascade")
 
-    partner_id = fields.Many2one("res.partner", "Owner", check_company=True)
+    # index=True: coloană FK spre res_partner pe tabela de linii de inventar, care crește cu
+    # fiecare inventariere. Fără index, ștergerea/unificarea unui partener o scanează integral.
+    partner_id = fields.Many2one("res.partner", "Owner", check_company=True, index=True)
     product_id = fields.Many2one(
         "product.product",
         "Product",

--- a/deltatech_stock_inventory/readme/HISTORY.md
+++ b/deltatech_stock_inventory/readme/HISTORY.md
@@ -1,3 +1,8 @@
+## 19.0.2.7.3 (2026-08-15)
+
+- Imp: `stock.inventory.line.partner_id` is now indexed — a foreign key to `res_partner` on a table that grows with every stock count.
+  Context: `res_partner` is referenced by ~158 foreign-key columns; on a production database 77 of them had no index, so a single partner deletion triggered sequential scans over 3.180 MB of tables. Deleting 5.350 merged partner records took over 8 minutes without indexes and 190 seconds with them, foreign keys left ENABLED.
+
 ## 19.0.2.7.2 (2026-08-05)
 
 - **Inventory Note** is again carried over to the generated stock move, so the


### PR DESCRIPTION
## De ce

`res_partner` este referit de ~158 de coloane cu cheie străină. Pe o bază de producție, **77 dintre
ele nu aveau index**, așa că ștergerea unui singur partener declanșa scanări secvențiale peste
**3.180 MB** de tabele. Efectul se vede zilnic: un operator care șterge sau arhivează un contact
duplicat din interfață așteaptă peste o secundă pentru fiecare fișă.

## Măsurători

Pe o copie de producție cu 537.199 de parteneri, ștergerea a 100 de parteneri orfani:

| | Timp | Per partener |
|---|---|---|
| Cu indexurile din acest PR | **6,9 s** | 68 ms |
| Fără ele (restul indexurilor rămân) | **116,8 s** | 1,17 s |

**De 17 ori mai rapid, pentru 23 MB de spațiu de index.**

Coloanele din acest PR explică singure ~94% din timpul de ștergere, chiar și după ce toate coloanele
standard Odoo sunt indexate — pentru că stau pe `stock_picking` și `account_move`, cele mai mari
tabele din bază.

La scară: unificarea a 5.350 de fișe de parteneri duplicați a durat peste 8 minute fără indexuri
(întreruptă fără să termine) și 190 de secunde cu ele, cu cheile străine rămase **active** — deci
fără `session_replication_role = replica`, care ar cere superuser (indisponibil pe odoo.sh) și ar
muta răspunderea integrității de pe bază pe autorul scriptului.

## Ce conține

`index=True` pe coloanele FK spre `res_partner` de pe tabelele care cresc, plus bump de versiune și
intrare în `readme/HISTORY.md` pentru fiecare modul atins.

Efect secundar util: indexurile nu mai trebuie create manual pe fiecare bază.

## Note

- Coloanele grele din Odoo standard (`account_move_line.partner_id` — 1.405 MB,
  `account_move.partner_shipping_id`, `account_analytic_line.partner_id`) nu sunt atinse aici;
  pentru ele indexurile se creează la nivel de bază.
- Modificarea e strict aditivă: doar atributul `index=True`, fără schimbări de comportament.

Context: tichet #9248 (curățenia nomenclatorului de parteneri).
