### PR TITLE
[FIX] deltatech_product_visibility: convert _sql_constraints to models.Constraint

### DIFF
--- a/deltatech_product_visibility/__manifest__.py
+++ b/deltatech_product_visibility/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Product Website Visibility Score",
     "summary": "Scor colorat de vizibilitate a produsului pe website (semafor + defalcare pe criterii)",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "author": "Terrabit, Voicu Stefan",
     "license": "OPL-1",
     "website": "https://www.terrabit.ro",

--- a/deltatech_product_visibility/models/visibility_criterion.py
+++ b/deltatech_product_visibility/models/visibility_criterion.py
@@ -29,9 +29,10 @@ class ProductVisibilityCriterion(models.Model):
     sequence = fields.Integer(default=10)
     active = fields.Boolean(default=True)
 
-    _sql_constraints = [
-        ("code_uniq", "unique(code)", "Există deja un criteriu pentru acest tip de verificare."),
-    ]
+    _code_uniq = models.Constraint(
+        "unique(code)",
+        "Există deja un criteriu pentru acest tip de verificare.",
+    )
 
     def action_recompute_scores(self):
         """Reevaluează scorul pentru toate produsele (util după modificarea ponderilor)."""


### PR DESCRIPTION
## Problem

Odoo 19 dropped support for the `_sql_constraints` list. The ORM only logs a warning (`odoo/orm/model_classes.py`) and never creates the constraint, so the `unique(code)` guard on `deltatech.visibility.criterion` was **silently inactive** — duplicate criteria for the same check code could be created.

## Fix

Converted to the Odoo 19 API:

```python
_code_uniq = models.Constraint(
    "unique(code)",
    "Există deja un criteriu pentru acest tip de verificare.",
)
```

The DB identifier is unchanged (`TableObject.full_name()` builds `{table}_{name}`, the same convention the old API used), so no pre-migration cleanup is needed. Version bumped to `19.0.1.0.1` so existing databases actually get the constraint on `-u`.

## Note for existing databases

The constraint never existed on databases installed directly on 19, so duplicates may have accumulated. If so, `-u` will log `Unable to add constraint` and Postgres will refuse the index. Check first:

```sql
SELECT code, count(*) FROM deltatech_visibility_criterion GROUP BY code HAVING count(*) > 1;
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)