### PR TITLE
[IMP] deltatech_actions: enable/disable cleanup crons from Settings too

### DIFF
--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.2.0",
+    "version": "19.0.0.3.0",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/models/res_config_settings.py
+++ b/deltatech_actions/models/res_config_settings.py
@@ -2,11 +2,53 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
-from odoo import fields, models
+from odoo import api, fields, models
+
+# Field name -> xmlid of the ir.cron it enables/disables. This settings screen
+# is meant to be the ONLY place these crons get turned on: they ship
+# active=False in data/ir_cron_data.xml, and toggling one of these fields
+# writes ir.cron.active directly, instead of requiring a trip to
+# Settings > Technical > Automation > Scheduled Actions.
+CRON_ACTIVE_FIELDS = {
+    "dt_actions_xml_active": "deltatech_actions.ir_cron_delete_xml_attachments",
+    "dt_actions_invoice_pdf_active": "deltatech_actions.ir_cron_delete_pdf_attachments_invoice",
+    "dt_actions_sale_pdf_active": "deltatech_actions.ir_cron_delete_pdf_attachments_sale_order",
+    "dt_actions_picking_pdf_active": "deltatech_actions.ir_cron_delete_pdf_attachments_stock_picking",
+    "dt_actions_messages_active": "deltatech_actions.ir_cron_delete_mail_messages",
+    "dt_actions_merge_contacts_active": "deltatech_actions.ir_cron_merge_contacts",
+    "dt_actions_merge_companies_active": "deltatech_actions.ir_cron_merge_companies",
+    "dt_actions_reorder_rules_active": "deltatech_actions.ir_cron_create_missing_reordering_rules",
+    "dt_actions_normalize_names_active": "deltatech_actions.cron_normalize_company_names",
+}
 
 
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
+
+    dt_actions_xml_active = fields.Boolean(string="Enable duplicate XML attachments cleanup")
+    dt_actions_invoice_pdf_active = fields.Boolean(string="Enable invoice PDF cleanup")
+    dt_actions_sale_pdf_active = fields.Boolean(string="Enable sale order PDF cleanup")
+    dt_actions_picking_pdf_active = fields.Boolean(string="Enable AWB label cleanup")
+    dt_actions_messages_active = fields.Boolean(string="Enable old messages cleanup")
+    dt_actions_merge_contacts_active = fields.Boolean(string="Enable duplicate contacts merge")
+    dt_actions_merge_companies_active = fields.Boolean(string="Enable duplicate companies merge")
+    dt_actions_reorder_rules_active = fields.Boolean(string="Enable missing reordering rules cron")
+    dt_actions_normalize_names_active = fields.Boolean(string="Enable company name normalization")
+
+    @api.model
+    def get_values(self):
+        res = super().get_values()
+        for field_name, xmlid in CRON_ACTIVE_FIELDS.items():
+            cron = self.env.ref(xmlid, raise_if_not_found=False)
+            res[field_name] = bool(cron and cron.active)
+        return res
+
+    def set_values(self):
+        super().set_values()
+        for field_name, xmlid in CRON_ACTIVE_FIELDS.items():
+            cron = self.env.ref(xmlid, raise_if_not_found=False)
+            if cron and cron.active != self[field_name]:
+                cron.sudo().active = self[field_name]
 
     # -- Duplicate XML attachments (account_move.cron_clean_xml_attachments) --
     dt_actions_xml_limit = fields.Integer(

--- a/deltatech_actions/readme/CONFIGURE.md
+++ b/deltatech_actions/readme/CONFIGURE.md
@@ -1,11 +1,14 @@
-All scheduled actions provided by this module are **disabled by default**, and by default run in
-**dry mode** (`dry_run`), meaning they only log what would be deleted without making any changes.
+All scheduled actions provided by this module are **disabled by default** (`active=False` on the
+underlying `ir.cron` record, set once at install and never reset on upgrade), and the ones that
+delete data also default to **dry mode** (`dry_run`), meaning they only log what would be deleted
+without making any changes.
 
-Their parameters live in **Settings > General Settings > Database Cleanup** (a dedicated app
-section, visible to system administrators) — nothing needs to be edited in the cron's code field
-any more. Enabling a scheduled action itself is still done from
-**Settings > Technical > Automation > Scheduled Actions**: review the parameters in the settings
-screen first, switch its "Dry run" toggle off, then enable the corresponding scheduled action.
+Everything — including turning a cron **on** — lives in **Settings > General Settings > Database
+Cleanup** (a dedicated app section, visible to system administrators). Each block has its own
+"Enabled" toggle, wired directly to that cron's `active` field: this settings screen is the
+intended single place to activate any of them, instead of hunting down the matching entry in
+Settings > Technical > Automation > Scheduled Actions. Review a block's parameters and switch its
+"Dry run" off *before* enabling it.
 
 ## Duplicate XML attachments
 
@@ -72,16 +75,16 @@ built-in `base.partner.merge.automatic.wizard`.
 Settings: contact groups per run (default `10`), company groups per run (default `10`). These two
 crons perform the merge directly — there is no dry-run mode.
 
-## Create missing reordering rules (0/0)
+## Missing reordering rules
 
 Model: `product.product`. Creates stock reordering rules for storable products that have none.
-Requires the `deltatech_auto_reorder_rule` module to be installed. No configurable parameters.
+Requires the `deltatech_auto_reorder_rule` module to be installed. Only setting: Enabled.
 
 ## Normalize company names
 
 Model: `res.partner`. Standardizes legal-form suffixes in company names
 (e.g. `srl` → `S.R.L.`, `sa` → `S.A.`, `pfa` → `P.F.A.`, `ii` → `I.I.`).
-Processes up to 500 records per cron run. No configurable parameters.
+Processes up to 500 records per cron run. Only setting: Enabled.
 
 ## Force-cancel server action
 

--- a/deltatech_actions/tests/test_cron_from_settings.py
+++ b/deltatech_actions/tests/test_cron_from_settings.py
@@ -81,6 +81,18 @@ class TestCronFromSettings(TransactionCase):
         self.env["stock.picking"].cron_clean_generated_pdfs_from_settings()
         self.assertFalse(att.exists())
 
+    def test_settings_enabled_toggle_writes_cron_active(self):
+        cron = self.env.ref("deltatech_actions.ir_cron_delete_pdf_attachments_invoice")
+        self.assertFalse(cron.active, "crons must ship disabled by default")
+
+        settings = self.env["res.config.settings"].create({"dt_actions_invoice_pdf_active": True})
+        settings.execute()
+        self.assertTrue(cron.active, "the settings screen must be able to enable a cron")
+
+        settings2 = self.env["res.config.settings"].create({"dt_actions_invoice_pdf_active": False})
+        settings2.execute()
+        self.assertFalse(cron.active, "the settings screen must be able to disable a cron again")
+
     def test_messages_exclude_models_parsed_from_csv(self):
         message = self.env["mail.message"].create(
             {

--- a/deltatech_actions/views/res_config_settings_views.xml
+++ b/deltatech_actions/views/res_config_settings_views.xml
@@ -16,8 +16,10 @@
                     <block title="Duplicate XML attachments" name="dt_actions_xml">
                         <setting
                             string="Duplicate XML attachments"
-                            help="Deletes duplicate EDI/UBL XML attachments on invoices. Enable the 'Delete duplicate xml attachments' scheduled action (Settings > Technical > Automation) to run it."
+                            help="Deletes duplicate EDI/UBL XML attachments on invoices."
                         >
+                            <field name="dt_actions_xml_active" />
+                            <label for="dt_actions_xml_active" string="Enabled" />
                             <field name="dt_actions_xml_dry_run" />
                             <div class="content-group">
                                 <label for="dt_actions_xml_limit" string="Invoices per run" class="col-lg-4 o_light_label" />
@@ -37,8 +39,10 @@
                     <block title="Invoice PDF cleanup" name="dt_actions_invoice_pdf">
                         <setting
                             string="Invoice PDF cleanup"
-                            help="Deletes old auto-generated invoice PDFs, including the ones attached to the outgoing email message rather than to the invoice itself. Enable the 'Delete pdf invoice attachments' scheduled action to run it."
+                            help="Deletes old auto-generated invoice PDFs, including the ones attached to the outgoing email message rather than to the invoice itself."
                         >
+                            <field name="dt_actions_invoice_pdf_active" />
+                            <label for="dt_actions_invoice_pdf_active" string="Enabled" />
                             <field name="dt_actions_invoice_pdf_dry_run" />
                             <div class="content-group">
                                 <label for="dt_actions_invoice_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
@@ -58,8 +62,10 @@
                     <block title="Sale order PDF cleanup" name="dt_actions_sale_pdf">
                         <setting
                             string="Sale order PDF cleanup"
-                            help="Deletes old auto-generated sale order/quotation PDFs. Enable the 'Delete pdf sale order attachments' scheduled action to run it."
+                            help="Deletes old auto-generated sale order/quotation PDFs."
                         >
+                            <field name="dt_actions_sale_pdf_active" />
+                            <label for="dt_actions_sale_pdf_active" string="Enabled" />
                             <field name="dt_actions_sale_pdf_dry_run" />
                             <div class="content-group">
                                 <label for="dt_actions_sale_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
@@ -79,8 +85,10 @@
                     <block title="AWB label cleanup" name="dt_actions_picking_pdf">
                         <setting
                             string="AWB label cleanup"
-                            help="Clears the carrier AWB label PDF on old, finished deliveries -- it can grow into the largest single filestore consumer on a long-running instance. The label is regenerable from the carrier's API on demand as long as the shipment is still on file there; confirm the retention window with your carrier(s) before enabling the scheduled action ('Delete pdf pickings attachments')."
+                            help="Clears the carrier AWB label PDF on old, finished deliveries -- it can grow into the largest single filestore consumer on a long-running instance. The label is regenerable from the carrier's API on demand as long as the shipment is still on file there; confirm the retention window with your carrier(s) before enabling this."
                         >
+                            <field name="dt_actions_picking_pdf_active" />
+                            <label for="dt_actions_picking_pdf_active" string="Enabled" />
                             <field name="dt_actions_picking_pdf_dry_run" />
                             <div class="content-group">
                                 <label for="dt_actions_picking_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
@@ -108,8 +116,10 @@
                     <block title="Old messages cleanup" name="dt_actions_messages">
                         <setting
                             string="Old messages cleanup"
-                            help="Deletes old chatter messages (and their non-XML/ZIP attachments) on models matching the excluded-models list -- excluded models keep their full history. Enable the 'Delete mail messages' scheduled action to run it."
+                            help="Deletes old chatter messages (and their non-XML/ZIP attachments) on models matching the excluded-models list -- excluded models keep their full history."
                         >
+                            <field name="dt_actions_messages_active" />
+                            <label for="dt_actions_messages_active" string="Enabled" />
                             <field name="dt_actions_messages_dry_run" />
                             <div class="content-group">
                                 <label for="dt_actions_messages_limit" string="Messages per run" class="col-lg-4 o_light_label" />
@@ -130,19 +140,51 @@
                         </setting>
                     </block>
 
-                    <block title="Duplicate contacts / companies" name="dt_actions_merge">
+                    <block title="Duplicate contacts" name="dt_actions_merge_contacts">
                         <setting
-                            string="Duplicate contacts / companies"
-                            help="Merges duplicate individual contacts sharing the same email, and duplicate companies sharing the same VAT number. Enable the corresponding scheduled actions ('Merge duplicate contacts by email', 'Merge duplicate companies by VAT') to run them."
+                            string="Duplicate contacts"
+                            help="Merges duplicate individual contacts sharing the same email address. Performs the merge directly -- there is no dry-run mode."
                         >
+                            <field name="dt_actions_merge_contacts_active" />
+                            <label for="dt_actions_merge_contacts_active" string="Enabled" />
                             <div class="content-group">
                                 <label for="dt_actions_merge_contacts_limit" string="Contact groups per run" class="col-lg-4 o_light_label" />
                                 <field name="dt_actions_merge_contacts_limit" class="oe_inline" />
                             </div>
+                        </setting>
+                    </block>
+
+                    <block title="Duplicate companies" name="dt_actions_merge_companies">
+                        <setting
+                            string="Duplicate companies"
+                            help="Merges duplicate companies sharing the same VAT number. Performs the merge directly -- there is no dry-run mode."
+                        >
+                            <field name="dt_actions_merge_companies_active" />
+                            <label for="dt_actions_merge_companies_active" string="Enabled" />
                             <div class="content-group">
                                 <label for="dt_actions_merge_companies_limit" string="Company groups per run" class="col-lg-4 o_light_label" />
                                 <field name="dt_actions_merge_companies_limit" class="oe_inline" />
                             </div>
+                        </setting>
+                    </block>
+
+                    <block title="Missing reordering rules" name="dt_actions_reorder_rules">
+                        <setting
+                            string="Missing reordering rules"
+                            help="Creates stock reordering rules for storable products that have none. Requires the deltatech_auto_reorder_rule module. No other parameters."
+                        >
+                            <field name="dt_actions_reorder_rules_active" />
+                            <label for="dt_actions_reorder_rules_active" string="Enabled" />
+                        </setting>
+                    </block>
+
+                    <block title="Normalize company names" name="dt_actions_normalize_names">
+                        <setting
+                            string="Normalize company names"
+                            help="Standardizes legal-form suffixes in company names (e.g. srl -&gt; S.R.L., sa -&gt; S.A., pfa -&gt; P.F.A., ii -&gt; I.I.). Processes up to 500 records per run. No other parameters."
+                        >
+                            <field name="dt_actions_normalize_names_active" />
+                            <label for="dt_actions_normalize_names_active" string="Enabled" />
                         </setting>
                     </block>
                 </app>


### PR DESCRIPTION
## Summary
- Continuă [#2852](https://github.com/dhongu/deltatech/pull/2852): ecranul Database Cleanup lăsa doar parametrii configurabili din UI, dar activarea propriu-zisă a cron-ului tot necesita un drum la Settings → Technical → Automation → Scheduled Actions.
- Adaugă un toggle **Enabled** pe fiecare din cele 9 blocuri, legat direct de `ir.cron.active` prin `get_values()`/`set_values()` — inclusiv pentru cele două cron-uri fără alți parametri (reguli de reaprovizionare, normalizare nume companii), care primesc acum un bloc minim doar cu acest toggle.
- Toate cele 9 cron-uri rămân `active=False` by default; ecranul de Settings devine locul unic destinat activării.

## Test plan
- [x] Test nou: `test_settings_enabled_toggle_writes_cron_active` — verifică că `settings.execute()` scrie `ir.cron.active`
- [ ] Verificare manuală: deschide Settings → General Settings → Database Cleanup, bifează „Enabled" pe un bloc, salvează, confirmă în Settings → Technical → Scheduled Actions că cron-ul e activ