### PR TITLE
[FIX] deltatech_purchase_ubl: stop silent duplicate products, add mapping preview

### DIFF
--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "19.0.1.2.4",
+    "version": "19.0.1.3.0",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",

--- a/deltatech_purchase_ubl/i18n/ro.po
+++ b/deltatech_purchase_ubl/i18n/ro.po
@@ -404,3 +404,113 @@ msgstr ""
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid "untaxed total"
 msgstr "total fără tva"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard__state__preview
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "Preview"
+msgstr "Previzualizare"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__line_ids
+msgid "Preview Lines"
+msgstr "Linii previzualizare"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model,name:deltatech_purchase_ubl.model_purchase_ubl_import_wizard_line
+msgid "UBL Import Preview Line"
+msgstr "Linie previzualizare import UBL"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__code
+msgid "Supplier Code"
+msgstr "Cod furnizor"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__barcode
+msgid "Barcode"
+msgstr "Cod de bare"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__name
+msgid "Description (XML)"
+msgstr "Descriere (XML)"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__qty
+msgid "Quantity"
+msgstr "Cantitate"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__price
+msgid "Unit Price"
+msgstr "Preț unitar"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__product_id
+msgid "Product"
+msgstr "Produs"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__matched_product_id
+msgid "Matched Product"
+msgstr "Produs potrivit"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__match_type
+msgid "Match Type"
+msgstr "Tip potrivire"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard_line__match_type__code
+msgid "By supplier code"
+msgstr "După cod furnizor"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard_line__match_type__barcode
+msgid "By barcode"
+msgstr "După cod de bare"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard_line__match_type__name
+msgid "By name"
+msgstr "După nume"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard_line__match_type__manual
+msgid "Chosen manually"
+msgstr "Ales manual"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields.selection,name:deltatech_purchase_ubl.selection__purchase_ubl_import_wizard_line__match_type__none
+msgid "Not found"
+msgstr "Negăsit"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__wizard_id
+msgid "Wizard"
+msgstr "Asistent"
+
+#. module: deltatech_purchase_ubl
+#: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard_line__sequence
+msgid "Sequence"
+msgstr "Secvență"
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid "<i class=\"fa fa-info-circle me-1\" title=\"Info\"/>"
+msgstr "<i class=\"fa fa-info-circle me-1\" title=\"Info\"/>"
+
+#. module: deltatech_purchase_ubl
+#: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
+msgid ""
+"Green lines matched by supplier code or barcode; yellow lines matched only "
+"by name — double-check them; red lines have no match and a NEW product "
+"will be created for them (if the option is enabled). You can pick a "
+"different product on any line before importing."
+msgstr ""
+"Liniile verzi au fost potrivite după codul de furnizor sau codul de bare; "
+"liniile galbene au fost potrivite doar după nume — verificați-le; liniile "
+"roșii nu au nicio potrivire și pentru ele se va crea un produs NOU (dacă "
+"opțiunea este activată). Puteți alege un alt produs pe orice linie înainte "
+"de import."

--- a/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
+++ b/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
@@ -12,7 +12,7 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
     _description = "Common matching/bill-creation logic for purchase invoice import wizards"
 
     state = fields.Selection(
-        [("draft", "Draft"), ("done", "Done")],
+        [("draft", "Draft"), ("preview", "Preview"), ("done", "Done")],
         default="draft",
         readonly=True,
     )
@@ -274,46 +274,57 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         return order, partner, vat_mismatch_warning
 
     def _match_product(self, supplier, code, name, barcode=None):
+        return self._match_product_detailed(supplier, code, name, barcode=barcode)[0]
+
+    def _match_product_detailed(self, supplier, code, name, barcode=None):
+        """Same matching as _match_product, but also reports HOW the product was found:
+        ("code" - supplier code/internal reference, "barcode", "name", or False when no
+        match). The match type feeds the wizard preview, where code/barcode matches are
+        trustworthy (green), name matches deserve a human look (yellow) and unmatched
+        lines would spawn a new product (red)."""
         Product = self.env["product.product"]
         SupplierInfo = self.env["product.supplierinfo"]
