### PR TITLE
[FIX] deltatech_queue_job: joburile anulate în lanț rămâneau pe veci în tabel

### DIFF
--- a/deltatech_queue_job/__manifest__.py
+++ b/deltatech_queue_job/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech  Queue Job Enhancements",
     "summary": "Deltatech Queue Job",
     "author": "Terrabit, Dorin Hongu",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.4.0",
     "license": "AGPL-3",
     "website": "https://www.terrabit.ro",
     "category": "Others",

--- a/deltatech_queue_job/models/__init__.py
+++ b/deltatech_queue_job/models/__init__.py
@@ -2,5 +2,6 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+from . import job_patch
 from . import queue_job
 from . import res_config_settings

--- a/deltatech_queue_job/models/job_patch.py
+++ b/deltatech_queue_job/models/job_patch.py
@@ -1,0 +1,56 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+"""Completarea datei de anulare pentru joburile anulate în lanț.
+
+``Job.cancel_dependent_jobs()`` anulează dependenții printr-un UPDATE SQL brut
+care scrie doar coloana ``state``, nu și ``date_cancelled``. Cronul
+``queue.job.autovacuum()`` selectează însă joburile de șters exact după
+``date_done`` sau ``date_cancelled``, așa că un job anulat pe această cale nu
+este eliminat niciodată, oricât ar trece.
+
+Pe o instanță de producție se adunaseră astfel 189.644 de joburi anulate fără
+dată — 53% din tabel — toate ``marketplace_write`` anulate în lanț la
+sincronizarea cu marketplace-urile.
+
+``cancel_dependent_jobs`` aparține clasei ``Job``, care nu e un model ORM și nu
+poate fi extinsă prin ``_inherit``; de aceea o completăm aici prin înlocuirea
+metodei. Interogarea nu poate fi corectată la sursă pentru că e generată de
+``_get_common_dependent_jobs_query()``, folosită și de ``enqueue_waiting()``,
+unde o dată de anulare ar fi greșită.
+"""
+
+import logging
+
+from odoo.tools import SQL
+
+from odoo.addons.queue_job.job import CANCELLED, Job
+
+_logger = logging.getLogger(__name__)
+
+_cancel_dependent_jobs_original = Job.cancel_dependent_jobs
+
+
+def cancel_dependent_jobs(self):
+    """Anulează dependenții, apoi le pune data de anulare lipsă."""
+    _cancel_dependent_jobs_original(self)
+    if not self.graph_uuid:
+        return
+    self.env.cr.execute(
+        SQL(
+            "UPDATE queue_job SET date_cancelled = now() "
+            "WHERE graph_uuid = %s AND state = %s AND date_cancelled IS NULL",
+            self.graph_uuid,
+            CANCELLED,
+        )
+    )
+    if self.env.cr.rowcount:
+        _logger.debug(
+            "Stamped date_cancelled on %d dependent job(s) of graph %s",
+            self.env.cr.rowcount,
+            self.graph_uuid,
+        )
+        self.env["queue.job"].invalidate_model(["date_cancelled"])
+
+
+Job.cancel_dependent_jobs = cancel_dependent_jobs

--- a/deltatech_queue_job/models/queue_job.py
+++ b/deltatech_queue_job/models/queue_job.py
@@ -7,12 +7,45 @@ import time
 from datetime import datetime, timedelta
 
 from odoo import api, fields, models, modules
+from odoo.tools import config
 
 _logger = logging.getLogger(__name__)
 
 
 class QueueJob(models.Model):
     _inherit = "queue.job"
