### PR TITLE
[FIX] ci: un grup de concurrency propriu pentru fiecare push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,15 @@ on:
 
 # A new push on a PR cancels the previous run: no point keeping a runner busy
 # with an outdated version of the branch.
+#
+# Only pull requests share a group. Everything else gets a group of its own
+# (`run_id` is unique per run), because GitHub keeps a SINGLE queued run per
+# group: with every push to 19.0 in the same group, merging two PRs in a row
+# cancelled the queued run of the first one. Coverage was not lost — the last
+# run covers the final state — but there was no green run per merge commit,
+# which is exactly what you need when bisecting.
 concurrency:
-  group: tests-${{ github.ref }}
+  group: tests-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 


### PR DESCRIPTION
Efect secundar constatat după merge-urile #2821 → #2824: rularea de pe `19.0` declanșată de merge-ul #2823 apare `cancelled` (run 31875222285).

Cauza: `concurrency.group` era `tests-${{ github.ref }}`, deci **toate** push-urile pe `19.0` cădeau în același grup. Chiar cu `cancel-in-progress: false` pentru push, GitHub ține o singură rulare *în așteptare* per grup — la două merge-uri consecutive, rularea în coadă a primului e anulată de al doilea.

Acoperirea nu se pierdea (ultima rulare acoperă starea finală a ramurii), dar nu rămâne o **rulare verde per commit de merge**, adică exact ce-ți trebuie la bisect.

Fixul: doar pull request-urile mai împart un grup — acolo anularea e dorită, un push nou peste PR face rularea precedentă inutilă. Restul primesc grup propriu prin `github.run_id`, unic per rulare.

```yaml
group: tests-${{ github.event_name == 'pull_request' && github.ref || github.run_id }}
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

PR-ul atinge `.github/`, deci CI-ul lui face rulare completă pe toate cele 10 shard-uri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
