### PR TITLE
[FIX+IMP] deltatech_actions: excluded models never excluded anything; clearer cleanup settings

### DIFF
--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.3.1",
+    "version": "19.0.0.4.0",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/i18n/deltatech_actions.pot
+++ b/deltatech_actions/i18n/deltatech_actions.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 05:57+0000\n"
-"PO-Revision-Date: 2026-08-27 05:57+0000\n"
+"POT-Creation-Date: 2026-08-27 07:27+0000\n"
+"PO-Revision-Date: 2026-08-27 07:27+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -377,13 +377,13 @@ msgid "Missing reordering rules"
 msgstr ""
 
 #. module: deltatech_actions
-#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_pattern
-msgid "Name pattern (AWB label)"
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Name pattern"
 msgstr ""
 
 #. module: deltatech_actions
-#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
-msgid "Name pattern (SQL LIKE, empty = all)"
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_pattern
+msgid "Name pattern (AWB label)"
 msgstr ""
 
 #. module: deltatech_actions
@@ -512,6 +512,11 @@ msgstr ""
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "SQL LIKE, empty = all"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
 msgid "Sale order PDF cleanup"
 msgstr ""
 
@@ -530,7 +535,7 @@ msgstr ""
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
-msgid "Subject pattern (SQL LIKE, empty = all)"
+msgid "Subject pattern"
 msgstr ""
 
 #. module: deltatech_actions

--- a/deltatech_actions/i18n/deltatech_actions.pot
+++ b/deltatech_actions/i18n/deltatech_actions.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-31 10:23+0000\n"
-"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"POT-Creation-Date: 2026-08-27 05:57+0000\n"
+"PO-Revision-Date: 2026-08-27 05:57+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,13 +16,58 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "AWB label cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Attachments per run"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_limit
+msgid "Attachments to delete (AWB label)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_limit
+msgid "Attachments to delete (invoice PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_limit
+msgid "Attachments to delete (sale order PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Clears the carrier AWB label PDF on old, finished deliveries -- it can grow "
+"into the largest single filestore consumer on a long-running instance. The "
+"label is regenerable from the carrier's API on demand as long as the "
+"shipment is still on file there; confirm the retention window with your "
+"carrier(s) before enabling this."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Company groups per run"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_res_config_settings
+msgid "Config Settings"
+msgstr ""
+
+#. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_res_partner
 msgid "Contact"
 msgstr ""
 
 #. module: deltatech_actions
-#: model:ir.model,website_form_label:deltatech_actions.model_res_partner
-msgid "Create a Customer"
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Contact groups per run"
 msgstr ""
 
 #. module: deltatech_actions
@@ -37,9 +82,21 @@ msgid "Created %s missing rules"
 msgstr ""
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Creates stock reordering rules for storable products that have none. "
+"Requires the deltatech_auto_reorder_rule module. No other parameters."
+msgstr ""
+
+#. module: deltatech_actions
 #. odoo-python
 #: code:addons/deltatech_actions/models/res_partner.py:0
 msgid "Cron job: Au fost normalizate %s nume de companii"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Database Cleanup"
 msgstr ""
 
 #. module: deltatech_actions
@@ -68,13 +125,93 @@ msgid "Delete pdf sale order attachments"
 msgstr ""
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Deletes duplicate EDI/UBL XML attachments on invoices."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Deletes old auto-generated invoice PDFs, including the ones attached to the "
+"outgoing email message rather than to the invoice itself."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Deletes old auto-generated sale order/quotation PDFs."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Deletes old chatter messages (and their non-XML/ZIP attachments), except on "
+"the models listed as excluded -- those keep their full history."
+msgstr ""
+
+#. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_account_move__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_mail_message__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_partner__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_dry_run
+msgid "Dry run (AWB label)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_dry_run
+msgid "Dry run (XML)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_dry_run
+msgid "Dry run (invoice PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_dry_run
+msgid "Dry run (messages)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_dry_run
+msgid "Dry run (sale order PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Dry run (test mode, deletes nothing)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Duplicate XML attachments"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Duplicate companies"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_companies_limit
+msgid "Duplicate company groups per run"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_contacts_limit
+msgid "Duplicate contact groups per run"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Duplicate contacts"
 msgstr ""
 
 #. module: deltatech_actions
@@ -84,15 +221,71 @@ msgid "EROARE - Normalizare companii - Cron Job"
 msgstr ""
 
 #. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_active
+msgid "Enable AWB label cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_normalize_names_active
+msgid "Enable company name normalization"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_active
+msgid "Enable duplicate XML attachments cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_companies_active
+msgid "Enable duplicate companies merge"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_contacts_active
+msgid "Enable duplicate contacts merge"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_active
+msgid "Enable invoice PDF cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_reorder_rules_active
+msgid "Enable missing reordering rules cron"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_active
+msgid "Enable old messages cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_active
+msgid "Enable sale order PDF cleanup"
+msgstr ""
+
+#. module: deltatech_actions
 #. odoo-python
 #: code:addons/deltatech_actions/models/res_partner.py:0
 msgid "Eroare în normalizarea companiilor: %s"
 msgstr ""
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Excluded models"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_exclude_models
+msgid "Excluded models (messages, comma-separated SQL LIKE patterns)"
+msgstr ""
+
+#. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_account_move__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_mail_message__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_partner__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__id
@@ -100,8 +293,33 @@ msgid "ID"
 msgstr ""
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Invoice PDF cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Invoices per run"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_limit
+msgid "Invoices to process (XML)"
+msgstr ""
+
+#. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_account_move
 msgid "Journal Entry"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_max_delete
+msgid "Max attachments to delete per invoice (XML)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Max deletions per invoice"
 msgstr ""
 
 #. module: deltatech_actions
@@ -115,8 +333,117 @@ msgid "Merge duplicate contacts by email"
 msgstr ""
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Merges duplicate companies sharing the same VAT number. Performs the merge "
+"directly -- there is no dry-run mode."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Merges duplicate individual contacts sharing the same email address. "
+"Performs the merge directly -- there is no dry-run mode."
+msgstr ""
+
+#. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_mail_message
 msgid "Message"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Messages per run"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_limit
