### PR TITLE
[FIX] dependențe nedeclarate în manifeste (tc, test_system, dc, sale_pallet)

### DIFF
--- a/deltatech_dc/__manifest__.py
+++ b/deltatech_dc/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Declaration of Conformity",
     "summary": "Print Declaration of Conformity",
-    "version": "19.0.1.0.11",
+    "version": "19.0.1.0.12",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",
@@ -16,6 +16,9 @@
         "sale",
         "mrp",
         "product_expiry",
+        # `account.move._get_invoiced_lot_values()`, apelat în report/report_dc.py,
+        # e definit în `stock_account` (extins apoi de `sale_stock`).
+        "stock_account",
         # "stock_picking_invoice_link"
     ],
     "data": [

--- a/deltatech_dc/readme/HISTORY.md
+++ b/deltatech_dc/readme/HISTORY.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 19.0.1.0.12 (2026-08-15)
+
+- Fix: added the missing `stock_account` dependency. `report/report_dc.py`
+  calls `account.move._get_invoiced_lot_values()`, which is defined in
+  `stock_account` (and extended by `sale_stock`). The module only worked when
+  another addon in the same database pulled `stock_account` in.

--- a/deltatech_sale_pallet/__manifest__.py
+++ b/deltatech_sale_pallet/__manifest__.py
@@ -4,11 +4,12 @@
 {
     "name": "Sale Pallet",
     "summary": "Sale pallet",
-    "version": "19.0.1.0.8",
+    "version": "19.0.1.0.9",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
-    "depends": ["sale_margin", "account"],
+    # `stock` e folosit de teste (`stock.quant._update_available_quantity`).
+    "depends": ["sale_margin", "account", "stock"],
     "license": "OPL-1",
     "data": ["views/product_view.xml", "views/invoice_view.xml"],
     "images": ["static/description/main_screenshot.png"],

--- a/deltatech_sale_pallet/readme/HISTORY.md
+++ b/deltatech_sale_pallet/readme/HISTORY.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 19.0.1.0.9 (2026-08-15)
+
+- Fix: added the missing `stock` dependency. The tests call
+  `stock.quant._update_available_quantity()`, which passed only because other
+  addons installed alongside brought `stock` into the database.

--- a/deltatech_tc/__manifest__.py
+++ b/deltatech_tc/__manifest__.py
@@ -4,11 +4,12 @@
 {
     "name": "Terrabit Connect - Base",
     "summary": "Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the customer's local network.",
-    "version": "19.0.1.1.0",
+    "version": "19.0.1.1.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Technical",
-    "depends": ["base"],
+    # `bus.bus._sendone()` (notificări către manageri) e definit în `bus`.
+    "depends": ["base", "bus"],
     "license": "OPL-1",
     "data": [
         "security/deltatech_tc_security.xml",

--- a/deltatech_tc/readme/HISTORY.md
+++ b/deltatech_tc/readme/HISTORY.md
@@ -1,3 +1,9 @@
+## 19.0.1.1.1 (2026-08-15)
+
+- Fix: added the missing `bus` dependency. The manual heartbeat notification
+  uses `self.env["bus.bus"]._sendone()`, which is defined in `bus`. The module
+  only worked when another addon in the same database brought `bus` in.
+
 ## 19.0.1.1.0 (2026-08-11)
 
 - **New job type `http_request`** — the station performs an HTTP call inside the customer's local

--- a/deltatech_test_system/__manifest__.py
+++ b/deltatech_test_system/__manifest__.py
@@ -6,11 +6,12 @@
 {
     "name": "Deltatech Test System",
     "summary": "Set system status: test or production",
-    "version": "19.0.0.0.8",
+    "version": "19.0.0.0.9",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Tools",
-    "depends": ["web"],
+    # Vizualizarea moștenește `base_setup.res_config_settings_view_form`.
+    "depends": ["web", "base_setup"],
     "license": "OPL-1",
     "data": [
         "views/templates.xml",

--- a/deltatech_test_system/readme/HISTORY.md
+++ b/deltatech_test_system/readme/HISTORY.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 19.0.0.0.9 (2026-08-15)
+
+- Fix: added the missing `base_setup` dependency. The settings view inherits
+  `base_setup.res_config_settings_view_form`, so installing the module on a
+  database without `base_setup` failed with `External ID not found`.


### PR DESCRIPTION
Urmare a auditului static făcut după #2823: fiecare dintre cele 189 de module a fost comparat cu închiderea tranzitivă a propriului `depends`, pe trei axe — modele folosite (`self.env["x"]`, `_inherit`), xmlid-uri referite din XML, și metode apelate care sunt definite **doar** în module absente din depends.

Aceeași familie cu `deltatech_kit_price` (dc3293a91): dependențe reale, mascate de faptul că se instala tot repo-ul într-o singură bază, unde un modul vecin le aducea. Instalat singur, fiecare dintre modulele de mai jos crapă.

| modul | adăugat | dovada |
|---|---|---|
| `deltatech_tc` | `bus` | `models/deltatech_tc_station.py:128` — `self.env["bus.bus"]._sendone(...)` la heartbeat manual |
| `deltatech_test_system` | `base_setup` | `views/res_config_settings_view.xml:7` — `inherit_id ref="base_setup.res_config_settings_view_form"`; fără el, instalarea cade cu `External ID not found` |
| `deltatech_dc` | `stock_account` | `report/report_dc.py:74` — `account.move._get_invoiced_lot_values()`, definit în `stock_account`, extins de `sale_stock` |
| `deltatech_sale_pallet` | `stock` | `tests/test_sale.py:40` — `stock.quant._update_available_quantity()` (doar teste) |

Fiecare modul are bump de versiune și intrare în `readme/HISTORY.md`.

## Ce NU am modificat

`deltatech_sale_pallet` apelează `_onchange_product_id_warning`, care în Odoo 19 e adus doar de `deltatech_sale_margin` — dar apelul e **protejat cu `hasattr`** și are comentariu explicit în cod. E o dependență opțională intenționată, nu un bug.

## Limitele auditului

Static: nu prinde referințe dinamice la modele, dependențe la nivel de *câmp* (doar model/metodă/xmlid), asseturi JS, grupuri de securitate sau fișiere de date. Iar CI-ul, chiar cu shard-uri, verifică doar module care au teste. Zgomotul a fost triat manual — `_read_group` e metodă de ORM, nu de addon, iar `deltatech_queue_job` și `deltatech_account_edi_ubl_advice` depind de module OCA/externe care nu erau în indexul de scanare, deci ieșeau cu închidere trunchiată.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
