### PR TITLE
[FIX] deltatech_image_optimize: report space actually reclaimed

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "images": ["static/description/main_screenshot.png"],
     "name": "Image Optimizer",
-    "version": "19.0.1.7.0",
+    "version": "19.0.1.8.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/models/ir_attachment.py
+++ b/deltatech_image_optimize/models/ir_attachment.py
@@ -4,6 +4,7 @@ import io
 import logging
 
 from odoo import api, fields, models
+from odoo.tools import SQL
 
 _logger = logging.getLogger(__name__)
 
@@ -182,6 +183,31 @@ class IrAttachment(models.Model):
     # ------------------------------------------------------------------
     # Batch runner
     # ------------------------------------------------------------------
+    def _dt_image_shared_file(self):
+        """Whether this attachment's filestore file is shared with others.
+
+        Odoo keeps a single file per checksum, so several attachments with the
+        same content point at the same ``store_fname``. Recompressing one of
+        them frees nothing on disk while the others still reference the old
+        file -- which is why the per-attachment byte difference overstates the
+        real saving, badly, on catalogs that reuse the same picture (measured
+        on a real deployment: 29 GB counted, ~4 GB actually reclaimed, because
+        815k image attachments lived in 508k files).
+
+        ``store_fname`` is indexed (``checksum`` is not), and it is derived from
+        the checksum, so it answers the same question and is cheap to ask.
+
+        Queried in SQL on purpose: ``search`` on ``ir.attachment`` silently adds
+        ``res_field = False`` when the domain does not mention that field, which
+        hides exactly the image attachments this module works on -- the count
+        then comes back as 0 and every file looks unshared.
+        """
+        self.ensure_one()
+        if not self.store_fname:  # stored in DB, not in the filestore
+            return False
+        self.env.cr.execute(SQL("SELECT count(*) FROM ir_attachment WHERE store_fname = %s", self.store_fname))
+        return self.env.cr.fetchone()[0] > 1
+
     @api.model
     def _dt_image_optimize_run(self, limit=None):
         """Optimize a batch of original image attachments.
@@ -190,11 +216,15 @@ class IrAttachment(models.Model):
         (``record.write({res_field: ...})``) so Odoo regenerates the resized
         variants (image_1024/512/256/128) from the new, smaller original.
 
-        :return: dict with ``scanned``, ``optimized`` and ``freed`` (bytes).
+        :return: dict with ``scanned``, ``optimized``, ``freed`` and
+            ``freed_disk`` (bytes). ``freed`` sums the per-attachment size
+            difference; ``freed_disk`` counts only attachments whose filestore
+            file was not shared with another attachment, so it is the figure
+            that matches what the disk actually gives back.
         """
         if Image is None:
             _logger.warning("Pillow (PIL) is not available; image optimizer skipped.")
-            return {"scanned": 0, "optimized": 0, "freed": 0}
+            return {"scanned": 0, "optimized": 0, "freed": 0, "freed_disk": 0}
 
         params = self._dt_image_optimize_params()
         limit = limit or params["batch"]
@@ -211,6 +241,7 @@ class IrAttachment(models.Model):
         now = fields.Datetime.now()
         optimized = 0
         freed = 0
+        freed_disk = 0
         # Decoded images and their raw bytes are heavy; flush and drop the ORM
         # cache regularly so memory stays flat over large batches (otherwise a
         # single batch can exhaust the worker/shell memory and get killed).
@@ -218,6 +249,9 @@ class IrAttachment(models.Model):
         flush_every = params["flush_every"]
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
+            # Ask before writing: the write replaces store_fname, so afterwards
+            # there is no way to tell whether the old file was shared.
+            shared = att._dt_image_shared_file()
             data, out_format = self._dt_image_recompress(
                 raw, params["quality"], params["max_dim"], params["webp_quality"], params["force_jpeg"]
             )
@@ -235,6 +269,8 @@ class IrAttachment(models.Model):
                     att.deltatech_image_optimized = now
                 else:
                     freed += len(raw) - len(data)
+                    if not shared:
+                        freed_disk += len(raw) - len(data)
                     optimized += 1
             else:
                 record = self.env[att.res_model].sudo().browse(att.res_id)
@@ -266,6 +302,8 @@ class IrAttachment(models.Model):
                         if new_att:
                             new_att.deltatech_image_optimized = now
                         freed += len(raw) - len(data)
+                        if not shared:
+                            freed_disk += len(raw) - len(data)
                         optimized += 1
             if index % flush_every == 0:
                 self.env.flush_all()
@@ -273,12 +311,18 @@ class IrAttachment(models.Model):
                 gc.collect()
 
         _logger.info(
-            "Image optimizer: scanned=%s optimized=%s freed=%.1f MB",
+            "Image optimizer: scanned=%s optimized=%s freed=%.1f MB (on disk: %.1f MB)",
             len(attachments),
             optimized,
             freed / 1048576.0,
+            freed_disk / 1048576.0,
         )
