### PR TITLE
[FIX] deltatech_stock_inventory: restore the unlink() guard on stock.inventory

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "19.0.2.7.3",
+    "version": "19.0.2.7.4",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/models/stock_inventory.py
+++ b/deltatech_stock_inventory/models/stock_inventory.py
@@ -5,6 +5,8 @@ from odoo.exceptions import UserError, ValidationError
 from odoo.tools import float_compare, float_is_zero
 from odoo.tools.safe_eval import safe_eval
 
+from odoo.addons.base.models.ir_model import MODULE_UNINSTALL_FLAG
+
 
 class Inventory(models.Model):
     _name = "stock.inventory"
@@ -103,20 +105,20 @@ class Inventory(models.Model):
         default = dict(default or {}, name=name)
         return super().copy_data(default)
 
-    # def unlink(self):
-    #     for inventory in self:
-    #         if (
-    #             inventory.state not in ("draft", "cancel")
-    #             and not self.env.context.get(MODULE_UNINSTALL_FLAG, False)
-    #             and not self.env.context.get("merge_inventory", False)
-    #         ):
-    #             raise UserError(
-    #                 self.env._(
-    #                     "You can only delete a draft inventory adjustment. "
-    #                     "If the inventory adjustment is not done, you can cancel it."
-    #                 )
-    #             )
-    #     return super().unlink()
+    def unlink(self):
+        for inventory in self:
+            if (
+                inventory.state not in ("draft", "cancel")
+                and not self.env.context.get(MODULE_UNINSTALL_FLAG, False)
+                and not self.env.context.get("merge_inventory", False)
+            ):
+                raise UserError(
+                    self.env._(
+                        "You can only delete a draft inventory adjustment. "
+                        "If the inventory adjustment is not done, you can cancel it."
+                    )
+                )
+        return super().unlink()
 
     def action_validate(self):
         if not self.exists():

--- a/deltatech_stock_inventory/readme/HISTORY.md
+++ b/deltatech_stock_inventory/readme/HISTORY.md
@@ -1,3 +1,16 @@
+## 19.0.2.7.4 (2026-08-22)
+
+- The **delete guard** on inventory adjustments is active again: only adjustments
+  in *Draft* or *Cancelled* state can be deleted. An adjustment that is *In
+  Progress* or *Validated* has already generated stock moves, and deleting it
+  left those moves behind without their source document. The guard existed in
+  18.0 but had been commented out during the 19.0 port, so any adjustment could
+  be deleted regardless of its state — silently, with no warning.
+- The two documented exceptions are preserved: module uninstall
+  (`_force_unlink`) and the explicit merge of adjustments, which deletes the
+  merged (validated) documents with `merge_inventory=True` in the context after
+  moving their lines and stock moves to the resulting adjustment.
+
 ## 19.0.2.7.3 (2026-08-15)
 
 - Imp: `stock.inventory.line.partner_id` is now indexed — a foreign key to `res_partner` on a table that grows with every stock count.


### PR DESCRIPTION
## Summary
Found while re-verifying 18.0 → 19.0 alignment for the Sanodor project. The `unlink()` override on `stock.inventory` was commented out during migration, so on 19.0 any inventory adjustment can be deleted regardless of state — including a `confirm`/`done` one with stock moves already generated and validated. On 18.0, deletion was only allowed for `draft`/`cancel`; the safe alternative for a validated adjustment is to cancel it, not delete it.

Restored the guard as-is:
- `MODULE_UNINSTALL_FLAG` import is unchanged between 18.0 and 19.0 (`odoo.addons.base.models.ir_model`)
- the `merge_inventory` context exception used by `wizard/stock_inventory_merge.py` still applies correctly — lines and moves are reassigned to the merged inventory *before* the `unlink()` call, so no traceability is lost there

## Test plan
- [ ] `./odoo/odoo-bin -c odoo.conf -d test19 -u deltatech_stock_inventory --test-tags=deltatech_stock_inventory --stop-after-init`
- [ ] Manual: try to delete a `done` inventory adjustment directly, confirm it's blocked with the expected message
- [ ] Manual: merge two `done` inventory adjustments via the existing wizard, confirm it still succeeds