-        product = False
         code = (code or "").strip()
         barcode = (barcode or "").strip()
 
         # Try explicit barcode from source document first
         if barcode:
             product = Product.search([("barcode", "=", barcode)], limit=1)
+            if product:
+                return product, "barcode"
 
-        if not product and supplier and code:
+        if supplier and code:
             domain = [("partner_id", "=", supplier.id), ("product_code", "=ilike", code)]
             sinfo = SupplierInfo.search(domain, limit=1)
             if sinfo:
-                if sinfo.product_id:
-                    product = sinfo.product_id
-                else:
-                    product = sinfo.product_tmpl_id.product_variant_id
+                product = sinfo.product_id or sinfo.product_tmpl_id.product_variant_id
+                if product:
+                    return product, "code"
 
-        if not product and supplier and name:
+        if supplier and name:
             domain = [("partner_id", "=", supplier.id), ("product_name", "=ilike", name)]
             sinfo = SupplierInfo.search(domain, limit=1)
             if sinfo:
-                if sinfo.product_id:
-                    product = sinfo.product_id
-                else:
-                    product = sinfo.product_tmpl_id.product_variant_id
+                product = sinfo.product_id or sinfo.product_tmpl_id.product_variant_id
+                if product:
+                    return product, "name"
 
-        if not product and code:
+        if code:
             product = Product.search([("default_code", "=ilike", code)], limit=1)
+            if product:
+                return product, "code"
 
         # Fallback: sometimes supplier code is actually barcode digits
-        if not product and code and code.isdigit():
+        if code and code.isdigit():
             product = Product.search([("barcode", "=", code)], limit=1)
-        if not product and name:
+            if product:
+                return product, "barcode"
+        if name:
             products = Product.search([("name", "=ilike", name)], limit=2)
             if len(products) == 1:
-                product = products[0]
+                return products[0], "name"
 