-        return {"scanned": len(attachments), "optimized": optimized, "freed": freed}
+        return {
+            "scanned": len(attachments),
+            "optimized": optimized,
+            "freed": freed,
+            "freed_disk": freed_disk,
+        }
 
     @api.model
     def _dt_image_optimize_variants_run(self, limit=None):
@@ -290,10 +334,14 @@ class IrAttachment(models.Model):
         (``att.write({'raw': ...})``): no resize (already sized), just a lower
         quality re-encode. No propagation, original untouched.
 
-        :return: dict with ``scanned``, ``optimized`` and ``freed`` (bytes).
+        :return: dict with ``scanned``, ``optimized``, ``freed`` and
+            ``freed_disk`` (bytes). ``freed`` sums the per-attachment size
+            difference; ``freed_disk`` counts only attachments whose filestore
+            file was not shared with another attachment, so it is the figure
+            that matches what the disk actually gives back.
         """
         if Image is None:
-            return {"scanned": 0, "optimized": 0, "freed": 0}
+            return {"scanned": 0, "optimized": 0, "freed": 0, "freed_disk": 0}
         get = self.env["ir.config_parameter"].sudo().get_param
         quality = max(1, min(95, int(get("deltatech_image_optimize.variant_quality", 85))))
         webp_quality = max(1, min(100, int(get("deltatech_image_optimize.webp_quality", 85))))
@@ -317,8 +365,11 @@ class IrAttachment(models.Model):
         now = fields.Datetime.now()
         optimized = 0
         freed = 0
+        freed_disk = 0
         for index, att in enumerate(attachments, start=1):
             raw = att.raw
+            # Ask before writing: the write replaces store_fname.
+            shared = att._dt_image_shared_file()
             # max_dim=0 -> no resize, only a lower quality re-encode.
             data, out_format = self._dt_image_recompress(raw, quality, 0, webp_quality, force_jpeg)
             vals = {"deltatech_image_optimized": now}
@@ -333,6 +384,8 @@ class IrAttachment(models.Model):
                 continue
             if data:
                 freed += len(raw) - len(data)
+                if not shared:
+                    freed_disk += len(raw) - len(data)
                 optimized += 1
             if index % flush_every == 0:
                 self.env.flush_all()
@@ -340,12 +393,18 @@ class IrAttachment(models.Model):
                 gc.collect()
 
         _logger.info(
-            "Image optimizer (variants): scanned=%s optimized=%s freed=%.1f MB",
+            "Image optimizer (variants): scanned=%s optimized=%s freed=%.1f MB (on disk: %.1f MB)",
             len(attachments),
             optimized,
             freed / 1048576.0,
+            freed_disk / 1048576.0,
         )
-        return {"scanned": len(attachments), "optimized": optimized, "freed": freed}
+        return {
+            "scanned": len(attachments),
+            "optimized": optimized,
+            "freed": freed,
+            "freed_disk": freed_disk,
+        }
 
     @api.model
     def _dt_image_optimize_cron(self):

--- a/deltatech_image_optimize/readme/DESCRIPTION.md
+++ b/deltatech_image_optimize/readme/DESCRIPTION.md
@@ -21,6 +21,40 @@ Processed attachments are flagged (``deltatech_image_optimized``) and skipped on
 the next run. Because Odoo creates a fresh attachment whenever an image field is
 updated, newly uploaded or changed images are picked up automatically.
 
+## How much space you actually get back
+
+The batch methods return two figures, and the difference between them matters:
+
+| Key | Meaning |
+| --- | --- |
+| ``freed`` | sum of the per-attachment size difference |
+| ``freed_disk`` | only the attachments whose filestore file was **not** shared |
+
+Odoo stores one file per checksum, so attachments with identical content share
+a single file. Recompressing one of them frees nothing while the others still
+point at the old file. On a catalog that reuses the same picture across
+products, ``freed`` therefore overstates the saving — on a real deployment it
+counted **29 GB** where the disk gave back about **4 GB**, because 815 000 image
+attachments lived in 508 000 files.
+
+Use ``freed_disk`` when you report space. Use ``freed`` only to see how much
+lighter the images themselves got — which is the real win on a website, since
+that is bytes off every page load, regardless of deduplication.
+
+To measure the whole database rather than one run:
+
+```sql
+SELECT pg_size_pretty(sum(sz)) FROM (
+    SELECT DISTINCT ON (checksum) file_size AS sz
+    FROM ir_attachment WHERE res_field IS NOT NULL AND checksum IS NOT NULL
+    ORDER BY checksum, id
+) t;
+```
+
+Note also that the filestore grows *before* it shrinks: the new file is written
+while the old one is still referenced, and the space comes back only when the
+filestore GC runs (the scheduled action does it at the end of each pass).
+
 ## Configuration
 
 System Parameters (Settings → Technical → System Parameters):

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 19.0.1.8.0 (2026)
+
+- The batch methods now also return ``freed_disk``, and log it next to
+  ``freed``. ``freed`` sums the per-attachment size difference, which
+  **overstates the saving** whenever the same picture is used on several
+  records: Odoo keeps one file per checksum, so recompressing one attachment
+  frees nothing while the others still reference the old file. On a real
+  deployment the run reported **29 GB** where the disk gave back about **4 GB**
+  -- 815 000 image attachments living in 508 000 files. ``freed_disk`` counts
+  only attachments whose file was not shared, so it is the figure to quote when
+  someone asks how much space this recovers.
+- The check reads ``store_fname`` (indexed, and derived from the checksum)
+  before the write, since writing replaces it.
+- ``readme/DESCRIPTION.md`` explains the difference, gives the SQL to measure
+  real occupancy across the whole database, and notes that the filestore grows
+  before it shrinks -- the space returns only once the GC runs.
+
 ## 19.0.1.7.0 (2026)
 
 - **Transparent images now really become WebP.** They were silently falling back

--- a/deltatech_image_optimize/tests/test_image_optimize.py
+++ b/deltatech_image_optimize/tests/test_image_optimize.py
@@ -220,3 +220,33 @@ class TestImageOptimize(TransactionCase):
         # the master image_1920 must be byte-for-byte unchanged (no propagation)
         self._image_attachment(partner).invalidate_recordset()
         self.assertEqual(self._image_attachment(partner).raw, orig_1920)
+
+    def test_freed_disk_excludes_shared_files(self):
+        """A picture used by two records frees disk only once, not twice."""
+        if Image is None:
+            self.skipTest("Pillow not available")
+
+        ICP = self.env["ir.config_parameter"].sudo()
+        ICP.set_param("deltatech_image_optimize.min_size", "1")
+        ICP.set_param("deltatech_image_optimize.quality", "70")
+        ICP.set_param("deltatech_image_optimize.target_fields", "image_1920")
+
+        Attachment = self.env["ir.attachment"]
+        while Attachment._dt_image_optimize_run(limit=200)["scanned"]:
+            pass
+
+        # The same bytes on two partners: Odoo keeps one file for both.
+        image = self._make_big_jpeg()
+        p1 = self.env["res.partner"].create({"name": "Shared A", "image_1920": image})
+        p2 = self.env["res.partner"].create({"name": "Shared B", "image_1920": image})
+        a1, a2 = self._image_attachment(p1), self._image_attachment(p2)
+        self.assertEqual(a1.store_fname, a2.store_fname, "identical images should share one file")
+        self.assertTrue(a1._dt_image_shared_file())
+
+        stats = Attachment._dt_image_optimize_run(limit=50)
+        self.assertEqual(stats["optimized"], 2)
+        # Both attachments shrank, so `freed` counts both...
+        self.assertGreater(stats["freed"], 0)
+        # ...but the first rewrite left the old file in place for the second,
+        # so at most one of the two can count as disk actually reclaimed.
+        self.assertLess(stats["freed_disk"], stats["freed"])


### PR DESCRIPTION
The module reported far more reclaimed space than the disk ever gave back.

`freed` sums the per-attachment size difference. But Odoo keeps **one file per
checksum**, so attachments with identical content share a single file in the
filestore. Recompressing one of them frees nothing while the others still point
at the old file — the byte difference is counted anyway, once per attachment.

On a real deployment (PTC), a full drain reported **29 GB**. The disk gave back
about **4 GB**. The database explains it: **815 667 image attachments living in
508 327 files**, 62.4 GB of logical size over 41.7 GB of actual occupancy.

## Change

The batch methods now also return and log `freed_disk`, which counts only the
attachments whose filestore file was not shared:

```
Image optimizer: scanned=2 optimized=2 freed=3.7 MB (on disk: 1.8 MB)
```

`freed` is kept — it still answers a useful question (how much lighter the
images got, which is bytes off every page load regardless of deduplication).
`freed_disk` is the one to quote when someone asks about disk space.

## Two details worth reviewing

- The check reads `store_fname` **before** the write, since writing replaces it.
  `store_fname` is indexed and derived from the checksum; `checksum` itself is
  not indexed.
- It queries in **SQL**, not through `search`. `search` on `ir.attachment` adds
  `res_field = False` when the domain does not mention that field, which hides
  exactly the image attachments being counted — the first version used
  `search_count` and every file came back as unshared. The new test caught it.

## Testing

New test `test_freed_disk_excludes_shared_files` puts the same image on two
records, asserts they share a file, and asserts `freed_disk < freed` after the
run. Full suite on a clean 19.0 database: **0 failed, 0 errors of 7**.

Docs: `readme/DESCRIPTION.md` gains a section explaining the difference, the SQL
to measure real occupancy database-wide, and a note that the filestore grows
before it shrinks — space returns only once the GC runs.

Version `19.0.1.7.0` → `19.0.1.8.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)