### PR TITLE
add: scripts for merging partners duplicated on the same VAT

### DIFF
--- a/scripts/partner_merge/01_fk_indexes.sql
+++ b/scripts/partner_merge/01_fk_indexes.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- 01 — Indexuri pe coloanele FK care referă res_partner
+-- =============================================================================
+-- De ce: res_partner e referit de ~158 de coloane FK, din care ~77 nu au index.
+-- La FIECARE rând șters din res_partner, PostgreSQL verifică fiecare constrângere;
+-- fără index verificarea e o scanare secvențială completă (măsurat: 3.180 MB
+-- scanate per rând). De aici impresia că ștergerea/unificarea „nu se mai termină"
+-- și tentația de a dezactiva FK-urile cu session_replication_role = replica.
+--
+-- Măsurat pe o bază de producție (5.624 fișe absorbite):
+--   fără indexuri : DELETE > 8 min, întrerupt fără să termine
+--   cu indexuri   : DELETE 178 s, cu FK ACTIVE
+--
+-- CONCURRENTLY => nu ia lock de scriere, se poate rula în timpul programului.
+-- NU poate rula într-o tranzacție, de aceea acest fișier e separat și NU are BEGIN.
+-- Dacă un index rămâne INVALID (întrerupere), vezi verificarea de la final.
+--
+-- Rulare:
+--   psql -d <bd> -f 01_fk_indexes.sql
+-- Idempotent: se poate relua oricând.
+-- =============================================================================
+\timing on
+\set ON_ERROR_STOP on
+
+\echo '== Coloane FK spre res_partner fără index (înainte) =='
+SELECT count(*) AS fara_index,
+       pg_size_pretty(sum(pg_relation_size(conrelid))) AS spatiu_scanat_per_stergere
+FROM (
+  SELECT c.conrelid, a.attnum
+  FROM pg_constraint c
+  JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+  WHERE c.contype = 'f' AND c.confrelid = 'res_partner'::regclass
+    AND c.conrelid::regclass::text <> 'res_partner'
+) fk
+WHERE NOT EXISTS (SELECT 1 FROM pg_index i WHERE i.indrelid = fk.conrelid AND fk.attnum = i.indkey[0]);
+
+\echo '== Creare indexuri lipsă (CONCURRENTLY) =='
+SELECT format(
+         'CREATE INDEX CONCURRENTLY IF NOT EXISTS %I ON %s (%I);',
+         left('ix_pfk_' || replace(tbl, '.', '_') || '_' || col, 63), tbl, col)
+FROM (
+  SELECT c.conrelid::regclass::text AS tbl, a.attname AS col, c.conrelid, a.attnum
+  FROM pg_constraint c
+  JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+  WHERE c.contype = 'f' AND c.confrelid = 'res_partner'::regclass
+    AND c.conrelid::regclass::text <> 'res_partner'
+) fk
+WHERE NOT EXISTS (SELECT 1 FROM pg_index i WHERE i.indrelid = fk.conrelid AND fk.attnum = i.indkey[0])
+ORDER BY pg_relation_size(conrelid) DESC
+\gexec
+
+\echo '== Indexuri INVALID (create parțial, de recreat) =='
+-- CREATE INDEX CONCURRENTLY întrerupt lasă un index invalid, care ocupă spațiu
+-- și NU e folosit. Dacă apar rânduri aici: DROP INDEX <nume>; apoi reia scriptul.
+SELECT c.relname AS index_invalid
+FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+WHERE NOT i.indisvalid AND c.relnamespace = 'public'::regnamespace;
+
+\echo '== Verificare finală =='
+SELECT count(*) AS coloane_fk_ramase_fara_index
+FROM (
+  SELECT c.conrelid, a.attnum
+  FROM pg_constraint c
+  JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+  WHERE c.contype = 'f' AND c.confrelid = 'res_partner'::regclass
+    AND c.conrelid::regclass::text <> 'res_partner'
+) fk
+WHERE NOT EXISTS (SELECT 1 FROM pg_index i WHERE i.indrelid = fk.conrelid AND fk.attnum = i.indkey[0]);

