### PR TITLE
[FIX] deltatech_sale_xls: fix import crash and skipped rows

### DIFF
--- a/deltatech_sale_xls/__manifest__.py
+++ b/deltatech_sale_xls/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Sale XLS",
     "summary": "Import/export sale line from/to Excel",
     "author": "Terrabit, Voicu Stefan",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",
     "category": "Sales",

--- a/deltatech_sale_xls/models/sale_order.py
+++ b/deltatech_sale_xls/models/sale_order.py
@@ -59,8 +59,8 @@ class SaleOrderLine(models.Model):
             order = self.env["sale.order"].browse(order_id)
 
         if not order:
-            order_index = fields.index.get("order_id", False)
-            if order_index:
+            order_index = fields.index("order_id") if "order_id" in fields else False
+            if order_index is not False:
                 order_id = data[0][order_index]
                 order = self.env["sale.order"].browse(order_id)
 
@@ -73,7 +73,7 @@ class SaleOrderLine(models.Model):
                     record.append("")
 
                 if product_index != -1:
-                    for record in data:
+                    for record in list(data):
                         product_name = record[product_index]
                         product = self.env["product.product"]
                         # extrage codul din numele produsului care este intre paranteze []

--- a/deltatech_sale_xls/readme/HISTORY.md
+++ b/deltatech_sale_xls/readme/HISTORY.md
@@ -1,0 +1,8 @@
+## 19.0.1.0.1
+
+- [FIX] `sale.order.line.load()` raised `AttributeError` when importing
+  without `default_order_id`/`active_id` in context (`fields.index` is a
+  list method, not a dict)
+- [FIX] iterating over `data` while calling `data.remove(record)` skipped
+  the record right after a removed one, so some unmatched lines silently
+  passed validation


### PR DESCRIPTION
## Summary
- `sale.order.line.load()` called `fields.index.get(...)` — `fields` is a list, `.index` is a method, not a dict — raising `AttributeError` whenever the XLS import ran without `default_order_id`/`active_id` in context.
- `data.remove(record)` was called while iterating over `data`, silently skipping the row right after any removed (unmatched) row.

Found while verifying 18.0 → 19.0 alignment for the Sanodor project.

## Test plan
- [ ] Manual: import an Excel line list on an existing sale order via the "Order lines" button, with an unmatched product in the middle of the list, and confirm no row is skipped.
- [ ] Manual: import from an entry point without `default_order_id`/`active_id` in context and confirm no crash.