### PR TITLE
fix(deltatech_website_short_description): repoziționează butonul Publish în button_box

### DIFF
--- a/deltatech_website_short_description/__manifest__.py
+++ b/deltatech_website_short_description/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "eCommerce Sale Short Description",
     "category": "Website",
     "summary": "eCommerce short description",
-    "version": "19.0.1.0.3",
+    "version": "19.0.1.0.4",
     "license": "OPL-1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_website_short_description/views/product_view.xml
+++ b/deltatech_website_short_description/views/product_view.xml
@@ -6,15 +6,15 @@
             <field name="model">product.template</field>
             <field name="inherit_id" ref="product.product_template_form_view" />
             <field name="arch" type="xml">
-<!--                <header position="inside">-->
-<!--                    <button-->
-<!--                    class="oe_stat_button"-->
-<!--                    name="website_publish_button"-->
-<!--                    string="Publish"-->
-<!--                    type="object"-->
-<!--                    icon="fa-globe"-->
-<!--                />-->
-<!--                </header>-->
+                <div name="button_box" position="inside">
+                    <button
+                    class="oe_stat_button"
+                    name="website_publish_button"
+                    string="Publish"
+                    type="object"
+                    icon="fa-globe"
+                />
+                </div>
                 <page name="sales" position="inside">
                     <group>
                         <group string="Website description">


### PR DESCRIPTION
## Sumar
- Butonul „Publish” (icon globe) de pe formularul de articol era adăugat via `header position="inside"`, ancoră care nu mai există în `product_template_form_view` din Odoo 19 (core a eliminat `<header>` din formular la migrarea 18→19), motiv pentru care fusese comentat.
- Repoziționat în `button_box`, alături de butonul nativ echivalent `is_published` (`website_redirect_button`) din `website_sale`.
- Bump versiune manifest `19.0.1.0.3` → `19.0.1.0.4`.

Legat de tichetul Terrabit #9294 (Damira — „nu am la nivel de articol butonul prin care adaug sau retrag un buton din magazinul online”).

## Test plan
- [ ] Upgrade modul `deltatech_website_short_description`
- [ ] Verificare vizuală: butonul „Publish” apare în button box pe formularul `product.template`
- [ ] Click pe buton comută `is_published` (Publicat/Nepublicat)