--- a/scripts/partner_merge/02_build_map.sql
+++ b/scripts/partner_merge/02_build_map.sql
@@ -1,0 +1,165 @@
+-- =============================================================================
+-- 02 — Construiește maparea de unificare (old_id -> master_id) + snapshot de control
+-- =============================================================================
+-- Nu modifică date de business. Creează doar tabelele de lucru:
+--   pm_group      — grupurile de duplicate pe CUI, cu categoria
+--   pm_map        — fișele de absorbit și masterul lor (lotul curent)
+--   pm_snapshot   — totalurile pe grup ÎNAINTE de unificare (pentru verificarea din 04)
+--
+-- Reguli de grupare: companii active, cu CUI normalizat (fără spații/punctuație),
+-- grupuri cu cel puțin 2 membri.
+--
+-- Master = fața cu cele mai multe facturi, apoi cele mai multe comenzi,
+--          apoi cea mai veche, apoi cel mai mic id (determinist).
+--
+-- Categorii:
+--   A  o singură față are documente, restul sunt complet goale
+--   B  documente doar pe o față (restul au cel mult date de contact)
+--   C  facturi pe mai multe fețe
+--   D  sold nereconciliat pe mai multe fețe
+-- Lotul automat = A + B. C și D se tratează separat, cu contabilitatea.
+--
+-- Rulare:
+--   psql -d <bd> -v categorii="'A','B'" -v limita_grupuri=200 -f 02_build_map.sql
+-- Parametri (opționali, cu valori implicite mai jos):
+--   categorii       — ce categorii intră în lot
+--   limita_grupuri  — câte grupuri în lotul curent (0 = toate)
+-- =============================================================================
+\timing on
+\set ON_ERROR_STOP on
+\if :{?categorii}      \else \set categorii "'A','B'" \endif
+\if :{?limita_grupuri} \else \set limita_grupuri 200  \endif
+
+BEGIN;
+
+-- 1) Fișele candidate, cu volumetria documentelor pe fiecare
+DROP TABLE IF EXISTS pm_face CASCADE;
+CREATE TABLE pm_face AS
+WITH norm AS (
+  SELECT id, name, create_date, company_registry,
+         upper(regexp_replace(vat, '[^0-9A-Za-z]', '', 'g')) AS vat_n
+  FROM res_partner
+  WHERE active AND is_company AND vat IS NOT NULL AND vat <> ''
+), grp AS (
+  SELECT vat_n FROM norm GROUP BY vat_n HAVING count(*) > 1
+)
+SELECT n.vat_n, n.id, n.name, n.create_date, n.company_registry,
+  (SELECT count(*) FROM account_move m  WHERE m.partner_id = n.id AND m.move_type <> 'entry')          AS facturi,
+  (SELECT count(*) FROM sale_order s    WHERE s.partner_id = n.id)                                      AS comenzi_v,
+  (SELECT count(*) FROM purchase_order o WHERE o.partner_id = n.id)                                     AS comenzi_a,
+  (SELECT count(*) FROM stock_picking k WHERE k.partner_id = n.id)                                      AS livrari,
+  (SELECT count(*) FROM res_partner c   WHERE c.parent_id = n.id)                                       AS copii,
+  (SELECT count(*) FROM sale_order s    WHERE s.partner_shipping_id = n.id OR s.partner_invoice_id = n.id) AS adresa_pe_comenzi,
+  (SELECT count(*) FROM res_users u     WHERE u.partner_id = n.id)                                      AS useri,
+  (SELECT count(*) FROM res_company k   WHERE k.partner_id = n.id)                                      AS e_companie_proprie,
+  COALESCE((SELECT round(sum(l.balance)::numeric, 2)
+            FROM account_move_line l
+            JOIN account_account a ON a.id = l.account_id
+            JOIN account_move mv   ON mv.id = l.move_id
+           WHERE l.partner_id = n.id AND mv.state = 'posted' AND a.reconcile AND NOT l.reconciled), 0) AS sold
+FROM norm n JOIN grp g ON g.vat_n = n.vat_n;
+CREATE INDEX ON pm_face(vat_n);
+CREATE UNIQUE INDEX ON pm_face(id);
+ANALYZE pm_face;
+
+-- 2) Clasificarea grupurilor + gărzile de excludere
+DROP TABLE IF EXISTS pm_group CASCADE;
+CREATE TABLE pm_group AS
+WITH g AS (
+  SELECT vat_n,
+         count(*) AS membri,
+         count(*) FILTER (WHERE facturi > 0)                                                    AS cu_facturi,
+         count(*) FILTER (WHERE facturi + comenzi_v + comenzi_a + livrari
+                              + copii + adresa_pe_comenzi + useri = 0)                          AS goi,
+         count(*) FILTER (WHERE sold <> 0)                                                      AS cu_sold,
+         count(*) FILTER (WHERE useri > 0)                                                      AS cu_useri,
+         sum(e_companie_proprie)                                                                AS companii_proprii,
+         -- denumiri divergente: prefixele numelor sunt toate distincte
+         count(DISTINCT lower(left(regexp_replace(name, '[^[:alnum:] ]', '', 'g'), 6))) AS prefixe_nume
+  FROM pm_face GROUP BY vat_n
+)
+SELECT vat_n, membri, cu_facturi, goi, cu_sold, cu_useri, companii_proprii, prefixe_nume,
+  CASE
+    WHEN goi = membri - 1 AND cu_facturi <= 1 THEN 'A'
+    WHEN cu_facturi <= 1                      THEN 'B'
+    WHEN cu_sold > 1                          THEN 'D'
+    ELSE                                           'C'
+  END AS categorie,
+  -- Motivul pentru care grupul NU intră în lotul automat (NULL = eligibil)
+  CASE
+    WHEN companii_proprii > 0 THEN 'contine compania proprie'
+    WHEN cu_useri > 1         THEN 'mai multe fete cu user portal'
+    WHEN prefixe_nume = membri THEN 'denumiri divergente - revizuire manuala'
+  END AS blocaj
+FROM g;
+CREATE UNIQUE INDEX ON pm_group(vat_n);
+ANALYZE pm_group;
+
+-- 3) Maparea lotului curent
+DROP TABLE IF EXISTS pm_map CASCADE;
+CREATE TABLE pm_map AS
+WITH eligibil AS (
+  SELECT vat_n FROM pm_group
+  WHERE categorie IN (:categorii) AND blocaj IS NULL
+  ORDER BY vat_n
+  LIMIT CASE WHEN :limita_grupuri > 0 THEN :limita_grupuri ELSE NULL END
+), master AS (
+  SELECT DISTINCT ON (f.vat_n) f.vat_n, f.id AS master_id
+  FROM pm_face f JOIN eligibil e ON e.vat_n = f.vat_n
+  ORDER BY f.vat_n, f.facturi DESC, f.comenzi_v DESC, f.create_date ASC, f.id ASC
+)
+SELECT f.vat_n, f.id AS old_id, m.master_id
+FROM pm_face f JOIN master m ON m.vat_n = f.vat_n
+WHERE f.id <> m.master_id;
+CREATE UNIQUE INDEX ON pm_map(old_id);
+CREATE INDEX ON pm_map(master_id);
+ANALYZE pm_map;
+
+-- Gardă: un master nu poate fi el însuși absorbit în alt grup (lanț de unificare)
+DO $$
+DECLARE n int;
+BEGIN
+  SELECT count(*) INTO n FROM pm_map m WHERE EXISTS (SELECT 1 FROM pm_map x WHERE x.old_id = m.master_id);
+  IF n > 0 THEN
+    RAISE EXCEPTION 'Lot inconsistent: % fișe au ca master un partener care e el însuși absorbit', n;
+  END IF;
+END$$;
+
+-- 4) Snapshot de control: totalurile pe grup ÎNAINTE de unificare.
+--    După merge, masterul trebuie să aibă exact aceste valori (nimic pierdut, nimic dublat).
+DROP TABLE IF EXISTS pm_snapshot CASCADE;
+CREATE TABLE pm_snapshot AS
+SELECT m.master_id,
+       count(*) + 1                          AS fise_in_grup,
+       sum(f.facturi)   + mf.facturi         AS facturi_asteptate,
+       sum(f.comenzi_v) + mf.comenzi_v       AS comenzi_v_asteptate,
+       sum(f.comenzi_a) + mf.comenzi_a       AS comenzi_a_asteptate,
+       sum(f.livrari)   + mf.livrari         AS livrari_asteptate,
+       round(sum(f.sold) + mf.sold, 2)       AS sold_asteptat
+FROM pm_map m
+JOIN pm_face f  ON f.id = m.old_id
+JOIN pm_face mf ON mf.id = m.master_id
+GROUP BY m.master_id, mf.facturi, mf.comenzi_v, mf.comenzi_a, mf.livrari, mf.sold;
+CREATE UNIQUE INDEX ON pm_snapshot(master_id);
+
+COMMIT;
+
+\echo ''
+\echo '== Clasificarea completă a grupurilor =='
+SELECT categorie, coalesce(blocaj, '(eligibil)') AS stare,
+       count(*) AS grupuri, sum(membri) - count(*) AS fise_de_absorbit
+FROM pm_group GROUP BY 1, 2 ORDER BY 1, 2;
+
+\echo ''
+\echo '== Lotul curent =='
+SELECT count(DISTINCT master_id) AS grupuri, count(*) AS fise_de_absorbit FROM pm_map;
+
+\echo ''
+\echo '== Eșantion (10 grupuri din lot) =='
+SELECT m.vat_n, m.master_id, f.name AS master, m.old_id, o.name AS absorbit,
+       o.facturi, o.comenzi_v, o.sold
+FROM pm_map m
+JOIN pm_face f ON f.id = m.master_id
+JOIN pm_face o ON o.id = m.old_id
+WHERE m.vat_n IN (SELECT DISTINCT vat_n FROM pm_map ORDER BY vat_n LIMIT 10)
+ORDER BY m.vat_n, m.old_id;

