### PR TITLE
[IMP] ci: sparge testele pe shard-uri paralele, pe familii funcționale

### DIFF
--- a/.github/scripts/plan_tests.py
+++ b/.github/scripts/plan_tests.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Decide which addons the test job has to install and test.
+"""Decide WHICH addons get tested and on HOW MANY parallel jobs.
 
 Rules:
 
@@ -7,11 +7,20 @@ Rules:
   transitive reverse dependents (a change in `deltatech` can break anything
   that depends on it). A change in a repo-root or dotdir file falls back to a
   full run.
-* workflow_dispatch, or no usable base commit -> the whole repo.
+* workflow_dispatch without input, or no usable base commit -> the whole repo.
+* workflow_dispatch with `modules` -> exactly that list (no reverse expansion:
+  a manual run is targeted by definition).
+
+The selection is then split into shards by functional family. The split is not
+only about parallelism: each family drags in its own Odoo core stack, so a
+`website` shard installs website+sale but not mrp or pos. Roughly half of a
+full run is spent installing modules, so keeping the stacks apart is what
+actually shortens the job.
 
 Writes to $GITHUB_OUTPUT:
-    addons     comma-separated list for INCLUDE ("" = whole repo)
+    run_tests  true/false (false = nothing to test, the test job is skipped)
     full       true/false (true = whole repo; only then do we upload coverage)
+    matrix     JSON for `strategy.matrix`
 
 This runs in a plain `ubuntu-latest` job, NOT inside the OCA container: git
 calls from inside the container could not resolve the base commit, so the old
@@ -19,9 +28,16 @@ inline version silently fell back to a full run on every single build.
 """
 
 import ast
+import json
 import os
 import subprocess
 import sys