-        if not product and name:
+        if name:
             name_without_spaces = name.replace(" ", "")
             lang = self.env.context.get("lang") or self.env.user.lang
             self.env.cr.execute(
@@ -329,11 +340,14 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
             product_id = self.env.cr.fetchone()
             if product_id:
                 product_template = self.env["product.template"].browse(product_id[0])
-                product = product_template.product_variant_id
+                return product_template.product_variant_id, "name"
 
-        return product
+        return Product.browse(), False
 
     def _match_product_on_order(self, order, partner, code, name, barcode=None):
+        return self._match_product_on_order_detailed(order, partner, code, name, barcode=barcode)[0]
+
+    def _match_product_on_order_detailed(self, order, partner, code, name, barcode=None):
         """
         Restrict product matching to products present on the given purchase order.
         Matching priority within the order:
@@ -342,9 +356,12 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         3) Product default_code
         4) Product barcode (when code itself is numeric)
         5) Product name exact match
+
+        Returns (product, match_type) like _match_product_detailed.
         """
+        Product = self.env["product.product"]
         if not order:
-            return False
+            return Product.browse(), False
         code = (code or "").strip()
         barcode = (barcode or "").strip()
         # Build quick access lists
@@ -354,7 +371,7 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         if barcode:
             for line in order_lines:
                 if (line.product_id.barcode or "").strip() == barcode:
-                    return line.product_id
+                    return line.product_id, "barcode"
 
         # 2) Supplier code for this vendor
         if partner and code:
@@ -362,24 +379,24 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
                 tmpl = line.product_id.product_tmpl_id
                 for sinfo in tmpl.seller_ids:
                     if sinfo.partner_id.id == partner.id and (sinfo.product_code or "").strip() == code:
-                        return line.product_id
+                        return line.product_id, "code"
         # 3) default_code within order lines
         if code:
             for line in order_lines:
                 if (line.product_id.default_code or "").strip() == code:
-                    return line.product_id
+                    return line.product_id, "code"
 
         # 4) barcode when code is numeric
         if code and code.isdigit():
             for line in order_lines:
                 if (line.product_id.barcode or "").strip() == code:
-                    return line.product_id
+                    return line.product_id, "barcode"
         # 5) product name exact match
         if name:
             for line in order_lines:
                 if (line.product_id.name or "").strip() == (name or "").strip():
-                    return line.product_id
-        return False
+                    return line.product_id, "name"
+        return Product.browse(), False
 
     def _update_supplier_price(self, supplier, product, code, price, currency):
         SupplierInfo = self.env["product.supplierinfo"]
@@ -568,7 +585,7 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
 
         return new_invoice
 
-    def _process_invoice_data(self, invoice_data):
+    def _process_invoice_data(self, invoice_data, product_map=None):
         """Generic processing shared by all invoice import wizards, regardless of the
         source document format (UBL XML, Marso PDF, ...). Expects invoice_data as a dict
         shaped like the return value of _parse_source():
@@ -580,6 +597,12 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
             "line_extension_amount", "tax_exclusive_amount", "tax_inclusive_amount",
             "payable_amount", "tax_amount",
         }
+
+        product_map, when given, is a manual mapping coming from the wizard preview step:
+        {source line index: product.product record (possibly empty)}. An entry present in
+        the map REPLACES automatic matching for that line — the user saw the preview and
+        either confirmed the match or picked another product; an empty product means
+        "leave unmatched" (still subject to create_missing_products).
         """
         self.ensure_one()
 
@@ -590,9 +613,11 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
         updated = []
         not_found = []
         created = []
-        for ln in invoice_data["lines"]:
-            # If order has lines, restrict match to the order; otherwise match globally
-            if order and order.order_line:
+        for index, ln in enumerate(invoice_data["lines"]):
+            if product_map is not None and index in product_map:
+                product = product_map[index]
+            elif order and order.order_line:
+                # If order has lines, restrict match to the order; otherwise match globally
                 product = self._match_product_on_order(
                     order, partner, ln.get("code"), ln.get("name"), ln.get("barcode")
                 )

--- a/deltatech_purchase_ubl/models/purchase_order.py
+++ b/deltatech_purchase_ubl/models/purchase_order.py
@@ -46,7 +46,13 @@ class PurchaseOrder(models.Model):
                 if not is_ubl:
                     continue
 
-                # Run the wizard headlessly in PO context
+                # Run the wizard headlessly in PO context.
+                # `purchase_ubl_no_new_products` in context lets an automated caller (no human
+                # reviewing the import as it happens) opt out of silent product creation when
+                # the source document doesn't identify the product unambiguously (missing
+                # supplier code, ambiguous name match) — see l10n_ro_message_spv_purchase,
+                # which sets this when it auto-attaches an SPV XML on a freshly created PO.
+                create_missing_products = not self.env.context.get("purchase_ubl_no_new_products")
                 try:
                     wiz = self.env["purchase.ubl.import.wizard"].create(
                         {
@@ -56,6 +62,7 @@ class PurchaseOrder(models.Model):
                             "update_prices": True,
                             "validate_receipt": True,
                             "create_bill": True,
+                            "create_missing_products": create_missing_products,
                         }
                     )
                     wiz = wiz.with_context(active_model="purchase.order", active_id=order.id)

--- a/deltatech_purchase_ubl/readme/HISTORY.md
+++ b/deltatech_purchase_ubl/readme/HISTORY.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [19.0.1.3.0] - 2026-08-24
+
+### Added
+- **Mapping preview in the import wizard** (ticket #9315): the interactive flow is now
+  two-step — "Preview" parses the XML and shows one line per invoice line with the product
+  the matcher found and how it found it, color-coded: green = matched by supplier code or
+  barcode (trustworthy), yellow = matched only by name (double-check), red = no match (a new
+  product would be created). The user can pick a different product on any line before
+  confirming the import; manual choices override automatic matching
+  (`_process_invoice_data(product_map=...)`). The headless entry point `action_import` is
+  unchanged, so automated callers keep working.
+
+### Fixed
+- **Bug** (ticket #9315): `_process_attachments_for_post` always ran the headless UBL import
+  with `create_missing_products=True`. This is fine for the interactive wizard, where a user
+  reviews what gets created, but it's also the only entry point for XML attachments posted by
+  automated callers (e.g. `l10n_ro_message_spv_purchase`, since ticket #9287 started attaching
+  the SPV XML on purchase orders created before the vendor bill exists). When the source invoice
+  line has no supplier product code and its name doesn't match an existing product exactly, the
+  headless import silently created a duplicate product with no one reviewing it.
+  `_process_attachments_for_post` now honors a `purchase_ubl_no_new_products` context key: when
+  set, the headless import runs with `create_missing_products=False` and leaves unmatched lines
+  in the wizard's "unmatched products" log instead of creating a product.
+
 ## [19.0.1.2.4] - 2026-08-20
 
 ### Fixed

--- a/deltatech_purchase_ubl/security/ir.model.access.csv
+++ b/deltatech_purchase_ubl/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_purchase_ubl_import_wizard,access_purchase_ubl_import_wizard,model_purchase_ubl_import_wizard,base.group_user,1,1,1,1
+access_purchase_ubl_import_wizard_line,access_purchase_ubl_import_wizard_line,model_purchase_ubl_import_wizard_line,base.group_user,1,1,1,1

--- a/deltatech_purchase_ubl/tests/test_process_attachments.py
+++ b/deltatech_purchase_ubl/tests/test_process_attachments.py
@@ -131,3 +131,29 @@ class TestProcessAttachmentsForPost(TransactionCase):
         # A log message should have been posted on the PO
         last_msg = self.po.message_ids.sorted(key=lambda m: m.id)[-1] if self.po.message_ids else False
         self.assertTrue(last_msg, "A log message should be posted on the PO")
+
+    def test_auto_import_does_not_create_product_with_no_new_products_context(self):
+        """Ticket #9315: an automated caller (e.g. l10n_ro_message_spv_purchase attaching an
+        SPV XML on a PO created before the vendor bill) must be able to opt out of silent
+        product creation when the invoice line has no supplier code and no exact name match —
+        the line should be reported as unmatched instead of spawning a duplicate product."""
+        xml = _xml_invoice(order_ref=self.po.name)
+        att = self.env["ir.attachment"].create(
+            {
+                "name": "invoice_attach_no_new_products.xml",
+                "datas": b64encode(xml),
+                "mimetype": "application/xml",
+                "res_model": "purchase.order",
+                "res_id": self.po.id,
+            }
+        )
+
+        products_before = self.env["product.product"].search_count([])
+        self.po.with_context(purchase_ubl_no_new_products=True)._process_attachments_for_post([], [att.id], {})
+
+        self.assertFalse(self.po.order_line, "No order line should be created when no product could be matched")
+        self.assertEqual(
+            self.env["product.product"].search_count([]),
+            products_before,
+            "No new product should have been created",
+        )

--- a/deltatech_purchase_ubl/tests/test_ubl_import.py
+++ b/deltatech_purchase_ubl/tests/test_ubl_import.py
@@ -1235,3 +1235,80 @@ class TestPurchaseUblImport(TransactionCase):
         wiz = Wiz.new({})
         action = wiz.action_view_vendor_bill()
         self.assertEqual(action, {"type": "ir.actions.act_window_close"})
+
+    def _make_preview_wizard(self, xml_bytes, order):
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        return Wiz.with_context(active_model="purchase.order", active_id=order.id).create(
+            {
+                "data_file": b64encode(xml_bytes),
+                "filename": "preview.xml",
+                "update_prices": False,
+                "create_bill": False,
+                "validate_receipt": False,
+                "create_missing_products": True,
+            }
+        )
+
+    def test_preview_reports_match_types(self):
+        """Ticket #9315: the preview step shows how each line was matched — supplier code
+        (green), name only (yellow), or not at all (red, would create a new product)."""
+        by_code = self.env["product.product"].create({"name": "Preview By Code", "type": "consu"})
+        self.env["product.supplierinfo"].create(
+            {
+                "partner_id": self.vendor.id,
+                "product_tmpl_id": by_code.product_tmpl_id.id,
+                "product_id": by_code.id,
+                "product_code": "PRV-CODE-1",
+            }
+        )
+        self.env["product.product"].create({"name": "Preview By Name", "type": "consu"})
+
+        xml = _xml_invoice(
+            order_ref=self.po.name,
+            lines=[
+                {"code": "PRV-CODE-1", "name": "Alt nume la furnizor", "qty": "1", "price": "10", "line_total": "10"},
+                {"code": "", "name": "Preview By Name", "qty": "2", "price": "20", "line_total": "40"},
+                {"code": "", "name": "Produs Inexistent Preview", "qty": "3", "price": "30", "line_total": "90"},
+            ],
+        )
+        wiz = self._make_preview_wizard(xml, self.po)
+        wiz.action_preview()
+
+        self.assertEqual(wiz.state, "preview")
+        self.assertEqual(len(wiz.line_ids), 3)
+        lines = wiz.line_ids.sorted("sequence")
+        self.assertEqual(lines[0].match_type, "code")
+        self.assertEqual(lines[0].product_id, by_code)
+        self.assertEqual(lines[1].match_type, "name")
+        self.assertEqual(lines[1].product_id.name, "Preview By Name")
+        self.assertEqual(lines[2].match_type, "none")
+        self.assertFalse(lines[2].product_id)
+
+    def test_preview_manual_mapping_overrides_matching_and_avoids_new_product(self):
+        """Ticket #9315: the user can pick a product manually on an unmatched preview line;
+        the import then uses that product instead of creating a new one."""
+        manual_product = self.env["product.product"].create({"name": "Produs Existent Cu Alt Nume", "type": "consu"})
+        xml = _xml_invoice(
+            order_ref=self.po.name,
+            lines=[
+                {"code": "", "name": "Nume Diferit Din Factura", "qty": "5", "price": "40", "line_total": "200"},
+            ],
+        )
+        wiz = self._make_preview_wizard(xml, self.po)
+        wiz.action_preview()
+        line = wiz.line_ids
+        self.assertEqual(line.match_type, "none")
+
+        products_before = self.env["product.product"].search_count([])
+        line.product_id = manual_product
+        wiz.action_confirm_import()
+
+        self.assertEqual(
+            self.env["product.product"].search_count([]),
+            products_before,
+            "manual mapping must prevent the creation of a new product",
+        )
+        pol = self.po.order_line.filtered(lambda l: l.product_id == manual_product)
+        self.assertTrue(pol, "the order line must use the manually chosen product")
+        self.assertAlmostEqual(pol.product_qty, 5.0, places=4)
+        self.assertAlmostEqual(pol.price_unit, 40.0, places=2)

--- a/deltatech_purchase_ubl/views/ubl_import_wizard_views.xml
+++ b/deltatech_purchase_ubl/views/ubl_import_wizard_views.xml
@@ -59,6 +59,32 @@
                 </group>
                 </group>
 
+                <!-- Preview: product mapping review -->
+                <div class="alert alert-info mb-2" role="alert" invisible="state != 'preview'">
+                    <i class="fa fa-info-circle me-1" title="Info" />
+                    <span>Green lines matched by supplier code or barcode; yellow lines matched only by name — double-check them; red lines have no match and a NEW product will be created for them (if the option is enabled). You can pick a different product on any line before importing.</span>
+                </div>
+                <field name="line_ids" nolabel="1" invisible="state != 'preview'">
+                    <list
+                        editable="bottom"
+                        create="false"
+                        delete="false"
+                        decoration-success="match_type in ('code', 'barcode')"
+                        decoration-warning="match_type == 'name'"
+                        decoration-danger="match_type == 'none'"
+                    >
+                        <field name="sequence" column_invisible="1" />
+                        <field name="matched_product_id" column_invisible="1" />
+                        <field name="code" />
+                        <field name="barcode" optional="hide" />
+                        <field name="name" />
+                        <field name="qty" />
+                        <field name="price" />
+                        <field name="product_id" />
+                        <field name="match_type" />
+                    </list>
+                </field>
+
                 <!-- Done: result -->
                 <separator string="Result" invisible="state != 'done'" />
                 <field name="log_html" nolabel="1" readonly="1" invisible="state != 'done'" />
@@ -68,11 +94,18 @@
 
                 <footer>
                     <button
-                        name="action_import"
+                        name="action_preview"
+                        type="object"
+                        string="Preview"
+                        class="btn-primary"
+                        invisible="state != 'draft'"
+                    />
+                    <button
+                        name="action_confirm_import"
                         type="object"
                         string="Import"
                         class="btn-primary"
-                        invisible="state != 'draft'"
+                        invisible="state != 'preview'"
                     />
                     <button
                         name="action_view_vendor_bill"

--- a/deltatech_purchase_ubl/wizard/ubl_import_wizard.py
+++ b/deltatech_purchase_ubl/wizard/ubl_import_wizard.py
@@ -25,6 +25,7 @@ class PurchaseUblImportWizard(models.TransientModel):
     data_file = fields.Binary(string="XML File", required=True)
     filename = fields.Char(string="Filename")
     total_check_warning = fields.Text(compute="_compute_total_check_warning")
+    line_ids = fields.One2many("purchase.ubl.import.wizard.line", "wizard_id", string="Preview Lines")
 
     # ------------------------------------------------------------
     # Helpers specific to the UBL XML format
@@ -215,9 +216,108 @@ class PurchaseUblImportWizard(models.TransientModel):
         }
 
     def action_import(self):
+        """Direct, headless import — kept for automated callers
+        (purchase.order._process_attachments_for_post). Interactive users go through
+        action_preview + action_confirm_import instead, where they can review and fix
+        the product mapping before anything is written."""
         self.ensure_one()
         if not self.data_file:
             raise UserError(_("Please select an XML file."))
         content = base64.b64decode(self.data_file)
         invoice_xml = self._parse_xml(content)
         return self._process_invoice_data(invoice_xml)
+
+    def action_preview(self):
+        """Parse the XML and show the mapping preview: one line per invoice line, with
+        the product the matcher found and how it found it (code/barcode = green, name =
+        yellow, nothing = red → a new product would be created). The user can override
+        the product on any line before confirming the import."""
+        self.ensure_one()
+        if not self.data_file:
+            raise UserError(_("Please select an XML file."))
+        content = base64.b64decode(self.data_file)
+        invoice_data = self._parse_xml(content)
+        order, partner, _warning = self._resolve_order_and_partner(invoice_data)
+
+        line_vals = []
+        for index, ln in enumerate(invoice_data["lines"]):
+            if order and order.order_line:
+                product, match_type = self._match_product_on_order_detailed(
+                    order, partner, ln.get("code"), ln.get("name"), ln.get("barcode")
+                )
+            else:
+                product, match_type = self._match_product_detailed(
+                    partner, ln.get("code"), ln.get("name"), ln.get("barcode")
+                )
+            line_vals.append(
+                (
+                    0,
+                    0,
+                    {
+                        "sequence": index,
+                        "code": ln.get("code"),
+                        "barcode": ln.get("barcode"),
+                        "name": ln.get("name"),
+                        "qty": ln.get("qty", 0.0),
+                        "price": ln.get("price", 0.0),
+                        "product_id": product.id if product else False,
+                        "matched_product_id": product.id if product else False,
+                        "match_type": match_type or "none",
+                    },
+                )
+            )
+        self.write({"line_ids": [(5, 0, 0)] + line_vals, "state": "preview"})
+        return self._reopen()
+
+    def action_confirm_import(self):
+        """Run the import using the product mapping reviewed/adjusted in the preview."""
+        self.ensure_one()
+        if not self.data_file:
+            raise UserError(_("Please select an XML file."))
+        content = base64.b64decode(self.data_file)
+        invoice_data = self._parse_xml(content)
+        product_map = {line.sequence: line.product_id for line in self.line_ids}
+        return self._process_invoice_data(invoice_data, product_map=product_map)
+
+    def _reopen(self):
+        return {
+            "type": "ir.actions.act_window",
+            "res_model": self._name,
+            "res_id": self.id,
+            "view_mode": "form",
+            "target": "new",
+        }
+
+
+class PurchaseUblImportWizardLine(models.TransientModel):
+    _name = "purchase.ubl.import.wizard.line"
+    _description = "UBL Import Preview Line"
+    _order = "sequence, id"
+
+    wizard_id = fields.Many2one("purchase.ubl.import.wizard", required=True, ondelete="cascade")
+    sequence = fields.Integer()
+    code = fields.Char(string="Supplier Code", readonly=True)
+    barcode = fields.Char(string="Barcode", readonly=True)
+    name = fields.Char(string="Description (XML)", readonly=True)
+    qty = fields.Float(string="Quantity", readonly=True)
+    price = fields.Float(string="Unit Price", readonly=True)
+    product_id = fields.Many2one("product.product", string="Product")
+    # The product the matcher proposed, kept to tell a manual override apart from the
+    # automatic match when the user edits product_id in the preview.
+    matched_product_id = fields.Many2one("product.product", readonly=True)
+    match_type = fields.Selection(
+        [
+            ("code", "By supplier code"),
+            ("barcode", "By barcode"),
+            ("name", "By name"),
+            ("manual", "Chosen manually"),
+            ("none", "Not found"),
+        ],
+        readonly=True,
+    )
+
+    @api.onchange("product_id")
+    def _onchange_product_id(self):
+        for line in self:
+            if line.product_id and line.product_id != line.matched_product_id:
+                line.match_type = "manual"


### PR DESCRIPTION
## Summary
- Ticket #9315 (Romchim): the headless UBL import triggered automatically by `_process_attachments_for_post` always ran with `create_missing_products=True`, same as the interactive wizard — but with no human reviewing the result. Since the #9287 fix started attaching the SPV XML on purchase orders created *before* the vendor bill exists, this path started firing for that scenario too, and silently created duplicate products whenever the invoice line had no supplier code and its name didn't match an existing product exactly. Confirmed directly on Romchim production: 3 orphan duplicate products created since the #9287 rollout, none used on any order/invoice line.
- `_process_attachments_for_post` now honors a `purchase_ubl_no_new_products` context key — when set (by `l10n_ro_message_spv_purchase`, companion PR on `dhongu/l10n-romania`), the headless run forces `create_missing_products=False`; the unmatched line is left in the wizard's log instead of spawning a product.
- Added a **Preview** step to the interactive wizard: it parses the XML and shows one line per invoice line with the matched product and how it was matched — green (supplier code/barcode), yellow (name only, worth a second look), red (no match, would create a new product). The user can pick a different product on any line before confirming the import.

## Test plan
- [x] `deltatech_purchase_ubl` test suite: 36/36 passing, including 3 new tests (headless no-new-products guard, preview match-type reporting, manual mapping override).
- [x] Companion `l10n_ro_message_spv_purchase` suite: 38/38 passing after wiring the context flag.
- [x] `_match_product`/`_match_product_on_order` keep their exact original signature and behavior (verified via existing tests unchanged); new `_detailed` variants used only by the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)