--- a/scripts/partner_merge/03_merge.sql
+++ b/scripts/partner_merge/03_merge.sql
@@ -1,0 +1,243 @@
+-- =============================================================================
+-- 03 — Execuția unificării pentru lotul din pm_map
+-- =============================================================================
+-- Principiu: NU dezactivăm cheile străine (fără session_replication_role, deci
+-- fără superuser — merge și pe odoo.sh). Inversăm buclele față de wizardul Odoo:
+-- un singur UPDATE per coloană pentru TOT lotul, în loc de un UPDATE per grup
+-- per coloană. Integritatea rămâne verificată de bază.
+--
+-- Ordinea contează:
+--   1. dedup coliziuni unique pe coloanele FK   (calculat pe valoarea ȚINTĂ)
+--   2. remap coloane FK + parent_id
+--   3. dedup coliziuni unique pe res_id          (RECALCULAT — pasul 2 a schimbat datele)
+--   4. remap legături polimorfe (res_model/res_id) + ir_model_data
+--   5. completare câmpuri goale pe master (opțional)
+--   6. ștergerea sau arhivarea fișelor absorbite
+--
+-- Dedup-ul colapsează pe valoarea ȚINTĂ, nu comparând fișa absorbită cu masterul:
+-- două fișe din același grup se pot ciocni ÎNTRE ELE după remap, fără ca masterul
+-- să fie implicat. Constrângerile unique rămân active și sub replica, deci acest
+-- pas e obligatoriu indiferent de abordare.
+--
+-- Rulare:
+--   psql -d <bd> -f 03_merge.sql                    -- SIMULARE: rulează tot, apoi ROLLBACK
+--   psql -d <bd> -v do_apply=1 -f 03_merge.sql      -- APLICĂ (COMMIT)
+--   psql -d <bd> -v do_apply=1 -v arhiveaza=1 -f 03_merge.sql
+-- Parametri:
+--   do_apply    0 = simulare cu rollback (implicit), 1 = commit
+--   arhiveaza   0 = șterge fișele absorbite (implicit), 1 = doar active=false
+--
+-- Necesită: 02_build_map.sql rulat (tabelele pm_map / pm_face).
+-- Recomandat: 01_fk_indexes.sql rulat înainte, altfel pasul 6 durează ore.
+-- =============================================================================
+\timing on
+\set ON_ERROR_STOP on
+\if :{?do_apply}  \else \set do_apply 0  \endif
+\if :{?arhiveaza} \else \set arhiveaza 0 \endif
+
+BEGIN;
+
+-- Funcție de dedup generică: pentru fiecare index UNIQUE care conține o coloană
+-- ce va fi remapată, colapsează rândurile care ar deveni identice după remap.
+-- p_mode = 'fk'   -> coloana remapată e o coloană FK spre res_partner
+-- p_mode = 'poly' -> coloana remapată e res_id (cu res_model = 'res.partner')
+CREATE OR REPLACE FUNCTION pg_temp.pm_dedupe_unique(p_mode text) RETURNS TABLE(tabela text, sterse bigint) AS $fn$
+DECLARE
+  r RECORD; key_expr text; n bigint; where_cl text;
+BEGIN
+  FOR r IN
+    SELECT c.relname AS tbl, i.indexrelid, i.indrelid AS indrelid_tbl,
+           (SELECT array_agg(att.attname ORDER BY k.ord)
+              FROM unnest(i.indkey::int[]) WITH ORDINALITY k(attnum, ord)
+              JOIN pg_attribute att ON att.attrelid = i.indrelid AND att.attnum = k.attnum) AS cols,
+           tgt.col AS remap_col
+    FROM pg_index i
+    JOIN pg_class c ON c.oid = i.indrelid AND c.relkind = 'r' AND c.relnamespace = 'public'::regnamespace
+    JOIN LATERAL (
+      SELECT a.attname AS col
+      FROM pg_attribute a
+      WHERE a.attrelid = i.indrelid AND a.attnum > 0 AND NOT a.attisdropped
+        AND (
+          (p_mode = 'fk' AND EXISTS (
+             SELECT 1 FROM pg_constraint fc
+             JOIN pg_attribute fa ON fa.attrelid = fc.conrelid AND fa.attnum = ANY(fc.conkey)
+             WHERE fc.contype = 'f' AND fc.confrelid = 'res_partner'::regclass
+               AND fc.conrelid = i.indrelid AND fa.attname = a.attname))
+          OR
+          (p_mode = 'poly' AND a.attname = 'res_id'
+           AND EXISTS (SELECT 1 FROM pg_attribute a2 WHERE a2.attrelid = i.indrelid
+                         AND a2.attname IN ('res_model', 'model') AND NOT a2.attisdropped))
+        )
+      LIMIT 1
+    ) tgt ON true
+    WHERE i.indisunique AND i.indisvalid AND i.indpred IS NULL
+      AND tgt.col = ANY (SELECT att.attname FROM unnest(i.indkey::int[]) k(attnum)
+                          JOIN pg_attribute att ON att.attrelid = i.indrelid AND att.attnum = k.attnum)
+      AND c.relname <> 'res_partner'
+  LOOP
+    -- cheia de partiționare = coloanele indexului, cu coloana remapată înlocuită de ținta ei
+    SELECT string_agg(
+             CASE WHEN col = r.remap_col
+                  THEN format('COALESCE(m.master_id, x.%I)', col)
+                  ELSE format('x.%I', col) END, ', ' ORDER BY ord)
+      INTO key_expr
+      FROM unnest(r.cols) WITH ORDINALITY AS u(col, ord);
+
+    IF p_mode = 'poly' THEN
+      where_cl := format('WHERE x.%I = ''res.partner''',
+        (SELECT a2.attname FROM pg_attribute a2
+          WHERE a2.attrelid = r.indrelid_tbl AND a2.attname IN ('res_model','model') AND NOT a2.attisdropped
+          ORDER BY CASE a2.attname WHEN 'res_model' THEN 0 ELSE 1 END LIMIT 1));
+    ELSE
+      where_cl := '';
+    END IF;
+
+    EXECUTE format($q$
+      WITH t AS (
+        SELECT x.ctid AS cid, ROW(%s) AS k
+        FROM %I x LEFT JOIN pm_map m ON m.old_id = x.%I
+        %s
+      ), dup AS (
+        -- k IS NOT NULL pe un ROW() e adevărat doar când TOATE câmpurile sunt non-null.
+        -- Obligatoriu: în PostgreSQL, NULL nu produce coliziune într-un index unique, dar
+        -- PARTITION BY grupează toate NULL-urile la un loc. Fără filtrul ăsta, un index de
+        -- tip website_visitor_partner_uniq (partner_id) ar face ca toți vizitatorii anonimi
+        -- (partner_id NULL) să pară duplicate între ei — măsurat: 181.583 rânduri șterse eronat.
+        SELECT cid, row_number() OVER (PARTITION BY k ORDER BY cid) AS rn
+        FROM t
+        WHERE k IS NOT NULL
+          AND k IN (SELECT k FROM t WHERE k IS NOT NULL GROUP BY k HAVING count(*) > 1)
+      )
+      DELETE FROM %I WHERE ctid IN (SELECT cid FROM dup WHERE rn > 1)
+    $q$, key_expr, r.tbl, r.remap_col, where_cl, r.tbl);
+    GET DIAGNOSTICS n = ROW_COUNT;
+    IF n > 0 THEN tabela := r.tbl; sterse := n; RETURN NEXT; END IF;
+  END LOOP;
+END$fn$ LANGUAGE plpgsql;
+
+\echo ''
+\echo '== 1. Dedup coliziuni unique pe coloanele FK =='
+SELECT * FROM pg_temp.pm_dedupe_unique('fk');
+
+\echo ''
+\echo '== 2. Remap coloane FK + parent_id =='
+DO $$
+DECLARE r RECORD; n bigint; total bigint := 0; t0 timestamptz := clock_timestamp();
+BEGIN
+  FOR r IN SELECT c.conrelid::regclass::text AS tbl, a.attname AS col
+           FROM pg_constraint c
+           JOIN pg_attribute a ON a.attrelid = c.conrelid AND a.attnum = ANY(c.conkey)
+           WHERE c.contype = 'f' AND c.confrelid = 'res_partner'::regclass
+             AND c.conrelid::regclass::text <> 'res_partner'
+  LOOP
+    EXECUTE format('UPDATE %s t SET %I = m.master_id FROM pm_map m WHERE t.%I = m.old_id', r.tbl, r.col, r.col);
+    GET DIAGNOSTICS n = ROW_COUNT; total := total + n;
+  END LOOP;
+  UPDATE res_partner p SET parent_id = m.master_id FROM pm_map m WHERE p.parent_id = m.old_id;
+  GET DIAGNOSTICS n = ROW_COUNT; total := total + n;
+  RAISE NOTICE 'remap FK + parent_id: % rânduri în % s', total, round(extract(epoch from clock_timestamp() - t0), 1);
+END$$;
+
+\echo ''
+\echo '== 3. Dedup coliziuni unique pe res_id (recalculat după pasul 2) =='
+SELECT * FROM pg_temp.pm_dedupe_unique('poly');
+
+\echo ''
+\echo '== 4. Remap legături polimorfe =='
+-- Odoo folosește DOUĂ convenții pentru legăturile polimorfe:
+--   (res_model, res_id) — mail.activity, ir.attachment, mail.followers, rating.rating...
+--   (model,     res_id) — mail.message, ir.model.data
+-- Ambele trebuie acoperite; tratarea doar a primeia lasă în urmă mesajele din chatter
+-- (măsurat: 87 de rânduri orfane în mail_message la primul test).
+DO $$
+DECLARE r RECORD; n bigint; total bigint := 0; t0 timestamptz := clock_timestamp();
+BEGIN
+  FOR r IN
+    SELECT t.table_name,
+           (SELECT c.column_name FROM information_schema.columns c
+             WHERE c.table_schema='public' AND c.table_name=t.table_name
+               AND c.column_name IN ('res_model','model')
+             ORDER BY CASE c.column_name WHEN 'res_model' THEN 0 ELSE 1 END LIMIT 1) AS model_col
+    FROM information_schema.tables t
+    WHERE t.table_schema = 'public' AND t.table_type = 'BASE TABLE'
+      AND EXISTS (SELECT 1 FROM information_schema.columns c
+                   WHERE c.table_schema='public' AND c.table_name=t.table_name AND c.column_name='res_id')
+      AND EXISTS (SELECT 1 FROM information_schema.columns c
+                   WHERE c.table_schema='public' AND c.table_name=t.table_name
+                     AND c.column_name IN ('res_model','model')
+                     AND c.data_type IN ('character varying','text'))
+  LOOP
+    EXECUTE format('UPDATE %I t SET res_id = m.master_id FROM pm_map m WHERE t.%I = ''res.partner'' AND t.res_id = m.old_id',
+                   r.table_name, r.model_col);
+    GET DIAGNOSTICS n = ROW_COUNT; total := total + n;
+  END LOOP;
+  RAISE NOTICE 'remap polimorfic: % rânduri în % s', total, round(extract(epoch from clock_timestamp() - t0), 1);
+END$$;
+
+\echo ''
+\echo '== 5. Completarea câmpurilor goale pe master =='
+-- Doar câmpuri de contact GOALE pe master, luate de la cea mai recentă fișă absorbită
+-- care le are completate. Nu suprascrie niciodată o valoare existentă pe master.
+DO $$
+DECLARE r RECORD; n bigint; total bigint := 0;
+BEGIN
+  -- Notă: `mobile` nu mai există pe res.partner în Odoo 19.
+  FOR r IN SELECT unnest(ARRAY['email','phone','website','street','street2','city','zip','function']) AS col
+  LOOP
+    EXECUTE format($q$
+      UPDATE res_partner mst SET %I = src.val
+      FROM (
+        SELECT DISTINCT ON (m.master_id) m.master_id, o.%I AS val
+        FROM pm_map m JOIN res_partner o ON o.id = m.old_id
+        WHERE o.%I IS NOT NULL AND o.%I <> ''
+        ORDER BY m.master_id, o.write_date DESC
+      ) src
+      WHERE mst.id = src.master_id AND (mst.%I IS NULL OR mst.%I = '')
+    $q$, r.col, r.col, r.col, r.col, r.col, r.col);
+    GET DIAGNOSTICS n = ROW_COUNT; total := total + n;
+  END LOOP;
+  RAISE NOTICE 'câmpuri completate pe masteri: %', total;
+END$$;
+
+\echo ''
+\echo '== 6. Ștergerea / arhivarea fișelor absorbite =='
+-- Notă: psql NU substituie variabile în interiorul blocurilor $$...$$,
+-- de aceea ramificarea se face aici, la nivel de \if, nu în plpgsql.
+\if :arhiveaza
+  DO $$
+  DECLARE n bigint; t0 timestamptz := clock_timestamp();
+  BEGIN
+    UPDATE res_partner p SET active = false FROM pm_map m WHERE p.id = m.old_id;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RAISE NOTICE 'arhivate % fișe în % s', n, round(extract(epoch from clock_timestamp() - t0), 1);
+  END$$;
+\else
+  DO $$
+  DECLARE n bigint; t0 timestamptz := clock_timestamp();
+  BEGIN
+    DELETE FROM res_partner p USING pm_map m WHERE p.id = m.old_id;
+    GET DIAGNOSTICS n = ROW_COUNT;
+    RAISE NOTICE 'șterse % fișe (FK ACTIVE) în % s', n, round(extract(epoch from clock_timestamp() - t0), 1);
+  END$$;
+\endif
+
+\echo ''
+\echo '== Verificare imediată: referințe rămase către fișele absorbite =='
+-- Trebuie să fie 0 pe toate liniile. La mod_stergere='stergere' baza ar fi refuzat
+-- oricum ștergerea; verificarea contează mai ales pentru legăturile polimorfe,
+-- care NU au FK și deci nu sunt protejate de bază.
+SELECT 'mail_activity'  AS unde, count(*) AS ramase FROM mail_activity  WHERE res_model = 'res.partner' AND res_id IN (SELECT old_id FROM pm_map)
+UNION ALL SELECT 'ir_attachment',  count(*) FROM ir_attachment  WHERE res_model = 'res.partner' AND res_id IN (SELECT old_id FROM pm_map)
+UNION ALL SELECT 'mail_message',   count(*) FROM mail_message   WHERE model     = 'res.partner' AND res_id IN (SELECT old_id FROM pm_map)
+UNION ALL SELECT 'mail_followers', count(*) FROM mail_followers WHERE res_model = 'res.partner' AND res_id IN (SELECT old_id FROM pm_map)
+UNION ALL SELECT 'ir_model_data',  count(*) FROM ir_model_data  WHERE model     = 'res.partner' AND res_id IN (SELECT old_id FROM pm_map);
+
+\if :do_apply
+  \echo ''
+  \echo '>>> COMMIT — modificările se aplică'
+  COMMIT;
+\else
+  \echo ''
+  \echo '>>> SIMULARE — ROLLBACK, nimic nu s-a schimbat. Rulează cu -v do_apply=1 pentru a aplica.'
+  ROLLBACK;
+\endif