+
+# Maximum addons per shard. Bigger families are cut into `name-1`, `name-2`, ...
+# Do not lower this lightly: every shard pays the full fixed cost (container
+# boot, addon install, test db init) of roughly 2.5 minutes, so many small
+# shards buy wall-clock time with a lot of runner minutes.
+MAX_PER_SHARD = 30
 
 # Root files that can affect every addon: filtering makes no sense for them.
 INFRA_PREFIXES = (
@@ -73,6 +89,49 @@ def reverse_dependents(manifests, seeds):
     return selected
 
 
+def group_of(name):
+    """Functional family of an addon. New addons are placed automatically by prefix.
+
+    Order matters: `deltatech_website_sale_*` is a website addon, not a sale one,
+    so the website prefix has to be tested first.
+    """
+    # Prefixes are written WITHOUT a trailing underscore so that the bare addon
+    # (`deltatech_mrp`, `deltatech_account`) lands in its own family too.
+    families = (
+        ("website", ("deltatech_website",)),
+        ("pos", ("deltatech_pos",)),
+        ("mrp", ("deltatech_mrp",)),
+        ("account", ("deltatech_account", "deltatech_invoice", "deltatech_ledger")),
+        ("purchase", ("deltatech_purchase", "deltatech_fast_purchase")),
+        ("sale", ("deltatech_sale", "deltatech_saleorder", "deltatech_fast_sale")),
+        ("stock", ("deltatech_stock", "deltatech_picking", "deltatech_warehouse", "deltatech_product")),
+    )
+    for family, prefixes in families:
+        if name.startswith(prefixes):
+            return family
+    return "misc"
+
+
+def build_matrix(modules):
+    """Split the addons into shards: group by family, then cut at MAX_PER_SHARD."""
+    groups = {}
+    for name in sorted(modules):
+        groups.setdefault(group_of(name), []).append(name)
+
+    shards = []
+    # Stable order, so job names do not dance from one run to the next.
+    for group in sorted(groups):
+        members = groups[group]
+        # BALANCED cut, not greedy fill: 31 addons give 16+15, not 30+1. A shard
+        # with a single addon pays the whole fixed cost for almost no work.
+        count = -(-len(members) // MAX_PER_SHARD)  # ceil
+        chunks = [members[index::count] for index in range(count)]
+        for index, chunk in enumerate(chunks, start=1):
+            shard_name = group if len(chunks) == 1 else f"{group}-{index}"
+            shards.append({"name": shard_name, "modules": ",".join(chunk)})
+    return shards
+
+
 def usable(sha):
     if not sha or set(sha) == {"0"}:
         return False
@@ -103,10 +162,11 @@ def changed_addons(manifests, base_sha, head_sha):
     return touched
 
 
-def emit(addons, full):
+def emit(run_tests, full, shards):
     lines = [
-        f"addons={','.join(sorted(addons))}",
+        f"run_tests={'true' if run_tests else 'false'}",
         f"full={'true' if full else 'false'}",
+        f"matrix={json.dumps({'include': shards})}",
     ]
     for line in lines:
         print(line)
@@ -116,50 +176,59 @@ def emit(addons, full):
             handle.write("\n".join(lines) + "\n")
 
 
-def main():
-    manifests = load_manifests()
+def select(manifests):
+    """Return (selected_addons, full) for the current event."""
     event = os.environ.get("EVENT_NAME", "")
+    requested = os.environ.get("INPUT_MODULES", "").strip()
     base_sha = os.environ.get("BASE_SHA", "")
     head_sha = os.environ.get("HEAD_SHA", "") or "HEAD"
 
+    if requested:
+        # Targeted manual run: exactly what was asked for, no reverse expansion.
+        selection = {name.strip() for name in requested.split(",") if name.strip()}
+        unknown = selection - set(manifests)
+        if unknown:
+            print(f"::error::Addons not found in this repo: {', '.join(sorted(unknown))}")
+            sys.exit(1)
+        return selection, False
+
     if event not in ("pull_request", "push"):
         print(f"Event {event!r} -> full run.")
-        emit([], True)
-        return 0
+        return set(manifests), True
     if not usable(base_sha):
         print(f"Base commit {base_sha!r} not available -> full run.")
-        emit([], True)
-        return 0
+        return set(manifests), True
 
     touched = changed_addons(manifests, base_sha, head_sha)
     if touched is None:
-        emit([], True)
-        return 0
+        return set(manifests), True
 
     selection = reverse_dependents(manifests, touched)
     print(f"Touched addons: {', '.join(sorted(touched)) or '(none)'}")
     extra = selection - touched
     if extra:
         print(f"Reverse dependents added: {', '.join(sorted(extra))}")
-
-    if not selection:
-        # Only non-addon content (docs, images inside no addon) changed. An
-        # empty INCLUDE means "everything" for the OCA tooling, so pick a
-        # single cheap addon instead of accidentally running the whole repo.
-        print("No addon affected -> testing `deltatech` alone as a smoke check.")
-        if "deltatech" in manifests:
-            emit(["deltatech"], False)
-        else:
-            emit([], True)
-        return 0
-
     if len(selection) == len(manifests):
         print("Every addon is affected -> full run.")
-        emit([], True)
+        return selection, True
+    return selection, False
+
+
+def main():
+    manifests = load_manifests()
+    selection, full = select(manifests)
+
+    shards = build_matrix(selection)
+    if not shards:
+        # Only non-addon content changed (docs, images outside any addon).
+        print("No addon affected, nothing to test.")
+        emit(False, full, [])
         return 0
 
-    print(f"{len(selection)} addons selected out of {len(manifests)}.")
-    emit(selection, False)
+    print(f"{len(selection)} addons in {len(shards)} shards:")
+    for shard in shards:
+        print(f"  {shard['name']}: {len(shard['modules'].split(','))} addons")
+    emit(True, full, shards)
     return 0
 
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: tests
 
 on:
   workflow_dispatch:
+    inputs:
+      modules:
+        description: "Addons to test (comma separated). Empty = all."
+        required: false
+        default: ""
   pull_request:
     branches:
       - "19.0*"
@@ -34,16 +39,17 @@ jobs:
                   fi
               fi
           done
-  # Decide WHICH addons get tested. This runs outside the OCA container on
-  # purpose: git calls from inside it could not resolve the base commit, so the
-  # previous inline version fell back to a full run on every single build.
-  # See .github/scripts/plan_tests.py.
+  # Decide WHICH addons get tested and on how many parallel shards. This runs
+  # outside the OCA container on purpose: git calls from inside it could not
+  # resolve the base commit, so the previous inline version fell back to a full
+  # run on every single build. See .github/scripts/plan_tests.py.
   plan:
     runs-on: ubuntu-latest
-    name: Plan test selection
+    name: Plan test shards
     outputs:
-      addons: ${{ steps.plan.outputs.addons }}
+      run_tests: ${{ steps.plan.outputs.run_tests }}
       full: ${{ steps.plan.outputs.full }}
+      matrix: ${{ steps.plan.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,6 +59,7 @@ jobs:
         run: python3 .github/scripts/plan_tests.py
         env:
           EVENT_NAME: ${{ github.event_name }}
+          INPUT_MODULES: ${{ github.event.inputs.modules }}
           BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || github.event.before }}
           # HEAD is the checked-out ref: the PR merge commit, or the pushed
           # commit. Using the merge commit also covers PRs from forks, whose
@@ -61,15 +68,14 @@ jobs:
 
   test:
     needs: plan
+    # A PR touching only non-addon content has nothing to install.
+    if: ${{ needs.plan.outputs.run_tests == 'true' }}
     runs-on: ubuntu-22.04
-    container: ${{ matrix.container }}
-    name: ${{ matrix.name }}
+    container: ghcr.io/oca/oca-ci/py3.10-odoo19.0:latest
+    name: test (${{ matrix.name }})
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - container: ghcr.io/oca/oca-ci/py3.10-odoo19.0:latest
-            name: test with Odoo
+      matrix: ${{ fromJSON(needs.plan.outputs.matrix) }}
 
     services:
       postgres:
@@ -105,11 +111,11 @@ jobs:
 
       - name: Initialize test db
         env:
-          INCLUDE: ${{ needs.plan.outputs.addons }}
+          INCLUDE: ${{ matrix.modules }}
         run: oca_init_test_database
       - name: Run tests
         env:
-          INCLUDE: ${{ needs.plan.outputs.addons }}
+          INCLUDE: ${{ matrix.modules }}
         run: oca_run_tests
 
       # Coverage goes up only on a full run. On a filtered run the report would
@@ -119,6 +125,9 @@ jobs:
         uses: codecov/codecov-action@v6  # <-- New action to upload coverage file
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          # One flag per shard: each shard covers a different slice of the repo,
+          # so without this the uploads would overwrite each other.
+          flags: ${{ matrix.name }}
           # The action will automatically search for common coverage files (e.g., coverage.xml)
 
       - name: Upload test results to Codecov (Pass/Fail)
@@ -126,6 +135,26 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          flags: ${{ matrix.name }}
+
+  # Shard names are dynamic ("test (website)"), so they cannot be used as a
+  # required status check in branch protection. This job has a stable name and
+  # collects the result of the whole matrix — put THIS one in branch protection.
+  tests-passed:
+    needs: [plan, test]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    name: tests passed
+    steps:
+      - name: Check matrix result
+        run: |
+          # `skipped` is a legitimate result: a PR touching no addon has
+          # nothing to test. Only failure and cancellation must fail the gate.
+          echo "plan=${{ needs.plan.result }} test=${{ needs.test.result }}"
+          case "${{ needs.plan.result }}/${{ needs.test.result }}" in
+            success/success|success/skipped) exit 0 ;;
+            *) echo "Tests did not pass."; exit 1 ;;
+          esac
 
 
 #      - name: Update .pot files

