### PR TITLE
[IMP] deltatech_actions: age filter for duplicate XML cleanup too

### DIFF
--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.3.0",
+    "version": "19.0.0.3.1",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/models/account_move.py
+++ b/deltatech_actions/models/account_move.py
@@ -26,6 +26,7 @@ class AccountMove(models.Model):
             duplicates=int(icp.get_param("deltatech_actions.xml_duplicates", 10)),
             max_attachments_to_delete=int(icp.get_param("deltatech_actions.xml_max_delete", 50)),
             dry_run=str2bool(icp.get_param("deltatech_actions.xml_dry_run", "True")),
+            max_date_days=int(icp.get_param("deltatech_actions.xml_max_date_days", 30)),
         )
 
     @api.model
@@ -41,7 +42,9 @@ class AccountMove(models.Model):
         )
 
     @api.model
-    def cron_clean_xml_attachments(self, limit=10, duplicates=10, max_attachments_to_delete=50, dry_run=False):
+    def cron_clean_xml_attachments(
+        self, limit=10, duplicates=10, max_attachments_to_delete=50, dry_run=False, max_date_days=False
+    ):
         """
         Searches for duplicate xml attachments for invoices and deletes them (mainly edi ubl)
         :param limit: how many invoices with duplicate attachments should be processed.
@@ -50,23 +53,32 @@ class AccountMove(models.Model):
         :param duplicates: how many attachments with same name are found
         :param max_attachments_to_delete: maximum attachment number to delete
         :param dry_run: if set to True, just selects the attachments and does not delete anything
+        :param max_date_days: only consider attachments older than this many days. Ex. 30 =
+        an attachment created today is never touched even if it duplicates an older one.
+        Falsy = no age filter, kept for backwards compatibility.
         :return: None
         """
+        max_date = datetime.now() - relativedelta(days=max_date_days) if max_date_days else None
+        date_clause = "AND create_date <= %(create_date)s" if max_date else ""
 
-        query = """SELECT name, count(name) as count_name
+        query = f"""SELECT name, count(name) as count_name
         FROM ir_attachment
         WHERE mimetype='application/xml' AND res_model='account.move'
+        {date_clause}
         GROUP BY name
         HAVING COUNT(name) > %(duplicates)s limit %(limit)s;
         """
-        params = {"limit": limit, "duplicates": duplicates}
+        params = {"limit": limit, "duplicates": duplicates, "create_date": max_date}
         self.env.cr.execute(query, params=params)
         res = self.env.cr.fetchall()
         counter = 1
         att_count = len(res)
         total_attachments = 0
         for attachment_name in res:
-            attachments = self.env["ir.attachment"].search([("name", "=", attachment_name[0])])
+            domain = [("name", "=", attachment_name[0])]
+            if max_date:
+                domain.append(("create_date", "<=", max_date))
+            attachments = self.env["ir.attachment"].search(domain)
             if attachments:
                 counter += 1
                 invoice_id = self.browse(attachments[0].res_id)

--- a/deltatech_actions/models/res_config_settings.py
+++ b/deltatech_actions/models/res_config_settings.py
@@ -66,6 +66,11 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.xml_max_delete",
         default=50,
     )
+    dt_actions_xml_max_date_days = fields.Integer(
+        string="Older than (days, XML)",
+        config_parameter="deltatech_actions.xml_max_date_days",
+        default=30,
+    )
     dt_actions_xml_dry_run = fields.Boolean(
         string="Dry run (XML)",
         config_parameter="deltatech_actions.xml_dry_run",

--- a/deltatech_actions/readme/CONFIGURE.md
+++ b/deltatech_actions/readme/CONFIGURE.md
@@ -16,7 +16,9 @@ Cron: *Delete duplicate xml attachments*. Model: `account.move`. Removes duplica
 attachments on invoices.
 
 Settings: invoices per run (default `10`), minimum duplicates before deletion starts (default
-`10`), max deletions per invoice (default `50`), dry run (default on).
+`10`), max deletions per invoice (default `50`), older than N days (default `30` — a duplicate
+created today is never touched even if it already matches the threshold above), dry run (default
+on).
 
 ## Invoice PDF cleanup
 

--- a/deltatech_actions/tests/test_cron_xml.py
+++ b/deltatech_actions/tests/test_cron_xml.py
@@ -2,6 +2,7 @@
 # See README.rst file on addons root folder for license details
 
 import base64
+from datetime import datetime, timedelta
 
 from odoo.tests.common import TransactionCase, tagged
 
@@ -65,3 +66,27 @@ class TestCronCleanXMLAttachments(TransactionCase):
         )
         self.assertEqual(len(remaining_dups), 1)
         self.assertTrue(single.exists())
+
+    def test_xml_cron_max_date_days_protects_recent_duplicates(self):
+        old1 = self._create_xml("OLD_UBL.xml")
+        old2 = self._create_xml("OLD_UBL.xml")
+        past_dt = datetime.utcnow() - timedelta(days=60)
+        self.env.cr.execute(
+            "UPDATE ir_attachment SET create_date = %s WHERE id IN %s",
+            (past_dt, tuple((old1 + old2).ids)),
+        )
+
+        recent1 = self._create_xml("RECENT_UBL.xml")
+        recent2 = self._create_xml("RECENT_UBL.xml")
+
+        self.env["account.move"].cron_clean_xml_attachments(
+            limit=10, duplicates=1, max_attachments_to_delete=1, dry_run=False, max_date_days=30
+        )
+
+        # Older than the 30-day cutoff: one of the duplicates gets removed.
+        remaining_old = self.env["ir.attachment"].search([("name", "=", "OLD_UBL.xml")])
+        self.assertEqual(len(remaining_old), 1)
+
+        # Created today: protected by the cutoff, even though they duplicate.
+        self.assertTrue(recent1.exists())
+        self.assertTrue(recent2.exists())

--- a/deltatech_actions/views/res_config_settings_views.xml
+++ b/deltatech_actions/views/res_config_settings_views.xml
@@ -33,6 +33,10 @@
                                 <label for="dt_actions_xml_max_delete" string="Max deletions per invoice" class="col-lg-4 o_light_label" />
                                 <field name="dt_actions_xml_max_delete" class="oe_inline" />
                             </div>
+                            <div class="content-group">
+                                <label for="dt_actions_xml_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
+                                <field name="dt_actions_xml_max_date_days" class="oe_inline" />
+                            </div>
                         </setting>
                     </block>
 


### PR DESCRIPTION
## Summary
- `cron_clean_xml_attachments` era singurul cron de curățare din modul fără niciun filtru de vechime — ștergea duplicate indiferent cât de recente erau.
- Adaugă `max_date_days` (default `30`), expus în Settings → General Settings → Database Cleanup, aplicat atât la identificarea grupurilor de duplicate cât și la selecția atașamentelor candidate pentru ștergere.
- Comportament neschimbat când parametrul e fals (backwards compatible pentru apeluri directe fără parametru).

## Test plan
- [x] Test nou: `test_xml_cron_max_date_days_protects_recent_duplicates`