--- a/scripts/partner_merge/04_verify.sql
+++ b/scripts/partner_merge/04_verify.sql
@@ -1,0 +1,103 @@
+-- =============================================================================
+-- 04 — Verificarea de după unificare
+-- =============================================================================
+-- Compară situația reală a masterilor cu snapshotul luat în 02, ÎNAINTE de merge.
+-- Regula: ce era răspândit pe fișele grupului trebuie să se regăsească integral
+-- pe master — nimic pierdut, nimic dublat.
+--
+-- Rulare (după COMMIT-ul lui 03):
+--   psql -d <bd> -f 04_verify.sql
+-- =============================================================================
+\timing on
+\set ON_ERROR_STOP on
+
+\echo '== A. Fișele absorbite mai există? (0 = șterse; >0 = rulat în mod arhivare) =='
+SELECT count(*) FILTER (WHERE p.id IS NOT NULL)     AS inca_existente,
+       count(*) FILTER (WHERE p.active)             AS inca_active
+FROM pm_map m LEFT JOIN res_partner p ON p.id = m.old_id;
+
+\echo ''
+\echo '== B. Totaluri pe master: real vs. așteptat =='
+WITH real AS (
+  SELECT s.master_id,
+    (SELECT count(*) FROM account_move mv WHERE mv.partner_id = s.master_id AND mv.move_type <> 'entry') AS facturi,
+    (SELECT count(*) FROM sale_order so    WHERE so.partner_id = s.master_id)                             AS comenzi_v,
+    (SELECT count(*) FROM purchase_order po WHERE po.partner_id = s.master_id)                            AS comenzi_a,
+    (SELECT count(*) FROM stock_picking sp WHERE sp.partner_id = s.master_id)                             AS livrari,
+    COALESCE((SELECT round(sum(l.balance)::numeric, 2)
+              FROM account_move_line l
+              JOIN account_account a ON a.id = l.account_id
+              JOIN account_move mv   ON mv.id = l.move_id
+             WHERE l.partner_id = s.master_id AND mv.state = 'posted' AND a.reconcile AND NOT l.reconciled), 0) AS sold
+  FROM pm_snapshot s
+)
+SELECT count(*)                                                              AS masteri_verificati,
+       count(*) FILTER (WHERE r.facturi   <> s.facturi_asteptate)            AS abateri_facturi,
+       count(*) FILTER (WHERE r.comenzi_v <> s.comenzi_v_asteptate)          AS abateri_comenzi_v,
+       count(*) FILTER (WHERE r.comenzi_a <> s.comenzi_a_asteptate)          AS abateri_comenzi_a,
+       count(*) FILTER (WHERE r.livrari   <> s.livrari_asteptate)            AS abateri_livrari,
+       count(*) FILTER (WHERE r.sold      <> s.sold_asteptat)                AS abateri_sold
+FROM pm_snapshot s JOIN real r ON r.master_id = s.master_id;
+
+\echo ''
+\echo '== C. Detaliul abaterilor (trebuie să fie gol) =='
+WITH real AS (
+  SELECT s.master_id,
+    (SELECT count(*) FROM account_move mv WHERE mv.partner_id = s.master_id AND mv.move_type <> 'entry') AS facturi,
+    (SELECT count(*) FROM sale_order so    WHERE so.partner_id = s.master_id)                             AS comenzi_v,
+    COALESCE((SELECT round(sum(l.balance)::numeric, 2)
+              FROM account_move_line l
+              JOIN account_account a ON a.id = l.account_id
+              JOIN account_move mv   ON mv.id = l.move_id
+             WHERE l.partner_id = s.master_id AND mv.state = 'posted' AND a.reconcile AND NOT l.reconciled), 0) AS sold
+  FROM pm_snapshot s
+)
+SELECT s.master_id, p.name,
+       s.facturi_asteptate, r.facturi,
+       s.comenzi_v_asteptate, r.comenzi_v,
+       s.sold_asteptat, r.sold
+FROM pm_snapshot s
+JOIN real r ON r.master_id = s.master_id
+LEFT JOIN res_partner p ON p.id = s.master_id
+WHERE r.facturi <> s.facturi_asteptate
+   OR r.comenzi_v <> s.comenzi_v_asteptate
+   OR r.sold <> s.sold_asteptat
+ORDER BY 1 LIMIT 50;
+
+\echo ''
+\echo '== D. Referințe orfane rămase (legături polimorfe — fără protecție FK) =='
+SELECT 'mail_activity' AS unde, count(*) AS orfane FROM mail_activity WHERE res_model='res.partner' AND res_id NOT IN (SELECT id FROM res_partner)
+UNION ALL SELECT 'ir_attachment', count(*) FROM ir_attachment WHERE res_model='res.partner' AND res_id NOT IN (SELECT id FROM res_partner)
+UNION ALL SELECT 'mail_message',  count(*) FROM mail_message  WHERE model='res.partner'     AND res_id NOT IN (SELECT id FROM res_partner)
+UNION ALL SELECT 'mail_followers',count(*) FROM mail_followers WHERE res_model='res.partner' AND res_id NOT IN (SELECT id FROM res_partner)
+UNION ALL SELECT 'ir_model_data', count(*) FROM ir_model_data WHERE model='res.partner'      AND res_id NOT IN (SELECT id FROM res_partner);
+
+\echo ''
+\echo '== E. Masteri cu denumire suspectă (de corectat manual) =='
+-- Masterul e ales după volumul de documente, NU după calitatea denumirii. Uneori
+-- supraviețuiește fișa cu numele prost formatat (fără spații, sau chiar egal cu CUI-ul),
+-- iar varianta corectă era pe o fișă absorbită. Nu afectează integritatea, dar se vede
+-- în rapoarte și în documentele emise de aici înainte.
+-- Pragul de lungime nu e suficient: „MayaVirágKft" are exact 12 caractere și scăpa,
+-- deși e clar o denumire lipită la import. Semnalul mai bun e tranziția
+-- minusculă -> MAJUSCULĂ într-un nume fără spații (CamelCase), indiferent de lungime.
+SELECT p.id, p.name AS denumire_master, p.vat,
+       CASE WHEN p.name ~ '^[A-Z]{0,2}[0-9]{4,}$'                     THEN 'denumirea e chiar CUI-ul'
+            WHEN p.name !~ ' ' AND p.name ~ '[[:lower:]][[:upper:]]'  THEN 'cuvinte lipite (import prost)'
+            WHEN p.name !~ ' ' AND length(p.name) > 8                 THEN 'fără spații'
+       END AS motiv,
+       -- denumirea de pe fișele absorbite, ca alternativă de corectare
+       (SELECT string_agg(DISTINCT o.name, ' | ')
+          FROM pm_map m JOIN res_partner o ON o.id = m.old_id
+         WHERE m.master_id = p.id) AS variante_absorbite
+FROM pm_snapshot s JOIN res_partner p ON p.id = s.master_id
+WHERE p.name ~ '^[A-Z]{0,2}[0-9]{4,}$'
+   OR (p.name !~ ' ' AND (p.name ~ '[[:lower:]][[:upper:]]' OR length(p.name) > 8))
+ORDER BY 1;
+
+\echo ''
+\echo '== F. Duplicate pe CUI rămase (progres) =='
+SELECT count(*) AS grupuri_ramase, sum(n) - count(*) AS fise_inca_de_absorbit
+FROM (SELECT count(*) AS n FROM res_partner
+      WHERE active AND is_company AND vat IS NOT NULL AND vat <> ''
+      GROUP BY upper(regexp_replace(vat, '[^0-9A-Za-z]', '', 'g')) HAVING count(*) > 1) t;

