### PR TITLE
fix: keep absorbed names for the post-merge report, relabel the orphan check

### DIFF
--- a/scripts/partner_merge/02_build_map.sql
+++ b/scripts/partner_merge/02_build_map.sql
@@ -135,7 +135,11 @@ SELECT m.master_id,
        sum(f.comenzi_v) + mf.comenzi_v       AS comenzi_v_asteptate,
        sum(f.comenzi_a) + mf.comenzi_a       AS comenzi_a_asteptate,
        sum(f.livrari)   + mf.livrari         AS livrari_asteptate,
-       round(sum(f.sold) + mf.sold, 2)       AS sold_asteptat
+       round(sum(f.sold) + mf.sold, 2)       AS sold_asteptat,
+       -- Denumirile fișelor absorbite, capturate ACUM: după merge ele nu mai există,
+       -- deci un JOIN în 04 nu ar mai găsi nimic. Servesc la corectarea manuală a
+       -- masterilor cu denumire degradată (vezi 04, secțiunea E).
+       string_agg(DISTINCT f.name, ' | ')     AS denumiri_absorbite
 FROM pm_map m
 JOIN pm_face f  ON f.id = m.old_id
 JOIN pm_face mf ON mf.id = m.master_id

--- a/scripts/partner_merge/04_verify.sql
+++ b/scripts/partner_merge/04_verify.sql
@@ -65,7 +65,11 @@ WHERE r.facturi <> s.facturi_asteptate
 ORDER BY 1 LIMIT 50;
 
 \echo ''
-\echo '== D. Referințe orfane rămase (legături polimorfe — fără protecție FK) =='
+\echo '== D. Orfani polimorfi ÎN TOATĂ BAZA (stare preexistentă, nu efectul acestui lot) =='
+-- ATENȚIE la interpretare: numără orfanii din toată baza, inclusiv cei lăsați de ștergeri
+-- anterioare făcute din interfață sau din alte scripturi. Efectul lotului curent se citește
+-- din verificarea de la finalul lui 03, care filtrează pe pm_map. O valoare nenulă aici NU
+-- înseamnă că unificarea a lăsat referințe în urmă.
 SELECT 'mail_activity' AS unde, count(*) AS orfane FROM mail_activity WHERE res_model='res.partner' AND res_id NOT IN (SELECT id FROM res_partner)
 UNION ALL SELECT 'ir_attachment', count(*) FROM ir_attachment WHERE res_model='res.partner' AND res_id NOT IN (SELECT id FROM res_partner)
 UNION ALL SELECT 'mail_message',  count(*) FROM mail_message  WHERE model='res.partner'     AND res_id NOT IN (SELECT id FROM res_partner)
@@ -86,10 +90,7 @@ SELECT p.id, p.name AS denumire_master, p.vat,
             WHEN p.name !~ ' ' AND p.name ~ '[[:lower:]][[:upper:]]'  THEN 'cuvinte lipite (import prost)'
             WHEN p.name !~ ' ' AND length(p.name) > 8                 THEN 'fără spații'
        END AS motiv,
-       -- denumirea de pe fișele absorbite, ca alternativă de corectare
-       (SELECT string_agg(DISTINCT o.name, ' | ')
-          FROM pm_map m JOIN res_partner o ON o.id = m.old_id
-         WHERE m.master_id = p.id) AS variante_absorbite
+       s.denumiri_absorbite AS variante_absorbite
 FROM pm_snapshot s JOIN res_partner p ON p.id = s.master_id
 WHERE p.name ~ '^[A-Z]{0,2}[0-9]{4,}$'
    OR (p.name !~ ' ' AND (p.name ~ '[[:lower:]][[:upper:]]' OR length(p.name) > 8))


### PR DESCRIPTION
Două defecte de raportare, găsite rulând scripturile pe baza de staging a unui client.
Ambele sunt în verificarea de după unificare — logica de merge propriu-zisă nu se schimbă.

## 1. Secțiunea E nu putea afișa denumirile absorbite

Masterul e ales după volumul de documente, nu după calitatea denumirii, așa că uneori
supraviețuiește fișa cu numele lipit la import. Secțiunea E le listează, ca să fie corectate
manual — și le arăta alături de denumirile de pe fișele absorbite, ca alternativă.

Doar că le citea printr-un JOIN pe acele fișe, care la momentul verificării sunt deja șterse.
Coloana ieșea mereu goală, exact în cazurile unde era utilă:

```
   id   |     denumire_master      | motiv                         | variante_absorbite
 727929 | MayaVirágKft             | cuvinte lipite (import prost) |
 776675 | OTPFaktoringZrtCsoportaz | cuvinte lipite (import prost) |
```

Denumirile se capturează acum în `pm_snapshot` la pasul 02, înainte de merge, și se citesc
de acolo.

## 2. Secțiunea D era etichetată înșelător

D numără orfanii polimorfi din **toată baza**, inclusiv pe cei lăsați de ștergeri anterioare
făcute din interfață sau din alte scripturi. Titlul însă se citea ca și cum ar raporta
rezultatul lotului curent.

Pe staging a afișat 835 de rânduri orfane în `mail_message` — niciunul produs de unificare.
Cifra lotului e verificarea de la finalul lui 03, care filtrează pe `pm_map` și a dat zero pe
toate cele cinci categorii. Titlul și comentariul spun acum explicit ce măsoară și ce nu.

## Context: rularea care le-a scos la iveală

Lot de 50 de grupuri, aplicat pe staging:

| Verificare | Rezultat |
|---|---|
| Fișe absorbite rămase | 0 |
| Abateri facturi / comenzi / livrări / sold | 0 din 50 de masteri |
| Referințe rămase către fișele absorbite (03) | 0 pe toate cele 5 categorii |
| Progres | 6.050 → 6.000 grupuri de duplicate |

Zero abateri înseamnă că fiecare document și fiecare leu de sold nereconciliat de pe fișele
absorbite a ajuns pe master.
