### PR TITLE
[FIX] deltatech_rpc_audit: XML-RPC crashes when an ORM method returns None

### DIFF
--- a/deltatech_rpc_audit/__manifest__.py
+++ b/deltatech_rpc_audit/__manifest__.py
@@ -5,7 +5,7 @@
     "images": ["static/description/main_screenshot.png"],
     "name": "RPC Audit Log",
     "summary": "Log XML-RPC / JSON-RPC calls with the real client IP",
-    "version": "19.0.1.2.0",
+    "version": "19.0.1.2.1",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Technical",

--- a/deltatech_rpc_audit/controllers/rpc.py
+++ b/deltatech_rpc_audit/controllers/rpc.py
@@ -236,6 +236,13 @@ class AuditXMLRPC(XMLRPC):
         params, method = xmlrpc.client.loads(data, use_datetime=True)
         _log_rpc_call(service, method, params)
         result = dispatch_rpc(service, method, params)
+        if result is None:
+            # A handful of ORM methods (e.g. account.move.line.reconcile()
+            # when there is nothing to reconcile) legitimately return None.
+            # XML-RPC's marshaller is built with allow_none=False, so core
+            # itself would raise "cannot marshal None" here; coerce to False
+            # the same way JSON-RPC clients already expect a "no result".
+            result = False
         return dumps((result,))
 
 

--- a/deltatech_rpc_audit/readme/HISTORY.md
+++ b/deltatech_rpc_audit/readme/HISTORY.md
@@ -1,5 +1,13 @@
 # History
 
+## 19.0.1.2.1 (2026-08-25)
+
+- Fix: coerce a `None` XML-RPC result to `False` before marshalling. A handful of
+  ORM methods (e.g. `account.move.line.reconcile()` when there is nothing to
+  reconcile) legitimately return `None`; core's own marshaller is built with
+  `allow_none=False`, so the call was crashing with `TypeError: cannot marshal
+  None unless allow_none is enabled` instead of returning a normal result.
+
 ## 19.0.1.2.0 (2026-08-14)
 
 - Add: the modern `/json/2/<model>/<method>` endpoint is audited too. The legacy


### PR DESCRIPTION
## Summary
- `account.move.line.reconcile()` (and other core ORM methods) can legitimately return `None`.
- XML-RPC's marshaller is built with `allow_none=False`, so `dumps()` raised `TypeError: cannot marshal None unless allow_none is enabled` instead of returning a normal result to the client.
- `AuditXMLRPC._xmlrpc` now coerces a `None` result to `False` before marshalling, matching what JSON-RPC clients already expect for "no result".

## Test plan
- [ ] Call an XML-RPC method whose ORM method returns `None` (e.g. `account.move.line.reconcile()` with nothing to reconcile) and confirm it returns `False` instead of a 500.
- [ ] Confirm normal XML-RPC calls (non-`None` results) are unaffected.