--- a/scripts/partner_merge/README.md
+++ b/scripts/partner_merge/README.md
@@ -1,0 +1,104 @@
+# Unificarea partenerilor duplicați pe CUI
+
+Set de scripturi pentru unificarea în masă a fișelor de parteneri care împart același CUI, fără a dezactiva cheile
+străine și fără drepturi de superuser (merge și pe odoo.sh).
+
+## De ce nu wizardul standard și nu `session_replication_role`
+
+Wizardul Odoo (`base.partner.merge.automatic.wizard`) rulează `_update_foreign_keys` **per grup**: la ~4.800 de grupuri
+× ~158 de coloane FK înseamnă peste 750.000 de instrucțiuni UPDATE. Nu se termină într-o fereastră rezonabilă.
+
+Tentația următoare e `SET session_replication_role = replica` (dezactivează verificarea FK). Costă superuser —
+indisponibil pe odoo.sh — și mută răspunderea integrității de pe bază pe autorul scriptului. Nu e necesar: **lentoarea
+nu vine de la verificarea FK în sine, ci de la coloanele FK neindexate.** `res_partner` e referit de ~158 de coloane,
+din care ~77 nu aveau index; fără index, fiecare ștergere declanșează scanări secvențiale complete (măsurat: 3.180 MB
+scanați per rând).
+
+Abordarea de aici: creează indexurile (pasul 01), apoi inversează buclele — un singur UPDATE per coloană pentru tot
+lotul, în loc de unul per grup per coloană.
+
+## Măsurători pe o bază de producție (peste 500.000 de parteneri)
+
+Lot complet A + B: **4.800 de grupuri, 5.350 de fișe absorbite.**
+
+| Etapă                                               | Timp            |
+| --------------------------------------------------- | --------------- |
+| Creare 77 indexuri (`CONCURRENTLY`)                 | ~4 s, 1.222 MB  |
+| Dedup coliziuni unique pe coloanele FK              | ~1 s            |
+| Remap 158 coloane FK + `parent_id` (95.023 rânduri) | 69,4 s          |
+| Dedup coliziuni pe `res_id` (3.703 rânduri)         | ~1 s            |
+| Remap legături polimorfe (4.675 rânduri)            | 2,1 s           |
+| Completare câmpuri goale pe masteri (889)           | <1 s            |
+| **DELETE 5.350 fișe, cu FK ACTIVE**                 | **189,7 s**     |
+| **Total**                                           | **~4,5 minute** |
+
+Pentru comparație, aceeași ștergere fără indexuri a depășit 8 minute fără să termine.
+
+## Rulare
+
+```bash
+# 1. Indexurile (o singură dată, se poate rula în timpul programului)
+psql -d <bd> -f 01_fk_indexes.sql
+
+# 2. Construiește lotul (fără efect asupra datelor de business)
+psql -d <bd> -v categorii="'A','B'" -v limita_grupuri=200 -f 02_build_map.sql
+
+# 3. Simulare — rulează tot fluxul, apoi ROLLBACK
+psql -d <bd> -f 03_merge.sql
+
+# 4. Aplicare, după ce simularea arată curat
+psql -d <bd> -v do_apply=1 -f 03_merge.sql
+
+# 5. Verificare
+psql -d <bd> -f 04_verify.sql
+```
+
+Parametri utili:
+
+- `-v limita_grupuri=0` — tot lotul (implicit 200)
+- `-v arhiveaza=1` — `active = false` în loc de ștergere (recomandat la primele loturi)
+- `-v categorii="'A'"` — doar categoria cea mai sigură
+
+## Categoriile de grupuri
+
+| Cat. | Descriere                                          | Tratament                     |
+| ---- | -------------------------------------------------- | ----------------------------- |
+| A    | o singură față are documente, restul complet goale | automat                       |
+| B    | documente doar pe o față                           | automat                       |
+| C    | facturi pe mai multe fețe                          | manual, cu contabilitatea     |
+| D    | sold nereconciliat pe mai multe fețe               | manual, după închiderea lunii |
+
+Pasul 02 exclude automat din lot grupurile care: conțin compania proprie, au user portal pe mai multe fețe, sau au
+denumiri complet divergente (revizuire manuală — vezi mai jos).
+
+## Capcane confirmate prin testare
+
+**NULL nu produce coliziune într-un index unique.** `PARTITION BY` însă grupează toate NULL-urile la un loc. Fără
+filtrul `k IS NOT NULL`, dedup-ul a marcat ca duplicate toți vizitatorii anonimi de site (`website_visitor.partner_id`
+unique, majoritar NULL) — **181.583 de rânduri șterse eronat**, fără nicio eroare. Clasa asta de bug nu se vede decât
+rulând.
+
+**Odoo are două convenții polimorfe:** `(res_model, res_id)` pentru `mail.activity`, `ir.attachment`, `mail.followers`,
+`rating.rating`; dar `(model, res_id)` pentru `mail.message` și `ir.model.data`. Tratarea doar a primeia lasă chatterul
+agățat de fișe șterse.
+
+**Dedup-ul se face pe valoarea ȚINTĂ, nu comparând fișa absorbită cu masterul.** Două fișe din același grup se pot
+ciocni între ele după remap, fără ca masterul să fie implicat. Și trebuie recalculat după fiecare etapă de remap:
+remapul lui `partner_id` creează coliziuni pe `res_id` care nu existau la începutul tranzacției. Constrângerile unique
+rămân active și sub `session_replication_role = replica` — bypass-ul de FK nu acoperă acest pas.
+
+**Masterul e ales după documente, nu după calitatea denumirii.** Uneori supraviețuiește fișa cu numele prost formatat.
+Pasul 04, secțiunea E, listează masterii cu denumire suspectă, de corectat manual după merge.
+
+**`mobile` nu mai există pe `res.partner` în Odoo 19.**
+
+## Înainte de producție
+
+- Rulează întâi pe staging, cap-coadă, cu `04_verify.sql` curat.
+- Backup / PITR confirmat înainte de rularea cu `do_apply=1`.
+- Validează cu clientul regula de master pe un eșantion de ~20 de grupuri.
+- Primele loturi mici (`limita_grupuri=50`) și, dacă vrei plasă de siguranță, `arhiveaza=1`.
+- Indexurile de la pasul 01 rămân permanent și accelerează orice ștergere sau arhivare de partener de aici înainte.
+  Patru dintre cele mai scumpe coloane sunt din modulele noastre (`l10n_ro_transport_partner_id`,
+  `l10n_ro_etransport_start_address`, `delegate_id`) — merită `index=True` în cod, ca să nu revină problema la fiecare
+  instalare nouă.


