### PR TITLE
[FIX] deltatech_pos_stock: stock badge frozen on stale value in open sessions

### DIFF
--- a/deltatech_pos_stock/__manifest__.py
+++ b/deltatech_pos_stock/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "images": ["static/description/main_screenshot.png"],
     "name": "Deltatech POS Stock",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Point of Sale",
     "summary": "Display stock in POS",
     "author": "Terrabit, Dorin Hongu",
@@ -14,6 +14,7 @@
         "point_of_sale._assets_pos": [
             "deltatech_pos_stock/static/src/xml/product_card.xml",
             "deltatech_pos_stock/static/src/js/product_card.esm.js",
+            "deltatech_pos_stock/static/src/js/pos_stock_synchronisation.esm.js",
             "deltatech_pos_stock/static/src/css/pos_stock.css",
         ],
     },

--- a/deltatech_pos_stock/models/__init__.py
+++ b/deltatech_pos_stock/models/__init__.py
@@ -1,3 +1,4 @@
 from . import pos_config
 from . import res_config_settings
 from . import product_template
+from . import stock_quant

--- a/deltatech_pos_stock/models/product_template.py
+++ b/deltatech_pos_stock/models/product_template.py
@@ -18,3 +18,22 @@ class ProductTemplate(models.Model):
         if config.display_stock and config.warehouse_id:
             records = records.with_context(warehouse_id=config.warehouse_id.id)
         return super()._load_pos_data_read(records, config)
+
+    def _notify_pos_stock_change(self):
+        # `qty_available` e un câmp calculat, nestocat: o vânzare scrie pe stock.quant,
+        # nu pe product.template, deci write_date-ul șablonului nu se schimbă niciodată
+        # și sincronizarea normală a POS-ului (bazată pe write_date, vezi pos.load.mixin)
+        # nu retrimite niciodată stocul actualizat către sesiunile deja deschise. Împingem
+        # explicit valoarea proaspătă pe bus-ul folosit deja de core pentru sincronizarea
+        # între dispozitive (`notify_synchronisation`).
+        if not self:
+            return
+        domain = [("state", "=", "opened"), ("config_id.display_stock", "=", True)]
+        company_ids = self.mapped("company_id").ids
+        if company_ids:
+            domain.append(("company_id", "in", company_ids))
+        sessions = self.env["pos.session"].sudo().search(domain)
+        for config in sessions.config_id:
+            data = self._load_pos_data_read(self, config)
+            if data:
+                config._notify("STOCK_SYNCHRONISATION", {"product.template": data})

--- a/deltatech_pos_stock/models/stock_quant.py
+++ b/deltatech_pos_stock/models/stock_quant.py
@@ -1,0 +1,23 @@
+from odoo import api, models
+
+
+class StockQuant(models.Model):
+    _inherit = "stock.quant"
+
+    def write(self, vals):
+        # Doar `quantity` (stocul fizic) afectează `qty_available`; `reserved_quantity`
+        # nu schimbă valoarea afișată în badge-ul POS, deci nu merită să declanșeze
+        # o notificare (rezervările se schimbă mult mai des decât stocul fizic).
+        templates = self._get_pos_templates_to_notify() if "quantity" in vals else self.env["product.template"]
+        res = super().write(vals)
+        templates._notify_pos_stock_change()
+        return res
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        quants = super().create(vals_list)
+        quants.filtered("quantity")._get_pos_templates_to_notify()._notify_pos_stock_change()
+        return quants
+
+    def _get_pos_templates_to_notify(self):
+        return self.product_id.product_tmpl_id.filtered("available_in_pos")

--- a/deltatech_pos_stock/readme/HISTORY.md
+++ b/deltatech_pos_stock/readme/HISTORY.md
@@ -1,3 +1,15 @@
+## 19.0.1.1.0 (2026-08-19)
+
+- Fixed stale stock badge: `qty_available` is a non-stored computed field, so a sale (which
+  writes on `stock.quant`, not on `product.template`) never bumps the template's `write_date`.
+  The POS incremental sync filters on `write_date`, so it never re-sent the recalculated
+  quantity to sessions already open — the badge could stay frozen at a days-old value.
+- `stock.quant` now pushes a live `STOCK_SYNCHRONISATION` bus notification (reusing the same
+  `pos.bus.mixin` channel core uses for `notify_synchronisation`) whenever a product's on-hand
+  quantity changes, to every open POS session with `display_stock` enabled. The frontend
+  subscribes to it and merges the fresh `product.template` data straight into the in-memory
+  model, independent of the `write_date`-based sync.
+
 ## 19.0.1.0.0 (2026-08-14)
 
 - Migrated to Odoo 19.0.

--- a/deltatech_pos_stock/static/src/js/pos_stock_synchronisation.esm.js
+++ b/deltatech_pos_stock/static/src/js/pos_stock_synchronisation.esm.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+
+import {PosStore} from "@point_of_sale/app/services/pos_store";
+import {patch} from "@web/core/utils/patch";
+
+patch(PosStore.prototype, {
+    async processServerData() {
+        await super.processServerData(...arguments);
+        this.data.connectWebSocket("STOCK_SYNCHRONISATION", this._onStockSynchronisation.bind(this));
+    },
+
+    // Pornit din stock.quant (deltatech_pos_stock/models/stock_quant.py) de fiecare dată
+    // când se schimbă stocul fizic al unui produs vândut în POS. Fără asta, `qty_available`
+    // (câmp calculat, nestocat) rămâne blocat la valoarea cache-uită la deschiderea sesiunii,
+    // pentru că sincronizarea normală a POS-ului filtrează pe write_date, iar acesta nu se
+    // schimbă niciodată printr-o mișcare de stoc.
+    _onStockSynchronisation(data) {
+        const records = data && data["product.template"];
+        if (records && records.length) {
+            this.models.connectNewData({"product.template": records});
+        }
+    },
+});