+
+    def autovacuum(self):
+        """Șterge și joburile terminale rămase fără dată de finalizare.
+
+        Cronul standard selectează după ``date_done`` sau ``date_cancelled``,
+        deci joburile anulate în lanț de ``cancel_dependent_jobs()`` — care le
+        scria doar starea — nu erau eliminate niciodată. `job_patch` completează
+        data de acum înainte; aici curățăm ce s-a adunat înainte de el, folosind
+        ``date_created``, singurul câmp completat mereu.
+        """
+        res = super().autovacuum()
+        for channel in self.env["queue.job.channel"].search([]):  # pylint: disable=no-search-all
+            deadline = datetime.now() - timedelta(days=int(channel.removal_interval))
+            while True:
+                jobs = self.search(
+                    [
+                        ("state", "in", ("done", "cancelled")),
+                        ("date_done", "=", False),
+                        ("date_cancelled", "=", False),
+                        ("date_created", "<=", deadline),
+                        ("channel", "=", channel.complete_name),
+                    ],
+                    order="date_created",
+                    limit=1000,
+                )
+                if not jobs:
+                    break
+                _logger.info("Removing %d terminal job(s) left without a completion date", len(jobs))
+                jobs.sudo().unlink()
+                if not config["test_enable"]:
+                    self.env.cr.commit()  # pylint: disable=E8102
+        return res
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/deltatech_queue_job/readme/HISTORY.md
+++ b/deltatech_queue_job/readme/HISTORY.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 19.0.1.4.0
+
+- Fix: jobs cancelled through the dependency chain are now removed by the
+  autovacuum cron. `Job.cancel_dependent_jobs()` cancels them with a raw SQL
+  `UPDATE queue_job SET state = ...` that writes nothing else, while
+  `queue.job.autovacuum()` selects what to delete by `date_done` or
+  `date_cancelled` — so a job cancelled that way was never collected, however
+  long it sat there. A production instance had 189.644 such jobs, 53% of the
+  table and all of them `marketplace_write` cancelled in chains during
+  marketplace sync. `models/job_patch.py` stamps `date_cancelled` right after
+  the chain cancellation (the query itself cannot be fixed at the source: it is
+  shared with `enqueue_waiting()`, where a cancellation date would be wrong).
+- Imp: `autovacuum()` also removes terminal jobs left with no completion date at
+  all, keyed on `date_created` and on the same per-channel `removal_interval`.
+  This collects what piled up before the fix; jobs in `failed` state are never
+  touched, they are the only ones worth keeping for diagnosis.
+
 ## 19.0.1.3.0
 
 - Fix: `_cron_trigger` debounce actually works now. It used to compare against

--- a/deltatech_queue_job/tests/__init__.py
+++ b/deltatech_queue_job/tests/__init__.py
@@ -2,4 +2,5 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 from . import test_cron_trigger_debounce
+from . import test_date_cancelled
 from . import test_identity_key_dedup, test_queue_job

--- a/deltatech_queue_job/tests/test_date_cancelled.py
+++ b/deltatech_queue_job/tests/test_date_cancelled.py
@@ -1,0 +1,91 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+import uuid as uuid_lib
+from datetime import datetime, timedelta
+
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.queue_job.job import Job
+
+
+@tagged("post_install", "-at_install")
+class TestDateCancelled(TransactionCase):
+    """Joburile anulate în lanț trebuie să poată fi curățate de autovacuum.
+
+    ``Job.cancel_dependent_jobs()`` scrie doar starea, printr-un UPDATE brut, iar
+    cronul de autovacuum selectează după ``date_done``/``date_cancelled``: fără
+    dată, joburile rămâneau în tabel pentru totdeauna (189.644 pe o instanță de
+    producție).
+    """
+
+    def _create_job(self, state="cancelled", graph_uuid=None, channel="root"):
+        return self.env["queue.job"].create(
+            {
+                "uuid": str(uuid_lib.uuid4()),
+                "name": "Test Job",
+                "model_name": "queue.job",
+                "method_name": "search",
+                "state": state,
+                "graph_uuid": graph_uuid,
+                "channel": channel,
+            }
+        )
+
+    def _clear_dates(self, jobs):
+        """Reproduce ce lăsa în urmă UPDATE-ul brut din cancel_dependent_jobs."""
+        self.env.cr.execute(
+            "UPDATE queue_job SET date_cancelled = NULL, date_done = NULL WHERE id IN %s",
+            (tuple(jobs.ids),),
+        )
+        jobs.invalidate_recordset(["date_cancelled", "date_done"])
+
+    def test_patch_stamps_date_cancelled(self):
+        """După anularea dependenților, joburile anulate din graf au dată."""
+        graph = str(uuid_lib.uuid4())
+        parent = self._create_job(graph_uuid=graph)
+        child = self._create_job(graph_uuid=graph)
+        self._clear_dates(parent | child)
+        self.assertFalse(child.date_cancelled)
+
+        Job.load(self.env, parent.uuid).cancel_dependent_jobs()
+
+        child.invalidate_recordset(["date_cancelled"])
+        self.assertTrue(child.date_cancelled, "Anularea în lanț trebuie să lase o dată de anulare.")
+
+    def test_patch_ignores_jobs_outside_the_graph(self):
+        """Joburile din alt graf nu sunt atinse."""
+        graph = str(uuid_lib.uuid4())
+        parent = self._create_job(graph_uuid=graph)
+        strain = self._create_job(graph_uuid=str(uuid_lib.uuid4()))
+        self._clear_dates(parent | strain)
+
+        Job.load(self.env, parent.uuid).cancel_dependent_jobs()
+
+        strain.invalidate_recordset(["date_cancelled"])
+        self.assertFalse(strain.date_cancelled)
+
+    def test_autovacuum_removes_dateless_terminal_jobs(self):
+        """Joburile terminale fără dată, dinainte de patch, sunt curățate."""
+        channel = self.env["queue.job.channel"].search([("complete_name", "=", "root")], limit=1)
+        old = self._create_job(channel="root")
+        self._clear_dates(old)
+        self.env.cr.execute(
+            "UPDATE queue_job SET date_created = %s WHERE id = %s",
+            (datetime.now() - timedelta(days=int(channel.removal_interval) + 1), old.id),
+        )
+        old_id = old.id
+
+        self.env["queue.job"].autovacuum()
+
+        self.assertFalse(self.env["queue.job"].browse(old_id).exists())
+
+    def test_autovacuum_keeps_recent_dateless_jobs(self):
+        """Un job terminal recent fără dată rămâne — poate fi încă util."""
+        recent = self._create_job(channel="root")
+        self._clear_dates(recent)
+        recent_id = recent.id
+
+        self.env["queue.job"].autovacuum()
+
+        self.assertTrue(self.env["queue.job"].browse(recent_id).exists())


