### PR TITLE
[FIX] deltatech_purchase_add_extra_line: sync extra line on write()

### DIFF
--- a/deltatech_purchase_add_extra_line/__manifest__.py
+++ b/deltatech_purchase_add_extra_line/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Purchase Add Extra Line",
     "summary": "Purchase Add Extra Line",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.3.0",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_purchase_add_extra_line/models/purchase.py
+++ b/deltatech_purchase_add_extra_line/models/purchase.py
@@ -45,6 +45,22 @@ class PurchaseOrderLine(models.Model):
             line.check_extra_product()
         return res
 
+    def write(self, vals):
+        res = super().write(vals)
+        # A quantity/price/product change saved outside the form's live onchange
+        # (inline list edit, import, RPC write) never went through
+        # `check_extra_product`, so the extra line silently kept its old
+        # quantity/price (ticket #9275). `skip_check_extra_product` guards the
+        # recursion this triggers: `check_extra_product` writes back on the
+        # extra line (and, through PTC's override, sometimes on this same line).
+        if not self.env.context.get("skip_check_extra_product") and vals.keys() & {
+            "product_qty",
+            "product_id",
+            "price_unit",
+        }:
+            self.with_context(skip_check_extra_product=True).check_extra_product()
+        return res
+
     def unlink(self):
         for line in self:
             if line.product_id.extra_product_id:

--- a/deltatech_purchase_add_extra_line/readme/HISTORY.md
+++ b/deltatech_purchase_add_extra_line/readme/HISTORY.md
@@ -1,3 +1,7 @@
+## 19.0.1.3.0
+
+- [FIX] `check_extra_product` now also runs on `write()` of `product_qty`, `product_id` or `price_unit`: previously it only ran on `create()` and on the form's live `onchange_order_line`, so a quantity change saved through an inline list edit, an import or an XML-RPC write left the extra line at its old quantity and price (ticket #9275)
+
 ## 19.0.1.2.0
 
 - [IMP] Romanian translation (`i18n/ro.po`): the group reads **Linie suplimentară** and the fields **Produs suplimentar**, **Procent suplimentar**, **Cantitate suplimentară**, instead of staying in English on a Romanian interface


### PR DESCRIPTION
## Summary
- `check_extra_product` only ran on `create()` and on the form's live `onchange_order_line`, so a quantity/price change saved through an inline list edit, an import, or an XML-RPC write left the extra line at its old quantity and price.
- `write()` on `purchase.order.line` now also triggers `check_extra_product()` when `product_qty`, `product_id` or `price_unit` change, guarded against recursion via a context flag (the method writes back on the paired extra line, and sometimes on the same line through PTC's eco-tax override).

## Context
Ticket #9275 (PTC ecovaloare): a tire quantity change on P15149/P15142 didn't re-split the eco-tax because both orders were saved through `write()` (list/RPC), never through the form onchange. Confirmed the root cause and the fix on a local copy of the client's database (`ptc19`): after the fix, the eco-tax line's quantity correctly follows the tire line's quantity on `write()`.

## Test plan
- [x] Existing module tests pass (`deltatech_purchase_add_extra_line`, 5 tests, 0 failed/error)
- [x] Reproduced on local `ptc19` copies of P15149/P15142: eco line quantity did not follow tire quantity on `write()` before the fix, and did follow it after
- [ ] Reviewer: confirm no unwanted extra recompute cycles on production-scale purchase orders (many lines, bulk import)

🤖 Generated with [Claude Code](https://claude.com/claude-code)