--- a/deltatech_kit_price/__manifest__.py
+++ b/deltatech_kit_price/__manifest__.py
@@ -4,11 +4,14 @@
 {
     "name": "Deltatech Kit Price",
     "summary": "Compute product cost price in sale order line based on kit",
-    "version": "19.0.0.0.1",
+    "version": "19.0.0.0.2",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "category": "Manufacturing/Manufacturing",
-    "depends": ["sale_margin", "mrp"],
+    # `mrp_account` furnizează `product.product._compute_bom_price`, folosit în
+    # `_compute_purchase_price`. E `auto_install`, deci se instala din întâmplare
+    # când era în bază și alt modul care îl cere explicit.
+    "depends": ["sale_margin", "mrp", "mrp_account"],
     "license": "OPL-1",
     "data": [],
     "application": False,

--- a/deltatech_kit_price/readme/HISTORY.md
+++ b/deltatech_kit_price/readme/HISTORY.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## 19.0.0.0.2 (2026-08-15)
+
+- Fix: added the missing `mrp_account` dependency. `_compute_purchase_price()`
+  calls `product.product._compute_bom_price()`, which is defined in
+  `mrp_account`. Since `mrp_account` is `auto_install` and Odoo 19 test
+  databases are built with `--skip-auto-install`, the module only worked when
+  another addon in the same database required `mrp_account` explicitly
+  (`deltatech_mrp_cost` did). Installed on its own, both tests failed with
+  `AttributeError: 'product.product' object has no attribute
+  '_compute_bom_price'`.


### PR DESCRIPTION
Se stivuiește peste #2821 (base = `19.0-ci-path-filter`). GitHub re-țintește automat pe `19.0` după ce #2821 se merge-uiește.

## Ce face

Rularea completă (push pe `19.0`, sau PR care atinge infrastructura) instala toate cele 189 de module într-o singură bază: ~4 min instalare + ~4,5 min teste, într-un singur job.

`plan_tests.py` emite acum o matrice de shard-uri, împărțite pe **familii funcționale**, nu doar pe număr: fiecare familie își trage propriul stack Odoo, deci shard-ul `website` instalează website+sale dar nu mrp și nu pos. Jumătate din durata rulării complete e instalare, deci separarea stack-urilor e cea care scurtează efectiv jobul.

Pe tot repo-ul: **10 shard-uri**.

| shard | module |
|---|---|
| sale | 30 |
| stock | 30 |
| website | 26 |
| misc-1/2/3 | 23 fiecare |
| account | 13 |
| purchase | 10 |
| mrp | 8 |
| pos | 3 |

Familiile mai mari de `MAX_PER_SHARD` (30) se taie **echilibrat** (31 module dau 16+15, nu 30+1) — un shard cu un singur modul plătește tot costul fix pentru aproape nimic.

Pe PR selecția rămâne filtrată de #2821, deci de regulă **un singur shard**; sharding-ul schimbă doar rularea completă.

## În plus

- input `modules` la `workflow_dispatch` pentru rulare manuală țintită:
  `gh workflow run tests --ref 19.0 -f modules=mod_a,mod_b`
- job `tests passed` cu nume stabil, care strânge rezultatul matricei — numele shard-urilor sunt dinamice („test (website)") și nu pot fi puse ca required status check. Protecția ramurii `19.0` nu are momentan niciun check obligatoriu configurat (`contexts: []`); ăsta e cel de pus dacă se adaugă vreodată.
- `flags` per shard la Codecov, altfel încărcările shard-urilor se suprascriu între ele.

## Compromisul de cost

Câștigul e pe **wall-clock**, nu pe minute de runner: rularea completă trece de la ~11 min într-un job la ~5–6 min pe cel mai lung shard, dar consumă de câteva ori mai multe minute de runner (10 containere, fiecare cu costul fix de ~2,5 min: boot container + install + init db). Dacă asta contează, butonul e `MAX_PER_SHARD` din script — mai mare = mai puține shard-uri.

## ⚠️ La review

Sharding-ul **demască `depends` incomplete** — module care treceau doar pentru că toată suita se instala într-o singură bază. La `l10n_ro_ent` au fost 4 fixuri de acest tip (PR terrabit-solutions/l10n_ro_ent#91). Dacă un shard pică pe o dependență lipsă, dependența se declară în manifest; nu se cârpește gruparea din CI.

CI-ul acestui PR e chiar testul: atinge `.github/`, deci face rulare completă pe toate cele 10 shard-uri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)