### PR DESCRIPTION
## Problema

`Job.cancel_dependent_jobs()` din OCA `queue_job` anulează dependenții printr-un UPDATE SQL brut care scrie **doar** coloana `state`:

```python
def cancel_dependent_jobs(self):
    sql = self._get_common_dependent_jobs_query()
    self.env.cr.execute(sql, (CANCELLED, self.uuid, CANCELLED, WAIT_DEPENDENCIES))
```

Iar `queue.job.autovacuum()` alege ce șterge exact după datele de finalizare:

```python
[("date_done", "<=", deadline), "|", ("date_cancelled", "<=", deadline), ...]
```

Un job anulat pe această cale nu are nici `date_done`, nici `date_cancelled`, deci **nu este colectat niciodată**, oricât ar trece și indiferent de `removal_interval`-ul canalului.

Măsurat pe instanța PTC:

| | |
|---|---|
| joburi în tabel | 360.015 |
| anulate | 189.800 |
| **anulate fără `date_cancelled`** | **189.644 — 53% din tabel** |
| metoda lor | `marketplace_write` (189.475) |

Sunt joburi de sincronizare cu marketplace-urile, anulate în lanț când părintele lor eșuează sau e anulat.

## Soluția

`models/job_patch.py` completează `date_cancelled` imediat după anularea în lanț, restrâns la graful curent. Interogarea nu poate fi corectată la sursă: e generată de `_get_common_dependent_jobs_query()`, folosită și de `enqueue_waiting()`, unde o dată de anulare ar fi greșită. `cancel_dependent_jobs` aparține clasei `Job`, care nu e model ORM și nu poate fi extinsă prin `_inherit` — de aici înlocuirea metodei.

În plus, `autovacuum()` a fost extins să adune și ce s-a acumulat înainte de fix: joburi terminale fără nicio dată de finalizare, filtrate pe `date_created` și pe același `removal_interval` per canal. Joburile `failed` nu sunt atinse — sunt singurele cu valoare de diagnostic.

## Teste

Patru teste noi (22 în total pe modul, toate trec):

- `test_patch_stamps_date_cancelled` — anularea în lanț lasă o dată;
- `test_patch_ignores_jobs_outside_the_graph` — nu atinge alte grafuri;
- `test_autovacuum_removes_dateless_terminal_jobs` — vechiturile fără dată sunt curățate;
- `test_autovacuum_keeps_recent_dateless_jobs` — cele recente rămân.

## De verificat la deploy

Pe instanța verificată, cronurile `AutoVacuum Job Queue` și `Queue Job Runner` erau **inactive** (posibil doar efectul neutralizării copiei). Merită confirmat că pe producție sunt pornite — altfel nici joburile `done`, care au `date_done` corect, nu se curăță.

Curățarea retroactivă a celor deja acumulate se poate face și direct, cu `scripts/cleanup_operational_tables.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)