+msgid "Messages to delete"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Minimum duplicates"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_duplicates
+msgid "Minimum duplicates (XML)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Missing reordering rules"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_pattern
+msgid "Name pattern (AWB label)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Name pattern (SQL LIKE, empty = all)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_pattern
+msgid "Name pattern (invoice PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_pattern
+msgid "Name pattern (sale order PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Next execution"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_nextcall
+msgid "Next execution (AWB label)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_nextcall
+msgid "Next execution (XML)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_companies_nextcall
+msgid "Next execution (companies merge)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_normalize_names_nextcall
+msgid "Next execution (company names)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_contacts_nextcall
+msgid "Next execution (contacts merge)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_nextcall
+msgid "Next execution (invoice PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_nextcall
+msgid "Next execution (messages)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_reorder_rules_nextcall
+msgid "Next execution (reordering rules)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_nextcall
+msgid "Next execution (sale order PDF)"
 msgstr ""
 
 #. module: deltatech_actions
@@ -127,7 +454,55 @@ msgstr ""
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.cron_normalize_company_names_ir_actions_server
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
 msgid "Normalize company names"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Old messages cleanup"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Older than (days)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_max_date_days
+msgid "Older than (days, AWB label)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_max_date_days
+msgid "Older than (days, XML)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_max_date_days
+msgid "Older than (days, invoice PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_max_date_days
+msgid "Older than (days, messages)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_max_date_days
+msgid "Older than (days, sale order PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_only_cancel
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Only cancelled deliveries"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_only_done
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Only finished deliveries (done)"
 msgstr ""
 
 #. module: deltatech_actions