--- a/deltatech_pos_stock/tests/test_pos_stock_badge.py
+++ b/deltatech_pos_stock/tests/test_pos_stock_badge.py
@@ -80,3 +80,90 @@ class TestPosStockBadge(TestPointOfSaleHttpCommon):
             """,
             login="pos_user",
         )
+
+    def test_stock_badge_updates_live_without_reload(self):
+        """`qty_available` is a non-stored computed field, so a stock change never bumps
+        product.template's write_date and the normal write_date-based POS sync never
+        re-sends it to an already open session. stock.quant now pushes a dedicated
+        STOCK_SYNCHRONISATION bus notification instead - this proves the badge picks up
+        a stock change made *after* the session is loaded, without any page reload."""
+        self.main_pos_config.write({"display_stock": True, "display_price": False})
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        self.main_pos_config.current_session_id.set_opening_control(0, "")
+        product = self.env["product.product"].create(
+            {
+                "name": "Live Stock POS Product",
+                "is_storable": True,
+                "available_in_pos": True,
+                "list_price": 50.0,
+            }
+        )
+        self.env["stock.quant"]._update_available_quantity(product, self.main_pos_config.warehouse_id.lot_stock_id, 10)
+        quant = self.env["stock.quant"]._gather(product, self.main_pos_config.warehouse_id.lot_stock_id)
+
+        self.browser_js(
+            self._get_url(),
+            f"""
+            (async () => {{
+                const waitFor = async (fn) => {{
+                    for (let i = 0; i < 100; i++) {{
+                        const value = fn();
+                        if (value) {{
+                            return value;
+                        }}
+                        await new Promise((r) => setTimeout(r, 200));
+                    }}
+                    return null;
+                }};
+
+                const openButton = await waitFor(() =>
+                    [...document.querySelectorAll("button, .button")].find(
+                        (el) => el.innerText.trim() === "Open Register"
+                    )
+                );
+                if (!openButton) {{
+                    console.error("could not open the register");
+                    return;
+                }}
+                openButton.click();
+
+                const pos = await waitFor(() => odoo.__WOWL_DEBUG__?.root?.env?.services?.pos);
+                const template = await waitFor(() =>
+                    pos.models["product.template"]
+                        .getAll()
+                        .find((t) => t.display_name === "Live Stock POS Product")
+                );
+                if (!template) {{
+                    console.error("product template not found in the POS session");
+                    return;
+                }}
+
+                const getQtyText = () => {{
+                    const card = document.querySelector(`article[data-product-id="${{template.id}}"]`);
+                    return card?.querySelector(".product-qty")?.innerText.trim();
+                }};
+
+                const initialQty = await waitFor(getQtyText);
+                if (initialQty !== "10") {{
+                    console.error("unexpected initial quantity in the badge: " + initialQty);
+                    return;
+                }}
+
+                // Simulate a stock change happening elsewhere (another till, a delivery,
+                // a backend inventory adjustment) while this POS session stays open.
+                await pos.data.call("stock.quant", "write", [[{quant.id}], {{"quantity": 3}}]);
+
+                const updatedQty = await waitFor(() => {{
+                    const value = getQtyText();
+                    return value === "3" ? value : null;
+                }});
+                if (updatedQty !== "3") {{
+                    console.error("badge did not update live, still showing: " + getQtyText());
+                    return;
+                }}
+
+                console.log("test successful");
+            }})();
+            """,
+            login="pos_user",
+        )


### PR DESCRIPTION
## Problem

The stock badge on the POS product card (`deltatech_pos_stock`) could stay frozen at a stale
quantity for days in an already open session, even after real sales depleted the stock.

Root cause: `qty_available` on `product.template` is a non-stored computed field. A sale writes
on `stock.quant`, not on `product.template`, so the template's `write_date` never changes. The
POS incremental sync (`pos.load.mixin`) filters strictly on `write_date > last_server_date`, so
an already open session never gets the recalculated quantity re-sent - the badge stays at
whatever value was cached when the session's data was first loaded.

Reproduced and confirmed on a production instance (Damira): the badge showed a quantity that
matched real on-hand stock from several days earlier, not the current value, even though the
POS session had been opened fresh that same day.

## Fix

`stock.quant` now pushes a live `STOCK_SYNCHRONISATION` bus notification - reusing the same
`pos.bus.mixin` channel core already uses for `pos.config.notify_synchronisation` (POS device
sync) - whenever a product's on-hand `quantity` changes, to every open POS session with
`display_stock` enabled. The frontend subscribes to this channel and merges the fresh
`product.template` data straight into the in-memory model, independent of the `write_date`-based
sync cycle.

Only `quantity` changes trigger a notification (not `reserved_quantity`), since the badge shows
on-hand stock (`qty_available`), not the forecasted/reserved quantity.

## Test plan

- [x] Fresh install on a clean database (`deltatech_pos_stock` + demo data): existing badge test
      passes unchanged.
- [x] New test `test_stock_badge_updates_live_without_reload`: opens a POS session, confirms the
      initial badge value, then changes the product's stock quantity via RPC (simulating a sale
      from another till/channel) *while the session stays open*, and asserts the badge updates
      to the new value without any page reload.
- [x] Sanity-checked the new test actually detects the regression: temporarily disabled the
      notification call and confirmed the test fails (badge stays at the old value); restored
      the fix and both tests pass again.
- [x] `pre-commit` (ruff, eslint, pylint-odoo, prettier) passes clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>