### PR TITLE
[FIX] deltatech_stock_inventory: clear inventory note after applying (18.0)

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "18.0.2.6.1",
+    "version": "18.0.2.6.2",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/i18n/ro.po
+++ b/deltatech_stock_inventory/i18n/ro.po
@@ -542,7 +542,7 @@ msgstr ""
 #. module: deltatech_stock_inventory
 #: model:ir.model.fields,field_description:deltatech_stock_inventory.field_stock_quant__inventory_note
 msgid "Inventory Note"
-msgstr ""
+msgstr "Notă inventar"
 
 #. module: deltatech_stock_inventory
 #: model:ir.model.fields,field_description:deltatech_stock_inventory.field_product_product__is_inventory_ok

--- a/deltatech_stock_inventory/models/stock_quant.py
+++ b/deltatech_stock_inventory/models/stock_quant.py
@@ -92,7 +92,9 @@ class StockQuant(models.Model):
                     values["name"] = sequence.next_by_id()
 
             inventory.write(values)
-        self.write({"inventory_id": False, "inventory_line_id": False})
+        # Nota a fost preluata in referinta mișcării; o golim ca sa nu fie refolosita tacit
+        # la o ajustare ulterioara a aceluiași quant (standardul nu o curata).
+        self.write({"inventory_id": False, "inventory_line_id": False, "inventory_note": False})
         return res
 
     def write(self, vals):

--- a/deltatech_stock_inventory/readme/HISTORY.md
+++ b/deltatech_stock_inventory/readme/HISTORY.md
@@ -1,3 +1,13 @@
+## 18.0.2.6.2 (2026-08-17)
+
+- The **Inventory Note** is cleared when the adjustment is applied, so it is not
+  silently reused as the reason of a later adjustment on the same quant. The
+  standard `action_clear_inventory_quantity` does not reset custom fields, so a
+  note left over from a previous count became the reference of the next stock
+  move without the operator noticing.
+- Adds the missing Romanian translation of the column label ("Notă inventar"),
+  which was shown in English to operators, and tests for both behaviours.
+
 ## 18.0.2.6.1 (2026-08-03)
 
 - The **Inventory Note** column in the inventory adjustment list is now shown by

--- a/deltatech_stock_inventory/tests/__init__.py
+++ b/deltatech_stock_inventory/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_onchange_quantity_context
 from . import test_product_methods
 from . import test_stock_inventory_methods_extra
 from . import test_compute_warehouse_stocks
+from . import test_inventory_note

--- a/deltatech_stock_inventory/tests/test_inventory_note.py
+++ b/deltatech_stock_inventory/tests/test_inventory_note.py
@@ -1,0 +1,93 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.tests.common import TransactionCase
+
+
+class TestInventoryNote(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.stock_location = self.env["stock.location"].create({"name": "Test location", "usage": "internal"})
+        self.product = self.env["product.product"].create({"name": "Test note", "is_storable": True})
+
+    def _apply(self, quantity, note=False):
+        quant = self.env["stock.quant"].create(
+            {
+                "product_id": self.product.id,
+                "location_id": self.stock_location.id,
+                "inventory_quantity": quantity,
+                "inventory_note": note,
+            }
+        )
+        quant.action_apply_inventory()
+        return quant
+
+    def _last_move(self):
+        return self.env["stock.move"].search(
+            [("product_id", "=", self.product.id), ("is_inventory", "=", True)], order="id desc", limit=1
+        )
+
+    def test_note_becomes_move_reference(self):
+        """Nota de pe linie ajunge in referinta mișcării de stoc generate."""
+        self._apply(7, note="Marfa deteriorata la manipulare")
+        move = self._last_move()
+        # Pe 18.0 referinta unei mișcări fara transfer este chiar numele mișcării.
+        self.assertEqual(move.name, "Marfa deteriorata la manipulare")
+        self.assertEqual(move.reference, "Marfa deteriorata la manipulare")
+
+    def test_note_cleared_after_apply(self):
+        """Nota se goleste dupa aplicare, ca sa nu fie refolosita la ajustarea urmatoare."""
+        quant = self._apply(7, note="Motiv prima ajustare")
+        self.assertFalse(quant.inventory_note)
+
+        quant.inventory_quantity = 9
+        quant.action_apply_inventory()
+        move = self._last_move()
+        self.assertNotEqual(move.reference, "Motiv prima ajustare")
+
+    def test_without_note_standard_reference_kept(self):
+        """Fara nota, referinta rămâne cea standard.
+
+        Standardul adauga in referinta numele utilizatorului din `user_id` (*Assigned To*, cel
+        caruia i s-a repartizat numaratoarea), nu al celui care opereaza efectiv ajustarea. Fara
+        `user_id` completat, referinta nu spune nimic despre motiv sau despre operator — de aceea
+        nota de pe linie este singura urma per produs a motivului.
+        """
+        user = (
+            self.env["res.users"]
+            .with_context(no_reset_password=True)
+            .create(
+                {
+                    "name": "Operator inventar",
+                    "login": "operator_inv_note",
+                    "groups_id": [
+                        (
+                            6,
+                            0,
+                            [
+                                self.env.ref("stock.group_stock_manager").id,
+                                self.env.ref("deltatech_stock_inventory.group_view_inventory_button").id,
+                            ],
+                        )
+                    ],
+                }
+            )
+        )
+        quant = (
+            self.env["stock.quant"]
+            .with_user(user)
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "location_id": self.stock_location.id,
+                    "inventory_quantity": 5,
+                }
+            )
+        )
+        quant.action_apply_inventory()
+        self.assertNotIn(user.display_name, self._last_move().reference)
+
+        quant.write({"inventory_quantity": 8, "user_id": user.id})
+        quant.action_apply_inventory()
+        self.assertIn(user.display_name, self._last_move().reference)


### PR DESCRIPTION
Backport of the applicable part of PR #2794 (19.0), found while working helpdesk ticket #9156 (AGROAMAT).

The 19.0 regression that PR fixed — the per-line Inventory Note never reaching the generated stock move — **never existed on 18.0**: `values["name"] = self.inventory_note or values["name"]` has always been active here. Verified on the customer's 18.0 production database: an adjustment with a note produces a stock move whose reference is that note.

Two real defects do exist on 18.0, and this PR fixes both:

1. **The note is never cleared.** `action_apply_inventory` resets only `inventory_id`/`inventory_line_id`, and the standard `action_clear_inventory_quantity` does not touch custom fields. Confirmed empirically on the customer's production database: after applying, `inventory_note` was still set on the quant, so it would silently become the reference of the next adjustment on the same product.
2. **The column label was untranslated** — `msgid "Inventory Note"` had an empty `msgstr`, so operators saw it in English.

Adds three tests (32 tests total on the module, 0 failures locally on 18.0). One of them documents a behaviour worth knowing: the user name the standard appends to the move reference comes from `user_id` (*Assigned To*), **not** from the user performing the adjustment — so the per-line note is the only per-product trace of the reason.

`README.rst` / `static/description/index.html` are left out of this commit on purpose: they carry uncommitted regeneration from another session in this worktree, and they are generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)