### PR TITLE
[FIX] deltatech_purchase_ubl: sări peste factura fantomă pe comandă neconfirmată

### DIFF
--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,12 +4,12 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "19.0.1.2.3",
+    "version": "19.0.1.2.4",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",
-    "depends": ["purchase", "stock", "account"],
+    "depends": ["purchase_stock", "account"],
     "data": [
         "views/ubl_import_wizard_views.xml",
         "security/ir.model.access.csv",

--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "19.0.1.2.2",
+    "version": "19.0.1.2.3",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",

--- a/deltatech_purchase_ubl/i18n/deltatech_purchase_ubl.pot
+++ b/deltatech_purchase_ubl/i18n/deltatech_purchase_ubl.pot
@@ -337,6 +337,14 @@ msgstr ""
 #. module: deltatech_purchase_ubl
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Vendor bill creation skipped: purchase order %(order)s is not confirmed "
+"yet, so there is nothing to invoice."
+msgstr ""
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
 msgid "Vendor bill not created: %s"
 msgstr ""
 

--- a/deltatech_purchase_ubl/i18n/ro.po
+++ b/deltatech_purchase_ubl/i18n/ro.po
@@ -331,6 +331,16 @@ msgstr ""
 
 #. module: deltatech_purchase_ubl
 #. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid ""
+"Vendor bill creation skipped: purchase order %(order)s is not confirmed "
+"yet, so there is nothing to invoice."
+msgstr ""
+"Crearea facturii de furnizor a fost sărită: comanda de achiziție %(order)s "
+"nu este încă confirmată, deci nu există nimic de facturat."
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid "Vendor bill not created: %s"
 msgstr "Factura furnizor nu a fost creată: %s"

--- a/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
+++ b/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
@@ -692,7 +692,18 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         # "Create vendor bill". The checkbox stays available to force bill creation even when
         # the source has no invoice number.
         if self.create_bill or invoice_data.get("invoice_id"):
-            if order:
+            if order and order.state not in ("purchase", "done"):
+                # A draft/unconfirmed order has qty_to_invoice = 0 on every line
+                # (purchase_order_line._compute_qty_invoiced), regardless of product_qty.
+                # action_create_invoice() would still "succeed", producing a vendor bill
+                # with every line at zero quantity/amount - a useless ghost document. This
+                # hits the SPV auto-import flow, where a purchase order can be created and
+                # attached to its XML before it is ever confirmed (tichet #9287).
+                bill_log = _(
+                    "Vendor bill creation skipped: purchase order %(order)s is not confirmed "
+                    "yet, so there is nothing to invoice."
+                ) % {"order": order.name}
+            elif order:
                 invoice_ref = invoice_data.get("invoice_id")
                 duplicate_bill = self._find_duplicate_bill(partner, invoice_ref)
                 if duplicate_bill:

--- a/deltatech_purchase_ubl/readme/HISTORY.md
+++ b/deltatech_purchase_ubl/readme/HISTORY.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [19.0.1.2.3] - 2026-08-20
+
+### Fixed
+- **Bug** (found via ticket #9287): auto-creating the vendor bill whenever the source document
+  identifies an invoice number (added in 19.0.1.2.1) ran regardless of the purchase order's
+  state. A draft/unconfirmed order has `qty_to_invoice = 0` on every line
+  (`purchase_order_line._compute_qty_invoiced` only computes a nonzero value once the order is
+  `state == "purchase"`), so `action_create_invoice()` still "succeeded" but produced a vendor
+  bill with every line at zero quantity/amount — a useless ghost document. This hit the SPV
+  auto-import flow, where a purchase order can be created and attached to its XML before it is
+  ever confirmed.
+  - `_process_invoice_data` now skips vendor bill creation (logging why) when the resolved
+    order isn't confirmed yet (`state not in ("purchase", "done")`), instead of silently
+    creating an empty bill.
+  - Added test `test_vendor_bill_skipped_when_order_not_confirmed`.
+
 ## [19.0.1.2.2] - 2026-07-18
 
 ### Fixed

--- a/deltatech_purchase_ubl/readme/HISTORY.md
+++ b/deltatech_purchase_ubl/readme/HISTORY.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [19.0.1.2.4] - 2026-08-20
+
+### Fixed
+- **Bug**: `depends` listed `purchase` + `stock` separately, but the module actually uses fields
+  defined by their glue module `purchase_stock` (`purchase.order.picking_ids`,
+  `stock.picking.purchase_id`) in `_find_receipt`/`_validate_receipt_quantities`.
+  `purchase_stock` is `auto_install=True`, and CI's test database init runs with
+  `--skip-auto-install` (Odoo ≥ 19) - so it was only ever getting installed incidentally, when
+  another module in the same CI shard happened to declare it explicitly. `depends` now lists
+  `purchase_stock` directly instead of `purchase` + `stock`.
+
 ## [19.0.1.2.3] - 2026-08-20
 
 ### Fixed

--- a/deltatech_purchase_ubl/tests/test_ubl_import.py
+++ b/deltatech_purchase_ubl/tests/test_ubl_import.py
@@ -373,6 +373,45 @@ class TestPurchaseUblImport(TransactionCase):
         self.assertEqual(inv.ref, "INV-777")
         self.assertEqual(str(inv.invoice_date), "2025-01-01")
 
+    def test_vendor_bill_skipped_when_order_not_confirmed(self):
+        """Regression test for ticket #9287: a purchase order created (and attached to its
+        XML) before it is confirmed has qty_to_invoice=0 on every line regardless of
+        product_qty (purchase_order_line._compute_qty_invoiced). Auto-creating a vendor bill
+        in that state - as the "always create when invoice_id is present" override used to do
+        unconditionally - produces a ghost bill with every line at zero quantity/amount. The
+        bill creation must be skipped instead, until the order is confirmed."""
+        xml = _xml_invoice(
+            invoice_id="INV-DRAFT-1",
+            order_ref=self.po.name,
+            lines=[
+                {
+                    "code": "VEND-DRAFT-1",
+                    "name": "Draft Order Product",
+                    "qty": "3",
+                    "price": "12.5",
+                    "line_total": "37.5",
+                }
+            ],
+        )
+        self.assertEqual(self.po.state, "draft", "sanity check: order must not be confirmed for this test")
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        wiz = Wiz.with_context(active_model="purchase.order", active_id=self.po.id).create(
+            {
+                "data_file": b64encode(xml),
+                "filename": "draft_order.xml",
+                "update_prices": True,
+                "create_bill": False,
+                "validate_receipt": False,
+                "create_missing_products": True,
+            }
+        )
+        wiz.action_import()
+
+        self.assertTrue(self.po.order_line, "lines must still be imported")
+        self.assertFalse(self.po.invoice_ids, "no vendor bill should be created on an unconfirmed order")
+        self.assertIn("Vendor bill creation skipped", wiz.log or "")
+        self.assertIn("not confirmed", wiz.log or "")
+
     def test_product_match_by_name_no_spaces(self):
         # Create a product with spaces in name
         product = self.env["product.product"].create(


### PR DESCRIPTION
## Rezumat
Descoperit în timpul verificării fix-ului pentru tichetul #9287 pe producție Damira: `_process_invoice_data` creează automat factura furnizor de fiecare dată când documentul sursă are un număr de factură (comportament din 19.0.1.2.1, ca să nu se piardă referința/data facturii dacă utilizatorul uită să bifeze „Create vendor bill"), **indiferent de starea comenzii**.

O comandă `draft` (neconfirmată) are `qty_to_invoice = 0` pe toate liniile (`purchase_order_line._compute_qty_invoiced` calculează o valoare nenulă doar când `order.state == "purchase"`), deci `action_create_invoice()` "reușește" tehnic, dar produce o factură cu toate liniile la cantitate/sumă 0 — un document fantomă, inutil.

Efect concret: fluxul de auto-import din `l10n_ro_message_spv_purchase` (tichet #9287) creează comanda de achiziție ÎNAINTE de a exista o factură, apoi atașează XML-ul — ceea ce declanșează hook-ul de import automat din acest modul, care acum (cu fix-ul de #9287) chiar rulează. Verificat manual pe producție Damira: pe o comandă nou-creată (draft), a apărut o factură furnizor draft cu 18 linii, toate la cantitate 0.

## Fix
`_process_invoice_data` sare acum peste crearea facturii (cu un mesaj explicativ în log) când comanda rezolvată nu e încă confirmată (`state not in ("purchase", "done")`).

## Teste
Test nou `test_vendor_bill_skipped_when_order_not_confirmed` — sabotat manual (fix dezactivat) pentru validare, pică exact cum reproduce bug-ul; cu fix-ul restaurat, trece. Suită completă: 29/29 teste trec, nicio regresie (toate testele existente de creare factură confirmă deja comanda înainte de import).

Legat de tichetul #9287, descoperit ca efect colateral al verificării fix-ului pe producție — nu e cauza tichetului.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>