### PR DESCRIPTION
## Ce conține

Set de scripturi SQL pentru unificarea în masă a fișelor de parteneri care împart același CUI.

| Fișier | Rol |
|---|---|
| `01_fk_indexes.sql` | creează indexurile lipsă pe coloanele FK spre `res_partner`, cu `CONCURRENTLY` |
| `02_build_map.sql` | clasifică grupurile, alege masterul, construiește lotul, ia snapshot de control |
| `03_merge.sql` | execuția; implicit **simulare cu rollback**, aplică doar cu `-v do_apply=1` |
| `04_verify.sql` | compară totalurile masterilor cu snapshotul: nimic pierdut, nimic dublat |
| `README.md` | măsurători, capcane, procedura de rulare |

## De ce nu wizardul standard

`base.partner.merge.automatic.wizard` rulează `_update_foreign_keys` **per grup**: la ~4.800 de
grupuri × ~158 de coloane FK înseamnă peste 750.000 de instrucțiuni UPDATE. Scripturile inversează
buclele — un singur UPDATE per coloană pentru tot lotul.

## De ce nu `session_replication_role = replica`

Lentoarea nu vine din verificarea cheilor străine, ci din cele ~77 de coloane FK fără index: fără
ele, o singură ștergere scanează 3.180 MB de tabele. Cu indexurile create la pasul 01, tot fluxul
merge cu **cheile străine active** — deci fără superuser (indisponibil pe odoo.sh) și cu
integritatea garantată de bază, nu de o dovadă scrisă de mână.