@@ -136,8 +511,38 @@ msgid "Product Variant"
 msgstr ""
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Sale order PDF cleanup"
+msgstr ""
+
+#. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_sale_order
 msgid "Sales Order"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Standardizes legal-form suffixes in company names (e.g. srl -> S.R.L., sa ->"
+" S.A., pfa -> P.F.A., ii -> I.I.). Processes up to 500 records per run. No "
+"other parameters."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Subject pattern (SQL LIKE, empty = all)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_pattern
+msgid "Subject pattern (messages)"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Test mode: the scheduled action only logs what it would delete, without "
+"deleting anything. Untick it to actually delete."
 msgstr ""
 
 #. module: deltatech_actions

--- a/deltatech_actions/i18n/ro.po
+++ b/deltatech_actions/i18n/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2026-08-27 08:00+0300\n"
+"PO-Revision-Date: 2026-08-27 10:30+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ro\n"
@@ -394,14 +394,14 @@ msgid "Missing reordering rules"
 msgstr "Reguli de reaprovizionare lipsă"
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Name pattern"
+msgstr "Model de nume"
+
+#. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_pattern
 msgid "Name pattern (AWB label)"
 msgstr "Model de nume (etichetă AWB)"
-
-#. module: deltatech_actions
-#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
-msgid "Name pattern (SQL LIKE, empty = all)"
-msgstr "Model de nume (SQL LIKE, gol = toate)"
 
 #. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_pattern
@@ -529,6 +529,11 @@ msgstr "Variantă produs"
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "SQL LIKE, empty = all"
+msgstr "SQL LIKE, gol = toate"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
 msgid "Sale order PDF cleanup"
 msgstr "Curățare PDF-uri de comandă de vânzare"
 
@@ -550,8 +555,8 @@ msgstr ""
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
-msgid "Subject pattern (SQL LIKE, empty = all)"
-msgstr "Model de subiect (SQL LIKE, gol = toate)"
+msgid "Subject pattern"
+msgstr "Model de subiect"
 
 #. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_pattern

--- a/deltatech_actions/i18n/ro.po
+++ b/deltatech_actions/i18n/ro.po
@@ -4,17 +4,66 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 19.0+e\n"
+"Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-31 10:23+0000\n"
-"PO-Revision-Date: 2026-07-31 10:23+0000\n"
+"PO-Revision-Date: 2026-08-27 08:00+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
-"Plural-Forms: \n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);\n"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "AWB label cleanup"
+msgstr "Curățare etichete AWB"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Attachments per run"
+msgstr "Atașamente pe rulare"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_limit
+msgid "Attachments to delete (AWB label)"
+msgstr "Atașamente de șters (etichetă AWB)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_limit
+msgid "Attachments to delete (invoice PDF)"
+msgstr "Atașamente de șters (PDF factură)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_limit
+msgid "Attachments to delete (sale order PDF)"
+msgstr "Atașamente de șters (PDF comandă de vânzare)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Clears the carrier AWB label PDF on old, finished deliveries -- it can grow "
+"into the largest single filestore consumer on a long-running instance. The "
+"label is regenerable from the carrier's API on demand as long as the "
+"shipment is still on file there; confirm the retention window with your "
+"carrier(s) before enabling this."
+msgstr ""
+"Șterge PDF-ul etichetei AWB de pe livrările vechi, finalizate — pe o "
+"instanță veche poate deveni cel mai mare consumator de spațiu din filestore."
+" Eticheta se poate regenera la cerere din API-ul curierului, cât timp "
+"expediția mai există la el; confirmă perioada de păstrare cu curierii tăi "
+"înainte de a activa această curățare."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Company groups per run"
+msgstr "Grupuri de companii pe rulare"
+
+#. module: deltatech_actions
+#: model:ir.model,name:deltatech_actions.model_res_config_settings
+msgid "Config Settings"
+msgstr "Setări de configurare"
 
 #. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_res_partner
@@ -22,9 +71,9 @@ msgid "Contact"
 msgstr "Contact"
 
 #. module: deltatech_actions
-#: model:ir.model,website_form_label:deltatech_actions.model_res_partner
-msgid "Create a Customer"
-msgstr "Creează un client"
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Contact groups per run"
+msgstr "Grupuri de contacte pe rulare"
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_create_missing_reordering_rules_ir_actions_server
@@ -35,13 +84,27 @@ msgstr "Creează regulile de reaprovizionare lipsă (0/0)"
 #. odoo-python
 #: code:addons/deltatech_actions/models/product.py:0
 msgid "Created %s missing rules"
-msgstr "S-au creat %s reguli lipsă"
+msgstr "Au fost create %s reguli lipsă"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Creates stock reordering rules for storable products that have none. "
+"Requires the deltatech_auto_reorder_rule module. No other parameters."
+msgstr ""
+"Creează reguli de reaprovizionare pentru produsele stocabile care nu au "
+"niciuna. Necesită modulul deltatech_auto_reorder_rule. Fără alți parametri."
 
 #. module: deltatech_actions
 #. odoo-python
 #: code:addons/deltatech_actions/models/res_partner.py:0
 msgid "Cron job: Au fost normalizate %s nume de companii"
 msgstr "Cron job: Au fost normalizate %s nume de companii"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Database Cleanup"
+msgstr "Curățare bază de date"
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_xml_attachments_ir_actions_server
@@ -51,7 +114,7 @@ msgstr "Șterge atașamentele XML duplicate"
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_mail_messages_ir_actions_server
 msgid "Delete mail messages"
-msgstr "Șterge mesajele de e-mail"
+msgstr "Șterge mesajele din chatter"
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_pdf_attachments_invoice_ir_actions_server
@@ -61,7 +124,7 @@ msgstr "Șterge atașamentele PDF ale facturilor"
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_pdf_attachments_stock_picking_ir_actions_server
 msgid "Delete pdf pickings attachments"
-msgstr "Șterge atașamentele PDF ale operațiilor de stoc"
+msgstr "Șterge atașamentele PDF ale livrărilor"
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_delete_pdf_attachments_sale_order_ir_actions_server
@@ -69,14 +132,100 @@ msgid "Delete pdf sale order attachments"
 msgstr "Șterge atașamentele PDF ale comenzilor de vânzare"
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Deletes duplicate EDI/UBL XML attachments on invoices."
+msgstr "Șterge atașamentele XML (EDI/UBL) duplicate de pe facturi."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Deletes old auto-generated invoice PDFs, including the ones attached to the "
+"outgoing email message rather than to the invoice itself."
+msgstr ""
+"Șterge PDF-urile de factură generate automat, inclusiv pe cele atașate "
+"mesajului de email trimis, nu facturii în sine."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Deletes old auto-generated sale order/quotation PDFs."
+msgstr ""
+"Șterge PDF-urile generate automat pentru comenzi de vânzare și oferte."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Deletes old chatter messages (and their non-XML/ZIP attachments), except on "
+"the models listed as excluded -- those keep their full history."
+msgstr ""
+"Șterge mesajele vechi din chatter (și atașamentele lor care nu sunt "
+"XML/ZIP), cu excepția modelelor trecute ca excluse — acelea își păstrează "
+"întreg istoricul."
+
+#. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_account_move__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_mail_message__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_product_product__display_name
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_partner__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__display_name
 msgid "Display Name"
 msgstr "Nume afișat"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_dry_run
+msgid "Dry run (AWB label)"
+msgstr "Rulare de test (etichetă AWB)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_dry_run
+msgid "Dry run (XML)"
+msgstr "Rulare de test (XML)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_dry_run
+msgid "Dry run (invoice PDF)"
+msgstr "Rulare de test (PDF factură)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_dry_run
+msgid "Dry run (messages)"
+msgstr "Rulare de test (mesaje)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_dry_run
+msgid "Dry run (sale order PDF)"
+msgstr "Rulare de test (PDF comandă de vânzare)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Dry run (test mode, deletes nothing)"
+msgstr "Rulare de test (nu șterge nimic)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Duplicate XML attachments"
+msgstr "Atașamente XML duplicate"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Duplicate companies"
+msgstr "Companii duplicate"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_companies_limit
+msgid "Duplicate company groups per run"
+msgstr "Grupuri de companii duplicate pe rulare"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_contacts_limit
+msgid "Duplicate contact groups per run"
+msgstr "Grupuri de contacte duplicate pe rulare"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Duplicate contacts"
+msgstr "Contacte duplicate"
 
 #. module: deltatech_actions
 #. odoo-python
@@ -85,15 +234,71 @@ msgid "EROARE - Normalizare companii - Cron Job"
 msgstr "EROARE - Normalizare companii - Cron Job"
 
 #. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_active
+msgid "Enable AWB label cleanup"
+msgstr "Activează curățarea etichetelor AWB"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_normalize_names_active
+msgid "Enable company name normalization"
+msgstr "Activează normalizarea numelor de companii"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_active
+msgid "Enable duplicate XML attachments cleanup"
+msgstr "Activează curățarea atașamentelor XML duplicate"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_companies_active
+msgid "Enable duplicate companies merge"
+msgstr "Activează îmbinarea companiilor duplicate"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_contacts_active
+msgid "Enable duplicate contacts merge"
+msgstr "Activează îmbinarea contactelor duplicate"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_active
+msgid "Enable invoice PDF cleanup"
+msgstr "Activează curățarea PDF-urilor de factură"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_reorder_rules_active
+msgid "Enable missing reordering rules cron"
+msgstr "Activează acțiunea pentru regulile de reaprovizionare lipsă"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_active
+msgid "Enable old messages cleanup"
+msgstr "Activează curățarea mesajelor vechi"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_active
+msgid "Enable sale order PDF cleanup"
+msgstr "Activează curățarea PDF-urilor de comandă de vânzare"
+
+#. module: deltatech_actions
 #. odoo-python
 #: code:addons/deltatech_actions/models/res_partner.py:0
 msgid "Eroare în normalizarea companiilor: %s"
 msgstr "Eroare în normalizarea companiilor: %s"
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Excluded models"
+msgstr "Modele excluse"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_exclude_models
+msgid "Excluded models (messages, comma-separated SQL LIKE patterns)"
+msgstr "Modele excluse (mesaje, modele SQL LIKE separate prin virgulă)"
+
+#. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_account_move__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_mail_message__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_product_product__id
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_partner__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__id
 #: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__id
@@ -101,24 +306,162 @@ msgid "ID"
 msgstr "ID"
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Invoice PDF cleanup"
+msgstr "Curățare PDF-uri de factură"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Invoices per run"
+msgstr "Facturi pe rulare"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_limit
+msgid "Invoices to process (XML)"
+msgstr "Facturi de procesat (XML)"
+
+#. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_account_move
 msgid "Journal Entry"
 msgstr "Notă contabilă"
 
 #. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_max_delete
+msgid "Max attachments to delete per invoice (XML)"
+msgstr "Atașamente maxime de șters pe factură (XML)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Max deletions per invoice"
+msgstr "Ștergeri maxime pe factură"
+
+#. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_merge_companies_ir_actions_server
 msgid "Merge duplicate companies by VAT"
-msgstr "Combină companiile duplicate după CUI"
+msgstr "Îmbină companiile duplicate după codul de TVA"
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.ir_cron_merge_contacts_ir_actions_server
 msgid "Merge duplicate contacts by email"
-msgstr "Combină contactele duplicate după e-mail"
+msgstr "Îmbină contactele duplicate după email"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Merges duplicate companies sharing the same VAT number. Performs the merge "
+"directly -- there is no dry-run mode."
+msgstr ""
+"Îmbină companiile duplicate care au același cod de TVA. Îmbinarea se face "
+"direct — nu există mod de test."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Merges duplicate individual contacts sharing the same email address. "
+"Performs the merge directly -- there is no dry-run mode."
+msgstr ""
+"Îmbină contactele individuale duplicate care au aceeași adresă de email. "
+"Îmbinarea se face direct — nu există mod de test."
 
 #. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_mail_message
 msgid "Message"
 msgstr "Mesaj"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Messages per run"
+msgstr "Mesaje pe rulare"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_limit
+msgid "Messages to delete"
+msgstr "Mesaje de șters"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Minimum duplicates"
+msgstr "Duplicate minime"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_duplicates
+msgid "Minimum duplicates (XML)"
+msgstr "Duplicate minime (XML)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Missing reordering rules"
+msgstr "Reguli de reaprovizionare lipsă"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_pattern
+msgid "Name pattern (AWB label)"
+msgstr "Model de nume (etichetă AWB)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Name pattern (SQL LIKE, empty = all)"
+msgstr "Model de nume (SQL LIKE, gol = toate)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_pattern
+msgid "Name pattern (invoice PDF)"
+msgstr "Model de nume (PDF factură)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_pattern
+msgid "Name pattern (sale order PDF)"
+msgstr "Model de nume (PDF comandă de vânzare)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Next execution"
+msgstr "Următoarea execuție"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_nextcall
+msgid "Next execution (AWB label)"
+msgstr "Următoarea execuție (etichetă AWB)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_nextcall
+msgid "Next execution (XML)"
+msgstr "Următoarea execuție (XML)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_companies_nextcall
+msgid "Next execution (companies merge)"
+msgstr "Următoarea execuție (îmbinare companii)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_normalize_names_nextcall
+msgid "Next execution (company names)"
+msgstr "Următoarea execuție (nume de companii)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_merge_contacts_nextcall
+msgid "Next execution (contacts merge)"
+msgstr "Următoarea execuție (îmbinare contacte)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_nextcall
+msgid "Next execution (invoice PDF)"
+msgstr "Următoarea execuție (PDF factură)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_nextcall
+msgid "Next execution (messages)"
+msgstr "Următoarea execuție (mesaje)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_reorder_rules_nextcall
+msgid "Next execution (reordering rules)"
+msgstr "Următoarea execuție (reguli de reaprovizionare)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_nextcall
+msgid "Next execution (sale order PDF)"
+msgstr "Următoarea execuție (PDF comandă de vânzare)"
 
 #. module: deltatech_actions
 #. odoo-python
@@ -128,8 +471,56 @@ msgstr "Normalizare companii - Cron Job"
 
 #. module: deltatech_actions
 #: model:ir.actions.server,name:deltatech_actions.cron_normalize_company_names_ir_actions_server
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
 msgid "Normalize company names"
 msgstr "Normalizează numele companiilor"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Old messages cleanup"
+msgstr "Curățare mesaje vechi"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Older than (days)"
+msgstr "Mai vechi de (zile)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_max_date_days
+msgid "Older than (days, AWB label)"
+msgstr "Mai vechi de (zile, etichetă AWB)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_xml_max_date_days
+msgid "Older than (days, XML)"
+msgstr "Mai vechi de (zile, XML)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_invoice_pdf_max_date_days
+msgid "Older than (days, invoice PDF)"
+msgstr "Mai vechi de (zile, PDF factură)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_max_date_days
+msgid "Older than (days, messages)"
+msgstr "Mai vechi de (zile, mesaje)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_max_date_days
+msgid "Older than (days, sale order PDF)"
+msgstr "Mai vechi de (zile, PDF comandă de vânzare)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_only_cancel
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Only cancelled deliveries"
+msgstr "Doar livrările anulate"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_only_done
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Only finished deliveries (done)"
+msgstr "Doar livrările finalizate (efectuate)"
 
 #. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_product_product
@@ -137,9 +528,44 @@ msgid "Product Variant"
 msgstr "Variantă produs"
 
 #. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Sale order PDF cleanup"
+msgstr "Curățare PDF-uri de comandă de vânzare"
+
+#. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_sale_order
 msgid "Sales Order"
 msgstr "Comandă de vânzare"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Standardizes legal-form suffixes in company names (e.g. srl -> S.R.L., sa ->"
+" S.A., pfa -> P.F.A., ii -> I.I.). Processes up to 500 records per run. No "
+"other parameters."
+msgstr ""
+"Standardizează sufixele formei juridice din numele companiilor (ex. srl -> "
+"S.R.L., sa -> S.A., pfa -> P.F.A., ii -> I.I.). Procesează până la 500 "
+"înregistrări pe rulare. Fără alți parametri."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Subject pattern (SQL LIKE, empty = all)"
+msgstr "Model de subiect (SQL LIKE, gol = toate)"
+
+#. module: deltatech_actions
+#: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_messages_pattern
+msgid "Subject pattern (messages)"
+msgstr "Model de subiect (mesaje)"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"Test mode: the scheduled action only logs what it would delete, without "
+"deleting anything. Untick it to actually delete."
+msgstr ""
+"Mod de test: acțiunea programată doar înregistrează în jurnal ce ar șterge, "
+"fără să șteargă efectiv. Debifează pentru ștergere reală."
 
 #. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_stock_picking

--- a/deltatech_actions/models/mail_message.py
+++ b/deltatech_actions/models/mail_message.py
@@ -56,7 +56,7 @@ class MailMessage(models.Model):
             max_date = datetime.now() - relativedelta(days=max_date_days)
         if not pattern:
             query = """SELECT id FROM mail_message
-                                        WHERE model not like any(%(exclude_models)s)
+                                        WHERE NOT (model like any(%(exclude_models)s))
                                         AND create_date <= %(create_date)s
                                         ORDER BY id
                                         limit %(limit)s;
@@ -64,7 +64,7 @@ class MailMessage(models.Model):
             params = {"limit": limit, "create_date": max_date, "exclude_models": exclude_models}
         else:
             query = """SELECT id FROM mail_message
-                                WHERE model not like any(%(exclude_models)s)
+                                WHERE NOT (model like any(%(exclude_models)s))
                                 AND create_date <= %(create_date)s AND subject like %(pattern)s
                                 ORDER BY id
                                 limit %(limit)s;

--- a/deltatech_actions/models/res_config_settings.py
+++ b/deltatech_actions/models/res_config_settings.py
@@ -22,6 +22,14 @@ CRON_ACTIVE_FIELDS = {
 }
 
 
+# Same crons, exposed read/write as their next scheduled run (ir.cron.nextcall),
+# so the settings screen answers "when does this actually run?" without a trip to
+# Settings > Technical > Automation > Scheduled Actions.
+CRON_NEXTCALL_FIELDS = {
+    field_name.replace("_active", "_nextcall"): xmlid for field_name, xmlid in CRON_ACTIVE_FIELDS.items()
+}
+
+
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
@@ -35,12 +43,25 @@ class ResConfigSettings(models.TransientModel):
     dt_actions_reorder_rules_active = fields.Boolean(string="Enable missing reordering rules cron")
     dt_actions_normalize_names_active = fields.Boolean(string="Enable company name normalization")
 
+    dt_actions_xml_nextcall = fields.Datetime(string="Next execution (XML)")
+    dt_actions_invoice_pdf_nextcall = fields.Datetime(string="Next execution (invoice PDF)")
+    dt_actions_sale_pdf_nextcall = fields.Datetime(string="Next execution (sale order PDF)")
+    dt_actions_picking_pdf_nextcall = fields.Datetime(string="Next execution (AWB label)")
+    dt_actions_messages_nextcall = fields.Datetime(string="Next execution (messages)")
+    dt_actions_merge_contacts_nextcall = fields.Datetime(string="Next execution (contacts merge)")
+    dt_actions_merge_companies_nextcall = fields.Datetime(string="Next execution (companies merge)")
+    dt_actions_reorder_rules_nextcall = fields.Datetime(string="Next execution (reordering rules)")
+    dt_actions_normalize_names_nextcall = fields.Datetime(string="Next execution (company names)")
+
     @api.model
     def get_values(self):
         res = super().get_values()
         for field_name, xmlid in CRON_ACTIVE_FIELDS.items():
             cron = self.env.ref(xmlid, raise_if_not_found=False)
             res[field_name] = bool(cron and cron.active)
+        for field_name, xmlid in CRON_NEXTCALL_FIELDS.items():
+            cron = self.env.ref(xmlid, raise_if_not_found=False)
+            res[field_name] = cron.sudo().nextcall if cron else False
         return res
 
     def set_values(self):
@@ -49,6 +70,11 @@ class ResConfigSettings(models.TransientModel):
             cron = self.env.ref(xmlid, raise_if_not_found=False)
             if cron and cron.active != self[field_name]:
                 cron.sudo().active = self[field_name]
+        for field_name, xmlid in CRON_NEXTCALL_FIELDS.items():
+            cron = self.env.ref(xmlid, raise_if_not_found=False)
+            nextcall = self[field_name]
+            if cron and nextcall and cron.sudo().nextcall != nextcall:
+                cron.sudo().nextcall = nextcall
 
     # -- Duplicate XML attachments (account_move.cron_clean_xml_attachments) --
     dt_actions_xml_limit = fields.Integer(

--- a/deltatech_actions/readme/CONFIGURE.md
+++ b/deltatech_actions/readme/CONFIGURE.md
@@ -3,12 +3,19 @@ underlying `ir.cron` record, set once at install and never reset on upgrade), an
 delete data also default to **dry mode** (`dry_run`), meaning they only log what would be deleted
 without making any changes.
 
-Everything — including turning a cron **on** — lives in **Settings > General Settings > Database
-Cleanup** (a dedicated app section, visible to system administrators). Each block has its own
-"Enabled" toggle, wired directly to that cron's `active` field: this settings screen is the
-intended single place to activate any of them, instead of hunting down the matching entry in
-Settings > Technical > Automation > Scheduled Actions. Review a block's parameters and switch its
-"Dry run" off *before* enabling it.
+Everything — including turning a cron **on** — lives in the **Database Cleanup** section of
+**Settings > General Settings**, visible to system administrators. Each cleanup is one setting
+whose title checkbox is wired directly to that cron's `active` field: this screen is the intended
+single place to activate any of them, instead of hunting down the matching entry in Settings >
+Technical > Automation > Scheduled Actions. Every cleanup that deletes data has a separate
+"Dry run (test mode, deletes nothing)" checkbox below it — review the parameters and switch dry
+run off *before* relying on it.
+
+Once a cleanup is enabled, its **Next execution** date is shown (and can be changed) right there,
+the same way the automatic exchange-rate update does it — it is the cron's `nextcall`, so there is
+no need to open the scheduled action to find out when it runs. A cleanup that has been disabled
+since install keeps an old `nextcall`, so it fires on the first cron tick after you enable it;
+push the date forward if you want it to start later.
 
 ## Duplicate XML attachments
 

--- a/deltatech_actions/views/res_config_settings_views.xml
+++ b/deltatech_actions/views/res_config_settings_views.xml
@@ -59,8 +59,8 @@
                             <field name="dt_actions_invoice_pdf_max_date_days" class="oe_inline" />
                         </div>
                         <div class="content-group">
-                            <label for="dt_actions_invoice_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                            <field name="dt_actions_invoice_pdf_pattern" class="oe_inline" />
+                            <label for="dt_actions_invoice_pdf_pattern" string="Name pattern" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_invoice_pdf_pattern" class="oe_inline" placeholder="SQL LIKE, empty = all" />
                         </div>
                         <div class="content-group" invisible="not dt_actions_invoice_pdf_active">
                             <label for="dt_actions_invoice_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
@@ -87,8 +87,8 @@
                             <field name="dt_actions_sale_pdf_max_date_days" class="oe_inline" />
                         </div>
                         <div class="content-group">
-                            <label for="dt_actions_sale_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                            <field name="dt_actions_sale_pdf_pattern" class="oe_inline" />
+                            <label for="dt_actions_sale_pdf_pattern" string="Name pattern" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_sale_pdf_pattern" class="oe_inline" placeholder="SQL LIKE, empty = all" />
                         </div>
                         <div class="content-group" invisible="not dt_actions_sale_pdf_active">
                             <label for="dt_actions_sale_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
@@ -115,8 +115,8 @@
                             <field name="dt_actions_picking_pdf_max_date_days" class="oe_inline" />
                         </div>
                         <div class="content-group">
-                            <label for="dt_actions_picking_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                            <field name="dt_actions_picking_pdf_pattern" class="oe_inline" />
+                            <label for="dt_actions_picking_pdf_pattern" string="Name pattern" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_picking_pdf_pattern" class="oe_inline" placeholder="SQL LIKE, empty = all" />
                         </div>
                         <div class="content-group">
                             <field name="dt_actions_picking_pdf_only_done" />
@@ -151,8 +151,8 @@
                             <field name="dt_actions_messages_max_date_days" class="oe_inline" />
                         </div>
                         <div class="content-group">
-                            <label for="dt_actions_messages_pattern" string="Subject pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                            <field name="dt_actions_messages_pattern" class="oe_inline" />
+                            <label for="dt_actions_messages_pattern" string="Subject pattern" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_messages_pattern" class="oe_inline" placeholder="SQL LIKE, empty = all" />
                         </div>
                         <div class="content-group">
                             <label for="dt_actions_messages_exclude_models" string="Excluded models" class="col-lg-4 o_light_label" />

--- a/deltatech_actions/views/res_config_settings_views.xml
+++ b/deltatech_actions/views/res_config_settings_views.xml
@@ -6,192 +6,216 @@
         <field name="priority" eval="90" />
         <field name="inherit_id" ref="base.res_config_settings_view_form" />
         <field name="arch" type="xml">
-            <xpath expr="//form" position="inside">
-                <app
-                    data-string="Database Cleanup"
-                    string="Database Cleanup"
-                    name="deltatech_actions"
-                    groups="base.group_system"
-                >
-                    <block title="Duplicate XML attachments" name="dt_actions_xml">
-                        <setting
-                            string="Duplicate XML attachments"
-                            help="Deletes duplicate EDI/UBL XML attachments on invoices."
-                        >
-                            <field name="dt_actions_xml_active" />
-                            <label for="dt_actions_xml_active" string="Enabled" />
-                            <field name="dt_actions_xml_dry_run" />
-                            <div class="content-group">
-                                <label for="dt_actions_xml_limit" string="Invoices per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_xml_limit" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_xml_duplicates" string="Minimum duplicates" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_xml_duplicates" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_xml_max_delete" string="Max deletions per invoice" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_xml_max_delete" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_xml_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_xml_max_date_days" class="oe_inline" />
-                            </div>
-                        </setting>
-                    </block>
+            <xpath expr="//app[@name='general_settings']" position="inside">
+                <block title="Database Cleanup" name="dt_actions_cleanup" groups="base.group_system">
+                    <setting
+                        string="Duplicate XML attachments"
+                        help="Deletes duplicate EDI/UBL XML attachments on invoices."
+                    >
+                        <field name="dt_actions_xml_active" />
+                        <div class="content-group">
+                            <field name="dt_actions_xml_dry_run" class="oe_inline" />
+                            <label for="dt_actions_xml_dry_run" string="Dry run (test mode, deletes nothing)" />
+                            <div class="text-muted">Test mode: the scheduled action only logs what it would delete, without deleting anything. Untick it to actually delete.</div>
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_xml_limit" string="Invoices per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_xml_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_xml_duplicates" string="Minimum duplicates" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_xml_duplicates" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_xml_max_delete" string="Max deletions per invoice" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_xml_max_delete" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_xml_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_xml_max_date_days" class="oe_inline" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_xml_active">
+                            <label for="dt_actions_xml_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_xml_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Invoice PDF cleanup" name="dt_actions_invoice_pdf">
-                        <setting
-                            string="Invoice PDF cleanup"
-                            help="Deletes old auto-generated invoice PDFs, including the ones attached to the outgoing email message rather than to the invoice itself."
-                        >
-                            <field name="dt_actions_invoice_pdf_active" />
-                            <label for="dt_actions_invoice_pdf_active" string="Enabled" />
-                            <field name="dt_actions_invoice_pdf_dry_run" />
-                            <div class="content-group">
-                                <label for="dt_actions_invoice_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_invoice_pdf_limit" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_invoice_pdf_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_invoice_pdf_max_date_days" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_invoice_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_invoice_pdf_pattern" class="oe_inline" />
-                            </div>
-                        </setting>
-                    </block>
+                    <setting
+                        string="Invoice PDF cleanup"
+                        help="Deletes old auto-generated invoice PDFs, including the ones attached to the outgoing email message rather than to the invoice itself."
+                    >
+                        <field name="dt_actions_invoice_pdf_active" />
+                        <div class="content-group">
+                            <field name="dt_actions_invoice_pdf_dry_run" class="oe_inline" />
+                            <label for="dt_actions_invoice_pdf_dry_run" string="Dry run (test mode, deletes nothing)" />
+                            <div class="text-muted">Test mode: the scheduled action only logs what it would delete, without deleting anything. Untick it to actually delete.</div>
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_invoice_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_invoice_pdf_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_invoice_pdf_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_invoice_pdf_max_date_days" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_invoice_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_invoice_pdf_pattern" class="oe_inline" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_invoice_pdf_active">
+                            <label for="dt_actions_invoice_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_invoice_pdf_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Sale order PDF cleanup" name="dt_actions_sale_pdf">
-                        <setting
-                            string="Sale order PDF cleanup"
-                            help="Deletes old auto-generated sale order/quotation PDFs."
-                        >
-                            <field name="dt_actions_sale_pdf_active" />
-                            <label for="dt_actions_sale_pdf_active" string="Enabled" />
-                            <field name="dt_actions_sale_pdf_dry_run" />
-                            <div class="content-group">
-                                <label for="dt_actions_sale_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_sale_pdf_limit" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_sale_pdf_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_sale_pdf_max_date_days" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_sale_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_sale_pdf_pattern" class="oe_inline" />
-                            </div>
-                        </setting>
-                    </block>
+                    <setting
+                        string="Sale order PDF cleanup"
+                        help="Deletes old auto-generated sale order/quotation PDFs."
+                    >
+                        <field name="dt_actions_sale_pdf_active" />
+                        <div class="content-group">
+                            <field name="dt_actions_sale_pdf_dry_run" class="oe_inline" />
+                            <label for="dt_actions_sale_pdf_dry_run" string="Dry run (test mode, deletes nothing)" />
+                            <div class="text-muted">Test mode: the scheduled action only logs what it would delete, without deleting anything. Untick it to actually delete.</div>
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_sale_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_sale_pdf_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_sale_pdf_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_sale_pdf_max_date_days" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_sale_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_sale_pdf_pattern" class="oe_inline" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_sale_pdf_active">
+                            <label for="dt_actions_sale_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_sale_pdf_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="AWB label cleanup" name="dt_actions_picking_pdf">
-                        <setting
-                            string="AWB label cleanup"
-                            help="Clears the carrier AWB label PDF on old, finished deliveries -- it can grow into the largest single filestore consumer on a long-running instance. The label is regenerable from the carrier's API on demand as long as the shipment is still on file there; confirm the retention window with your carrier(s) before enabling this."
-                        >
-                            <field name="dt_actions_picking_pdf_active" />
-                            <label for="dt_actions_picking_pdf_active" string="Enabled" />
-                            <field name="dt_actions_picking_pdf_dry_run" />
-                            <div class="content-group">
-                                <label for="dt_actions_picking_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_picking_pdf_limit" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_picking_pdf_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_picking_pdf_max_date_days" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_picking_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_picking_pdf_pattern" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <field name="dt_actions_picking_pdf_only_done" />
-                                <label for="dt_actions_picking_pdf_only_done" string="Only finished deliveries (done)" />
-                            </div>
-                            <div class="content-group">
-                                <field name="dt_actions_picking_pdf_only_cancel" />
-                                <label for="dt_actions_picking_pdf_only_cancel" string="Only cancelled deliveries" />
-                            </div>
-                        </setting>
-                    </block>
+                    <setting
+                        string="AWB label cleanup"
+                        help="Clears the carrier AWB label PDF on old, finished deliveries -- it can grow into the largest single filestore consumer on a long-running instance. The label is regenerable from the carrier's API on demand as long as the shipment is still on file there; confirm the retention window with your carrier(s) before enabling this."
+                    >
+                        <field name="dt_actions_picking_pdf_active" />
+                        <div class="content-group">
+                            <field name="dt_actions_picking_pdf_dry_run" class="oe_inline" />
+                            <label for="dt_actions_picking_pdf_dry_run" string="Dry run (test mode, deletes nothing)" />
+                            <div class="text-muted">Test mode: the scheduled action only logs what it would delete, without deleting anything. Untick it to actually delete.</div>
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_picking_pdf_limit" string="Attachments per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_picking_pdf_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_picking_pdf_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_picking_pdf_max_date_days" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_picking_pdf_pattern" string="Name pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_picking_pdf_pattern" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <field name="dt_actions_picking_pdf_only_done" />
+                            <label for="dt_actions_picking_pdf_only_done" string="Only finished deliveries (done)" />
+                        </div>
+                        <div class="content-group">
+                            <field name="dt_actions_picking_pdf_only_cancel" />
+                            <label for="dt_actions_picking_pdf_only_cancel" string="Only cancelled deliveries" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_picking_pdf_active">
+                            <label for="dt_actions_picking_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_picking_pdf_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Old messages cleanup" name="dt_actions_messages">
-                        <setting
-                            string="Old messages cleanup"
-                            help="Deletes old chatter messages (and their non-XML/ZIP attachments) on models matching the excluded-models list -- excluded models keep their full history."
-                        >
-                            <field name="dt_actions_messages_active" />
-                            <label for="dt_actions_messages_active" string="Enabled" />
-                            <field name="dt_actions_messages_dry_run" />
-                            <div class="content-group">
-                                <label for="dt_actions_messages_limit" string="Messages per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_messages_limit" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_messages_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_messages_max_date_days" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_messages_pattern" string="Subject pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_messages_pattern" class="oe_inline" />
-                            </div>
-                            <div class="content-group">
-                                <label for="dt_actions_messages_exclude_models" string="Excluded models" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_messages_exclude_models" class="oe_inline" />
-                            </div>
-                        </setting>
-                    </block>
+                    <setting
+                        string="Old messages cleanup"
+                        help="Deletes old chatter messages (and their non-XML/ZIP attachments), except on the models listed as excluded -- those keep their full history."
+                    >
+                        <field name="dt_actions_messages_active" />
+                        <div class="content-group">
+                            <field name="dt_actions_messages_dry_run" class="oe_inline" />
+                            <label for="dt_actions_messages_dry_run" string="Dry run (test mode, deletes nothing)" />
+                            <div class="text-muted">Test mode: the scheduled action only logs what it would delete, without deleting anything. Untick it to actually delete.</div>
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_messages_limit" string="Messages per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_messages_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_messages_max_date_days" string="Older than (days)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_messages_max_date_days" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_messages_pattern" string="Subject pattern (SQL LIKE, empty = all)" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_messages_pattern" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <label for="dt_actions_messages_exclude_models" string="Excluded models" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_messages_exclude_models" class="oe_inline" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_messages_active">
+                            <label for="dt_actions_messages_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_messages_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Duplicate contacts" name="dt_actions_merge_contacts">
-                        <setting
-                            string="Duplicate contacts"
-                            help="Merges duplicate individual contacts sharing the same email address. Performs the merge directly -- there is no dry-run mode."
-                        >
-                            <field name="dt_actions_merge_contacts_active" />
-                            <label for="dt_actions_merge_contacts_active" string="Enabled" />
-                            <div class="content-group">
-                                <label for="dt_actions_merge_contacts_limit" string="Contact groups per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_merge_contacts_limit" class="oe_inline" />
-                            </div>
-                        </setting>
-                    </block>
+                    <setting
+                        string="Duplicate contacts"
+                        help="Merges duplicate individual contacts sharing the same email address. Performs the merge directly -- there is no dry-run mode."
+                    >
+                        <field name="dt_actions_merge_contacts_active" />
+                        <div class="content-group">
+                            <label for="dt_actions_merge_contacts_limit" string="Contact groups per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_merge_contacts_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_merge_contacts_active">
+                            <label for="dt_actions_merge_contacts_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_merge_contacts_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Duplicate companies" name="dt_actions_merge_companies">
-                        <setting
-                            string="Duplicate companies"
-                            help="Merges duplicate companies sharing the same VAT number. Performs the merge directly -- there is no dry-run mode."
-                        >
-                            <field name="dt_actions_merge_companies_active" />
-                            <label for="dt_actions_merge_companies_active" string="Enabled" />
-                            <div class="content-group">
-                                <label for="dt_actions_merge_companies_limit" string="Company groups per run" class="col-lg-4 o_light_label" />
-                                <field name="dt_actions_merge_companies_limit" class="oe_inline" />
-                            </div>
-                        </setting>
-                    </block>
+                    <setting
+                        string="Duplicate companies"
+                        help="Merges duplicate companies sharing the same VAT number. Performs the merge directly -- there is no dry-run mode."
+                    >
+                        <field name="dt_actions_merge_companies_active" />
+                        <div class="content-group">
+                            <label for="dt_actions_merge_companies_limit" string="Company groups per run" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_merge_companies_limit" class="oe_inline" />
+                        </div>
+                        <div class="content-group" invisible="not dt_actions_merge_companies_active">
+                            <label for="dt_actions_merge_companies_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_merge_companies_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Missing reordering rules" name="dt_actions_reorder_rules">
-                        <setting
-                            string="Missing reordering rules"
-                            help="Creates stock reordering rules for storable products that have none. Requires the deltatech_auto_reorder_rule module. No other parameters."
-                        >
-                            <field name="dt_actions_reorder_rules_active" />
-                            <label for="dt_actions_reorder_rules_active" string="Enabled" />
-                        </setting>
-                    </block>
+                    <setting
+                        string="Missing reordering rules"
+                        help="Creates stock reordering rules for storable products that have none. Requires the deltatech_auto_reorder_rule module. No other parameters."
+                    >
+                        <field name="dt_actions_reorder_rules_active" />
+                        <div class="content-group" invisible="not dt_actions_reorder_rules_active">
+                            <label for="dt_actions_reorder_rules_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_reorder_rules_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
 
-                    <block title="Normalize company names" name="dt_actions_normalize_names">
-                        <setting
-                            string="Normalize company names"
-                            help="Standardizes legal-form suffixes in company names (e.g. srl -&gt; S.R.L., sa -&gt; S.A., pfa -&gt; P.F.A., ii -&gt; I.I.). Processes up to 500 records per run. No other parameters."
-                        >
-                            <field name="dt_actions_normalize_names_active" />
-                            <label for="dt_actions_normalize_names_active" string="Enabled" />
-                        </setting>
-                    </block>
-                </app>
+                    <setting
+                        string="Normalize company names"
+                        help="Standardizes legal-form suffixes in company names (e.g. srl -&gt; S.R.L., sa -&gt; S.A., pfa -&gt; P.F.A., ii -&gt; I.I.). Processes up to 500 records per run. No other parameters."
+                    >
+                        <field name="dt_actions_normalize_names_active" />
+                        <div class="content-group" invisible="not dt_actions_normalize_names_active">
+                            <label for="dt_actions_normalize_names_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
+                            <field name="dt_actions_normalize_names_nextcall" class="oe_inline" />
+                        </div>
+                    </setting>
+                </block>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Ce conține

Două commituri pe `deltatech_actions`, pornite dintr-un raport de UI („nu e clar ce fac cele două bife").

### 1. `[FIX]` lista de modele excluse nu excludea nimic

Curățarea mesajelor vechi filtra cu `model NOT LIKE ANY(array[...])`, ceea ce Postgres desfășoară în `NOT LIKE p1 OR NOT LIKE p2 OR ...` — orice valoare care se potrivește cu un pattern trece prin celelalte. Cu 2+ intrări în listă (implicit `business.%,project.%,helpdesk.%`) excluderea nu funcționa deloc.

Măsurat pe o copie de producție:

| predicat | rânduri `sale.%` selectate ca „neexcluse" |
|---|---|
| `model NOT LIKE ANY(array['sale.%','res.%'])` | 630.349 |
| `NOT (model LIKE ANY(array['sale.%','res.%']))` | 0 |

Nu s-a pierdut chatter nicăieri: cronul vine dezactivat și în dry run.

### 2. `[IMP]` setările de curățenie: claritate, dată de rulare, traduceri

- În `<setting>`, Odoo ridică primul câmp boolean ca bifa titlului — deci bifa de lângă „Invoice PDF cleanup" era `_active`, iar a doua bifă, cea de după eticheta „Enabled", era de fapt `_dry_run`, fără etichetă proprie. Eticheta descria bifa greșită. Etichetele „Enabled" (redundante) au fost scoase, iar fiecare bifă de dry run are acum etichetă și o explicație de un rând.
- Cele 9 acțiuni nu justifică un app propriu în bara de Setări: sunt acum un singur bloc „Database Cleanup" în Configurări generale.
- Fiecare curățenie activă afișează (și permite modificarea) datei următoarei execuții, citită din / scrisă în `ir.cron.nextcall`, ca la actualizarea automată a cursului valutar.
- Textul de ajutor al curățării de mesaje descria lista de excluderi ca listă de includeri — corectat.
- `ro.po` complet: 99 de termeni, 0 netraduși. A fost regenerat și `deltatech_actions.pot` — `PoFileReader` fuzionează `ro.po` cu `.pot`-ul modulului și marchează obsolete ce lipsește acolo, deci cu `.pot`-ul vechi doar 33 din 114 rânduri se importau.

## Verificare

- Instalare curată pe `deltest19` + `-u` pe `ptc19`, fără erori; server pornit și `/web/login` → 200.
- Citirea/scrierea `nextcall` testată în shell: `set_values()` → `cron.active=True`, `nextcall=2026-09-01 03:00`.
- Traducerile confirmate în bază după `-u --i18n-overwrite`: `field_description->>'ro_RO'` și `arch_db->>'ro_RO'` populate.
- Predicatul SQL corectat, verificat pe date reale (tabelul de mai sus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)