### PR TITLE
[FIX] deltatech_image_optimize: keep the cron enabled across upgrades

### DIFF
--- a/deltatech_image_optimize/__manifest__.py
+++ b/deltatech_image_optimize/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "images": ["static/description/main_screenshot.png"],
     "name": "Image Optimizer",
-    "version": "19.0.1.8.0",
+    "version": "19.0.1.8.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Recompress oversized image attachments to reclaim filestore space",

--- a/deltatech_image_optimize/data/ir_cron.xml
+++ b/deltatech_image_optimize/data/ir_cron.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
+<odoo noupdate="1">
 
     <record id="ir_cron_dt_image_optimize" model="ir.cron">
         <field name="name">Image Optimizer: recompress oversized images</field>
@@ -9,7 +9,10 @@
         <field name="interval_number">1</field>
         <field name="interval_type">days</field>
         <!-- Disabled by default: review the configuration, run on staging,
-             then enable it manually. -->
+             then enable it manually. The file is noupdate="1" so that enabling
+             it survives a module upgrade: without the flag, every upgrade
+             reapplied this line and silently switched the cron back off, long
+             after someone had turned it on. -->
         <field name="active" eval="False" />
         <field name="nextcall" eval="(datetime.now() + relativedelta(days=1)).strftime('%Y-%m-%d 02:00:00')" />
     </record>

--- a/deltatech_image_optimize/readme/HISTORY.md
+++ b/deltatech_image_optimize/readme/HISTORY.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 19.0.1.8.1 (2026)
+
+- ``data/ir_cron.xml`` is now ``noupdate="1"``. It was not, so **every module
+  upgrade reapplied ``active = False`` and switched the scheduled action back
+  off**, silently, however long ago someone had enabled it. Seen in production:
+  the cron was enabled one day, an upgrade the next morning disabled it again,
+  and nothing in the logs said so -- it simply never ran. ``ir_config_parameter.xml``
+  already had the flag, which is why the tuned parameters survived the same
+  upgrade while the cron did not.
+- Existing databases: the flag stops future upgrades from touching the record,
+  but it cannot restore a cron already switched off. Check
+  Settings > Technical > Scheduled Actions after upgrading, and re-enable it if
+  it was on before.
+
 ## 19.0.1.8.0 (2026)
 
 - The batch methods now also return ``freed_disk``, and log it next to


### PR DESCRIPTION
`data/ir_cron.xml` was missing `noupdate="1"`. So **every module upgrade
reapplied `active = False`** and switched the scheduled action back off —
silently, however long ago someone had enabled it.

Seen in production this morning: the cron was enabled yesterday, an upgrade
turned it off overnight, and nothing in the logs said so. It would simply not
have run, and the only way to notice is that the backlog stops shrinking.

`data/ir_config_parameter.xml` already carried the flag, which is why the tuned
parameters survived the same upgrade while the cron did not — the inconsistency
is what made this easy to miss.

## Verification

On clean databases, both directions:

| XML | after install | admin enables | after upgrade |
| --- | --- | --- | --- |
| `<odoo>` (before) | `f` | `t` | **`f`** — the bug |
| `<odoo noupdate="1">` (after) | `f` | `t` | **`t`** |

And on the path that actually matters — a database installed with the old
version, then upgraded to this one:

| step | active | ir_model_data.noupdate |
| --- | --- | --- |
| installed (old version) | `f` | `f` |
| admin enables it | `t` | `f` |
| **upgrade to this version** | **`t`** | `f` |
| another upgrade | `t` | `f` |

So existing databases are protected from this upgrade on, even though the
stored `noupdate` flag stays false — Odoo honours the flag from the file at
load time. It cannot, of course, re-enable a cron that an earlier upgrade
already switched off: check Scheduled Actions after upgrading.

A first attempt at this verification was contaminated — the `noupdate` flag
persisted in `ir_model_data` from an earlier run in the same database, so
removing it from the XML appeared to change nothing. Each case above is a fresh
database.

Version `19.0.1.8.0` → `19.0.1.8.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)