## Măsurători

Pe o bază de producție, 4.800 de grupuri / 5.350 de fișe absorbite:

| Etapă | Timp |
|---|---|
| Remap 158 coloane FK (95.023 rânduri) | 69 s |
| Remap legături polimorfe | 2 s |
| Ștergere 5.350 fișe, FK active | 190 s |
| **Total** | **~4,5 minute** |

Aceeași ștergere fără indexuri a depășit 8 minute fără să termine.

## Capcane documentate în README

Toate trei au fost găsite rulând scripturile, nu citindu-le:

- **NULL nu produce coliziune într-un index unique, dar `PARTITION BY` grupează toate NULL-urile la
  un loc.** Prima versiune a dedup-ului marca drept duplicate toate rândurile cu FK NULL — pe baza de
  test, 181.583 de rânduri ar fi fost șterse eronat, fără nicio eroare.
- **Odoo are două convenții polimorfe:** `(res_model, res_id)` și `(model, res_id)`. Tratarea doar a
  primeia lasă chatterul agățat de fișe șterse.
- **Dedup-ul trebuie să colapseze pe valoarea ȚINTĂ**, nu comparând fișa absorbită cu masterul, și
  trebuie recalculat după fiecare etapă de remap.

## Note

- Nu conține date de client.
- Scripturile nu ating module; sunt utilitare de administrare, ca restul lui `scripts/`.
- Pasul 03 are implicit rollback, deci se poate rula în siguranță pentru simulare.
