### PR TITLE
[IMP] deltatech_actions: dry run reports what it would delete + Run now button

### DIFF
--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.4.0",
+    "version": "19.0.0.5.0",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/i18n/deltatech_actions.pot
+++ b/deltatech_actions/i18n/deltatech_actions.pot
@@ -6,14 +6,32 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0+e\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-08-27 07:27+0000\n"
-"PO-Revision-Date: 2026-08-27 07:27+0000\n"
+"POT-Creation-Date: 2026-08-27 07:41+0000\n"
+"PO-Revision-Date: 2026-08-27 07:41+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid " (%(size)s MB)"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "%(count)s records%(size)s deleted."
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "%(count)s records%(size)s would be deleted. Nothing was deleted."
+msgstr ""
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
@@ -38,6 +56,12 @@ msgstr ""
 #. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_limit
 msgid "Attachments to delete (sale order PDF)"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "Cleanup done"
 msgstr ""
 
 #. module: deltatech_actions
@@ -157,6 +181,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:deltatech_actions.field_sale_order__display_name
 #: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__display_name
 msgid "Display Name"
+msgstr ""
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "Dry run"
 msgstr ""
 
 #. module: deltatech_actions
@@ -512,6 +542,11 @@ msgstr ""
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Run now"
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
 msgid "SQL LIKE, empty = all"
 msgstr ""
 
@@ -548,6 +583,13 @@ msgstr ""
 msgid ""
 "Test mode: the scheduled action only logs what it would delete, without "
 "deleting anything. Untick it to actually delete."
+msgstr ""
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"This runs the cleanup right now. With Dry run ticked nothing is deleted; "
+"with it unticked the deletion is permanent."
 msgstr ""
 
 #. module: deltatech_actions

--- a/deltatech_actions/i18n/ro.po
+++ b/deltatech_actions/i18n/ro.po
@@ -6,7 +6,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 19.0\n"
 "Report-Msgid-Bugs-To: \n"
-"PO-Revision-Date: 2026-08-27 10:30+0300\n"
+"PO-Revision-Date: 2026-08-27 10:45+0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: ro\n"
@@ -14,6 +14,24 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);\n"
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid " (%(size)s MB)"
+msgstr " (%(size)s MB)"
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "%(count)s records%(size)s deleted."
+msgstr "S-au șters %(count)s înregistrări%(size)s."
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "%(count)s records%(size)s would be deleted. Nothing was deleted."
+msgstr "S-ar șterge %(count)s înregistrări%(size)s. Nu s-a șters nimic."
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
@@ -39,6 +57,12 @@ msgstr "Atașamente de șters (PDF factură)"
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_sale_pdf_limit
 msgid "Attachments to delete (sale order PDF)"
 msgstr "Atașamente de șters (PDF comandă de vânzare)"
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "Cleanup done"
+msgstr "Curățare efectuată"
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
@@ -171,6 +195,12 @@ msgstr ""
 #: model:ir.model.fields,field_description:deltatech_actions.field_stock_picking__display_name
 msgid "Display Name"
 msgstr "Nume afișat"
+
+#. module: deltatech_actions
+#. odoo-python
+#: code:addons/deltatech_actions/models/res_config_settings.py:0
+msgid "Dry run"
+msgstr "Rulare de test"
 
 #. module: deltatech_actions
 #: model:ir.model.fields,field_description:deltatech_actions.field_res_config_settings__dt_actions_picking_pdf_dry_run
@@ -529,6 +559,11 @@ msgstr "Variantă produs"
 
 #. module: deltatech_actions
 #: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid "Run now"
+msgstr "Rulează acum"
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
 msgid "SQL LIKE, empty = all"
 msgstr "SQL LIKE, gol = toate"
 
@@ -571,6 +606,15 @@ msgid ""
 msgstr ""
 "Mod de test: acțiunea programată doar înregistrează în jurnal ce ar șterge, "
 "fără să șteargă efectiv. Debifează pentru ștergere reală."
+
+#. module: deltatech_actions
+#: model_terms:ir.ui.view,arch_db:deltatech_actions.res_config_settings_view_form
+msgid ""
+"This runs the cleanup right now. With Dry run ticked nothing is deleted; "
+"with it unticked the deletion is permanent."
+msgstr ""
+"Rulează curățarea chiar acum. Cu „Rulare de test\" bifată nu se șterge "
+"nimic; cu ea debifată, ștergerea este definitivă."
 
 #. module: deltatech_actions
 #: model:ir.model,name:deltatech_actions.model_stock_picking

--- a/deltatech_actions/models/__init__.py
+++ b/deltatech_actions/models/__init__.py
@@ -2,6 +2,7 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
+from . import cleanup_summary
 from . import account_move
 from . import sale_order
 from . import product

--- a/deltatech_actions/models/account_move.py
+++ b/deltatech_actions/models/account_move.py
@@ -10,6 +10,8 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, models
 from odoo.tools import str2bool
 
+from .cleanup_summary import log_prefix, rows_summary
+
 _logger = logging.getLogger(__name__)
 
 
@@ -34,12 +36,14 @@ class AccountMove(models.Model):
         """Entry point used by the cron: reads its parameters from Settings
         (General Settings > Database Cleanup) instead of hardcoded values."""
         icp = self.env["ir.config_parameter"].sudo()
-        return self.cron_clean_generated_pdfs(
+        dry_run = str2bool(icp.get_param("deltatech_actions.invoice_pdf_dry_run", "True"))
+        rows = self.cron_clean_generated_pdfs(
             limit=int(icp.get_param("deltatech_actions.invoice_pdf_limit", 5000)),
             pattern=icp.get_param("deltatech_actions.invoice_pdf_pattern", "") or "",
             max_date_days=int(icp.get_param("deltatech_actions.invoice_pdf_max_date_days", 90)),
-            dry_run=str2bool(icp.get_param("deltatech_actions.invoice_pdf_dry_run", "True")),
+            dry_run=dry_run,
         )
+        return rows_summary(rows, dry_run)
 
     @api.model
     def cron_clean_xml_attachments(
@@ -85,19 +89,21 @@ class AccountMove(models.Model):
                 linked_attachments = invoice_id.edi_document_ids.attachment_id
                 attachments -= linked_attachments
                 if attachments:
-                    try:
-                        if not dry_run:
-                            if len(attachments) > max_attachments_to_delete:
-                                attachments = attachments[:max_attachments_to_delete]
-                            _logger.info(
-                                f"Deleting attachments: {attachment_name[0]} ({counter}/{att_count} - {len(attachments)} attachments to delete)"
-                            )
-                            total_attachments += len(attachments)
+                    if len(attachments) > max_attachments_to_delete:
+                        attachments = attachments[:max_attachments_to_delete]
+                    total_attachments += len(attachments)
+                    _logger.info(
+                        f"{log_prefix(dry_run)} attachments: {attachment_name[0]} "
+                        f"({counter}/{att_count} - {len(attachments)} attachments)"
+                    )
+                    if not dry_run:
+                        try:
                             attachments.sudo().unlink()
-                    except Exception as e:
-                        _logger.info(f"Cannot delete attachments: {e}")
+                        except Exception as e:
+                            _logger.info(f"Cannot delete attachments: {e}")
 
-        _logger.info(f"Deleted {total_attachments} attachments.")
+        _logger.info(f"{log_prefix(dry_run)} {total_attachments} attachments.")
+        return {"count": total_attachments, "size": None, "dry_run": dry_run}
 
     @api.model
     def cron_clean_generated_pdfs(self, limit=100, pattern="", max_date_days=False, dry_run=False):
@@ -146,6 +152,7 @@ class AccountMove(models.Model):
             except Exception as e:
                 _logger.info(e)
         _logger.info(
-            f"Deleted {len(attachment_ids)} attachments., total size: {round(sum_sizes / (1024 * 1024), 3)} MB"
+            f"{log_prefix(dry_run)} {len(attachment_ids)} attachments, "
+            f"total size: {round(sum_sizes / (1024 * 1024), 3)} MB"
         )
         return res

--- a/deltatech_actions/models/cleanup_summary.py
+++ b/deltatech_actions/models/cleanup_summary.py
@@ -1,0 +1,22 @@
+# ©  2026 Terrabit
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+# The cleanup crons share one result shape, so the settings screen can report what
+# a run did (or, in dry run, what it would have done) without knowing which cleanup
+# it just triggered.
+
+
+def rows_summary(rows, dry_run):
+    """Summarize the (id, file_size) rows selected by a PDF/label cleanup."""
+    rows = rows or []
+    return {
+        "count": len(rows),
+        "size": sum((row[1] or 0) for row in rows),
+        "dry_run": dry_run,
+    }
+
+
+def log_prefix(dry_run):
+    """'[DRY RUN] Would delete' vs 'Deleted', so a dry run never claims a deletion."""
+    return "[DRY RUN] Would delete" if dry_run else "Deleted"

--- a/deltatech_actions/models/mail_message.py
+++ b/deltatech_actions/models/mail_message.py
@@ -10,6 +10,8 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, models
 from odoo.tools import str2bool
 
+from .cleanup_summary import log_prefix
+
 _logger = logging.getLogger(__name__)
 
 
@@ -81,10 +83,20 @@ class MailMessage(models.Model):
         for attachment in all_attachments:
             if attachment.mimetype not in ["application/xml", "application/zip", "text/plain"]:
                 attachments_to_delete |= attachment
+        # counted before the unlink: the recordsets are unusable afterwards
+        message_count = len(messages_to_delete)
+        attachment_count = len(attachments_to_delete)
+        attachment_size = sum(attachments_to_delete.mapped("file_size"))
         if not dry_run:
             try:
                 attachments_to_delete.sudo().unlink()
                 messages_to_delete.sudo().unlink()
             except Exception as e:
                 _logger.info(e)
-        _logger.info(f"Deleted {len(messages_to_delete)} messages and {len(attachments_to_delete)} attachments linked.")
+        _logger.info(f"{log_prefix(dry_run)} {message_count} messages and {attachment_count} linked attachments.")
+        return {
+            "count": message_count,
+            "size": attachment_size,
+            "attachments": attachment_count,
+            "dry_run": dry_run,
+        }

--- a/deltatech_actions/models/res_config_settings.py
+++ b/deltatech_actions/models/res_config_settings.py
@@ -3,6 +3,7 @@
 # See README.rst file on addons root folder for license details
 
 from odoo import api, fields, models
+from odoo.tools import str2bool
 
 # Field name -> xmlid of the ir.cron it enables/disables. This settings screen
 # is meant to be the ONLY place these crons get turned on: they ship
@@ -27,6 +28,33 @@ CRON_ACTIVE_FIELDS = {
 # Settings > Technical > Automation > Scheduled Actions.
 CRON_NEXTCALL_FIELDS = {
     field_name.replace("_active", "_nextcall"): xmlid for field_name, xmlid in CRON_ACTIVE_FIELDS.items()
+}
+
+
+# Boolean parameters cannot use `config_parameter=`: res.config.settings.set_values()
+# calls set_param(key, False) for an unticked box, and set_param DELETES the parameter
+# on a falsy value -- so the next get_param(key, "True") read brings the default back
+# and unticking never took effect. They are read and written explicitly instead.
+BOOL_PARAM_FIELDS = {
+    "dt_actions_xml_dry_run": "deltatech_actions.xml_dry_run",
+    "dt_actions_invoice_pdf_dry_run": "deltatech_actions.invoice_pdf_dry_run",
+    "dt_actions_sale_pdf_dry_run": "deltatech_actions.sale_pdf_dry_run",
+    "dt_actions_picking_pdf_dry_run": "deltatech_actions.picking_pdf_dry_run",
+    "dt_actions_messages_dry_run": "deltatech_actions.messages_dry_run",
+    "dt_actions_picking_pdf_only_done": "deltatech_actions.picking_pdf_only_done",
+    "dt_actions_picking_pdf_only_cancel": "deltatech_actions.picking_pdf_only_cancel",
+}
+
+
+# Cleanups that can be triggered on the spot from the settings screen, keyed by the
+# suffix of their settings fields. Only the ones with a dry-run mode are here: the
+# partner merges delete data with no way back, and must stay cron-only.
+CRON_RUN_METHODS = {
+    "xml": ("account.move", "cron_clean_xml_attachments_from_settings"),
+    "invoice_pdf": ("account.move", "cron_clean_generated_pdfs_from_settings"),
+    "sale_pdf": ("sale.order", "cron_clean_generated_pdfs_from_settings"),
+    "picking_pdf": ("stock.picking", "cron_clean_generated_pdfs_from_settings"),
+    "messages": ("mail.message", "cron_clean_old_messages_from_settings"),
 }
 
 
@@ -62,6 +90,9 @@ class ResConfigSettings(models.TransientModel):
         for field_name, xmlid in CRON_NEXTCALL_FIELDS.items():
             cron = self.env.ref(xmlid, raise_if_not_found=False)
             res[field_name] = cron.sudo().nextcall if cron else False
+        icp = self.env["ir.config_parameter"].sudo()
+        for field_name, key in BOOL_PARAM_FIELDS.items():
+            res[field_name] = str2bool(icp.get_param(key, "True"))
         return res
 
     def set_values(self):
@@ -75,6 +106,9 @@ class ResConfigSettings(models.TransientModel):
             nextcall = self[field_name]
             if cron and nextcall and cron.sudo().nextcall != nextcall:
                 cron.sudo().nextcall = nextcall
+        icp = self.env["ir.config_parameter"].sudo()
+        for field_name, key in BOOL_PARAM_FIELDS.items():
+            icp.set_param(key, "True" if self[field_name] else "False")
 
     # -- Duplicate XML attachments (account_move.cron_clean_xml_attachments) --
     dt_actions_xml_limit = fields.Integer(
@@ -97,11 +131,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.xml_max_date_days",
         default=30,
     )
-    dt_actions_xml_dry_run = fields.Boolean(
-        string="Dry run (XML)",
-        config_parameter="deltatech_actions.xml_dry_run",
-        default=True,
-    )
+    dt_actions_xml_dry_run = fields.Boolean(string="Dry run (XML)")
 
     # -- Invoice PDF cleanup (account_move.cron_clean_generated_pdfs) --
     dt_actions_invoice_pdf_limit = fields.Integer(
@@ -119,11 +149,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.invoice_pdf_max_date_days",
         default=90,
     )
-    dt_actions_invoice_pdf_dry_run = fields.Boolean(
-        string="Dry run (invoice PDF)",
-        config_parameter="deltatech_actions.invoice_pdf_dry_run",
-        default=True,
-    )
+    dt_actions_invoice_pdf_dry_run = fields.Boolean(string="Dry run (invoice PDF)")
 
     # -- Sale order PDF cleanup (sale_order.cron_clean_generated_pdfs) --
     dt_actions_sale_pdf_limit = fields.Integer(
@@ -141,11 +167,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.sale_pdf_max_date_days",
         default=90,
     )
-    dt_actions_sale_pdf_dry_run = fields.Boolean(
-        string="Dry run (sale order PDF)",
-        config_parameter="deltatech_actions.sale_pdf_dry_run",
-        default=True,
-    )
+    dt_actions_sale_pdf_dry_run = fields.Boolean(string="Dry run (sale order PDF)")
 
     # -- Picking AWB label cleanup (stock_picking.cron_clean_generated_pdfs) --
     dt_actions_picking_pdf_limit = fields.Integer(
@@ -163,21 +185,9 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.picking_pdf_max_date_days",
         default=180,
     )
-    dt_actions_picking_pdf_dry_run = fields.Boolean(
-        string="Dry run (AWB label)",
-        config_parameter="deltatech_actions.picking_pdf_dry_run",
-        default=True,
-    )
-    dt_actions_picking_pdf_only_done = fields.Boolean(
-        string="Only finished deliveries (done)",
-        config_parameter="deltatech_actions.picking_pdf_only_done",
-        default=True,
-    )
-    dt_actions_picking_pdf_only_cancel = fields.Boolean(
-        string="Only cancelled deliveries",
-        config_parameter="deltatech_actions.picking_pdf_only_cancel",
-        default=True,
-    )
+    dt_actions_picking_pdf_dry_run = fields.Boolean(string="Dry run (AWB label)")
+    dt_actions_picking_pdf_only_done = fields.Boolean(string="Only finished deliveries (done)")
+    dt_actions_picking_pdf_only_cancel = fields.Boolean(string="Only cancelled deliveries")
 
     # -- Old messages cleanup (mail_message.cron_clean_old_messages) --
     dt_actions_messages_limit = fields.Integer(
@@ -195,11 +205,7 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.messages_max_date_days",
         default=90,
     )
-    dt_actions_messages_dry_run = fields.Boolean(
-        string="Dry run (messages)",
-        config_parameter="deltatech_actions.messages_dry_run",
-        default=True,
-    )
+    dt_actions_messages_dry_run = fields.Boolean(string="Dry run (messages)")
     dt_actions_messages_exclude_models = fields.Char(
         string="Excluded models (messages, comma-separated SQL LIKE patterns)",
         config_parameter="deltatech_actions.messages_exclude_models",
@@ -217,3 +223,53 @@ class ResConfigSettings(models.TransientModel):
         config_parameter="deltatech_actions.merge_companies_limit",
         default=10,
     )
+
+    # -- Run a cleanup on the spot, and report what it did --------------------------
+
+    def _dt_actions_run_now(self, key):
+        """Save the settings as shown, run that cleanup synchronously and report the
+        outcome as a notification: with dry run on, nothing is deleted and the user
+        still sees what would have been."""
+        self.ensure_one()
+        self.set_values()
+        model_name, method_name = CRON_RUN_METHODS[key]
+        result = getattr(self.env[model_name].sudo(), method_name)() or {}
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "info" if result.get("dry_run") else "success",
+                "title": self.env._("Dry run") if result.get("dry_run") else self.env._("Cleanup done"),
+                "message": self._dt_actions_run_message(result),
+                "sticky": False,
+            },
+        }
+
+    def _dt_actions_run_message(self, result):
+        count = result.get("count", 0)
+        size = result.get("size")
+        size_text = ""
+        if size:
+            size_text = self.env._(" (%(size)s MB)", size=round(size / (1024 * 1024), 1))
+        if result.get("dry_run"):
+            return self.env._(
+                "%(count)s records%(size)s would be deleted. Nothing was deleted.",
+                count=count,
+                size=size_text,
+            )
+        return self.env._("%(count)s records%(size)s deleted.", count=count, size=size_text)
+
+    def action_dt_actions_run_xml(self):
+        return self._dt_actions_run_now("xml")
+
+    def action_dt_actions_run_invoice_pdf(self):
+        return self._dt_actions_run_now("invoice_pdf")
+
+    def action_dt_actions_run_sale_pdf(self):
+        return self._dt_actions_run_now("sale_pdf")
+
+    def action_dt_actions_run_picking_pdf(self):
+        return self._dt_actions_run_now("picking_pdf")
+
+    def action_dt_actions_run_messages(self):
+        return self._dt_actions_run_now("messages")

--- a/deltatech_actions/models/sale_order.py
+++ b/deltatech_actions/models/sale_order.py
@@ -10,6 +10,8 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, models
 from odoo.tools import str2bool
 
+from .cleanup_summary import log_prefix, rows_summary
+
 _logger = logging.getLogger(__name__)
 
 
@@ -21,12 +23,14 @@ class SaleOrder(models.Model):
         """Entry point used by the cron: reads its parameters from Settings
         (General Settings > Database Cleanup) instead of hardcoded values."""
         icp = self.env["ir.config_parameter"].sudo()
-        return self.cron_clean_generated_pdfs(
+        dry_run = str2bool(icp.get_param("deltatech_actions.sale_pdf_dry_run", "True"))
+        rows = self.cron_clean_generated_pdfs(
             limit=int(icp.get_param("deltatech_actions.sale_pdf_limit", 5000)),
             pattern=icp.get_param("deltatech_actions.sale_pdf_pattern", "") or "",
             max_date_days=int(icp.get_param("deltatech_actions.sale_pdf_max_date_days", 90)),
-            dry_run=str2bool(icp.get_param("deltatech_actions.sale_pdf_dry_run", "True")),
+            dry_run=dry_run,
         )
+        return rows_summary(rows, dry_run)
 
     def force_cancel_order_and_moves(self):
         """
@@ -89,6 +93,7 @@ class SaleOrder(models.Model):
             except Exception as e:
                 _logger.info(e)
         _logger.info(
-            f"Deleted {len(attachment_ids)} attachments., total size: {round(sum_sizes / (1024 * 1024), 3)} MB"
+            f"{log_prefix(dry_run)} {len(attachment_ids)} attachments, "
+            f"total size: {round(sum_sizes / (1024 * 1024), 3)} MB"
         )
         return res

--- a/deltatech_actions/models/stock_picking.py
+++ b/deltatech_actions/models/stock_picking.py
@@ -10,6 +10,8 @@ from dateutil.relativedelta import relativedelta
 from odoo import api, models
 from odoo.tools import str2bool
 
+from .cleanup_summary import log_prefix, rows_summary
+
 _logger = logging.getLogger(__name__)
 
 
@@ -26,13 +28,15 @@ class StockPicking(models.Model):
             states.append("done")
         if str2bool(icp.get_param("deltatech_actions.picking_pdf_only_cancel", "True")):
             states.append("cancel")
-        return self.cron_clean_generated_pdfs(
+        dry_run = str2bool(icp.get_param("deltatech_actions.picking_pdf_dry_run", "True"))
+        rows = self.cron_clean_generated_pdfs(
             limit=int(icp.get_param("deltatech_actions.picking_pdf_limit", 5000)),
             pattern=icp.get_param("deltatech_actions.picking_pdf_pattern", "") or "",
             max_date_days=int(icp.get_param("deltatech_actions.picking_pdf_max_date_days", 180)),
-            dry_run=str2bool(icp.get_param("deltatech_actions.picking_pdf_dry_run", "True")),
+            dry_run=dry_run,
             states=states or None,
         )
+        return rows_summary(rows, dry_run)
 
     @api.model
     def cron_clean_generated_pdfs(self, limit=100, pattern="", max_date_days=False, dry_run=False, states=None):
@@ -90,6 +94,7 @@ class StockPicking(models.Model):
             except Exception as e:
                 _logger.info(e)
         _logger.info(
-            f"Deleted {len(attachment_ids)} attachments., total size: {round(sum_sizes / (1024 * 1024), 3)} MB"
+            f"{log_prefix(dry_run)} {len(attachment_ids)} attachments, "
+            f"total size: {round(sum_sizes / (1024 * 1024), 3)} MB"
         )
         return res

--- a/deltatech_actions/readme/CONFIGURE.md
+++ b/deltatech_actions/readme/CONFIGURE.md
@@ -17,6 +17,15 @@ no need to open the scheduled action to find out when it runs. A cleanup that ha
 since install keeps an old `nextcall`, so it fires on the first cron tick after you enable it;
 push the date forward if you want it to start later.
 
+Each cleanup that has a dry-run mode also has a **Run now** button: it saves the settings as shown,
+runs that cleanup on the spot and reports the outcome as a notification — "1832 records (512.4 MB)
+would be deleted. Nothing was deleted." in dry run, or the same count as deleted for a real run.
+Use it to size a cleanup before enabling its cron. The partner merges have no such button on
+purpose: they delete data with no dry-run mode and no way back, so they stay cron-only.
+
+The server log distinguishes the two modes as well — a dry run logs `[DRY RUN] Would delete N
+attachments ...` instead of claiming a deletion.
+
 ## Duplicate XML attachments
 
 Cron: *Delete duplicate xml attachments*. Model: `account.move`. Removes duplicate XML (EDI/ANAF)

--- a/deltatech_actions/tests/__init__.py
+++ b/deltatech_actions/tests/__init__.py
@@ -5,3 +5,5 @@ from . import test_cron_xml
 from . import test_cron_old_messages
 from . import test_invoice_cron_pdfs
 from . import test_res_partner
+from . import test_cron_from_settings
+from . import test_run_now_button

--- a/deltatech_actions/tests/test_run_now_button.py
+++ b/deltatech_actions/tests/test_run_now_button.py
@@ -1,0 +1,83 @@
+# © 2026 Deltatech
+# See README.rst file on addons root folder for license details
+
+import base64
+from datetime import datetime, timedelta
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestRunNowButton(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.icp = cls.env["ir.config_parameter"].sudo()
+        cls.partner = cls.env["res.partner"].create({"name": "Run Now Customer"})
+        cls.move = cls.env["account.move"].create(
+            {
+                "move_type": "out_invoice",
+                "partner_id": cls.partner.id,
+                "invoice_date": cls.env.cr.now(),
+            }
+        )
+
+    def _create_old_pdf(self, name="RUNNOW_0001.pdf", days_ago=100):
+        att = self.env["ir.attachment"].create(
+            {
+                "name": name,
+                "res_model": "account.move",
+                "res_id": self.move.id,
+                "type": "binary",
+                "datas": base64.b64encode(b"pdf"),
+                "mimetype": "application/pdf",
+            }
+        )
+        past = datetime.utcnow() - timedelta(days=days_ago)
+        self.env.cr.execute("UPDATE ir_attachment SET create_date = %s WHERE id = %s", (past, att.id))
+        return att
+
+    def _settings(self, dry_run):
+        return self.env["res.config.settings"].create(
+            {
+                "dt_actions_invoice_pdf_dry_run": dry_run,
+                "dt_actions_invoice_pdf_pattern": "RUNNOW_%",
+                "dt_actions_invoice_pdf_max_date_days": 1,
+                "dt_actions_invoice_pdf_limit": 100,
+            }
+        )
+
+    def test_run_now_in_dry_run_reports_without_deleting(self):
+        att = self._create_old_pdf()
+        action = self._settings(dry_run=True).action_dt_actions_run_invoice_pdf()
+
+        self.assertEqual(action["tag"], "display_notification")
+        self.assertIn("would be deleted", action["params"]["message"])
+        self.assertTrue(att.exists(), "dry run must not delete anything")
+
+    def test_run_now_without_dry_run_deletes(self):
+        att = self._create_old_pdf()
+        action = self._settings(dry_run=False).action_dt_actions_run_invoice_pdf()
+
+        self.assertEqual(action["params"]["type"], "success")
+        self.assertIn("deleted", action["params"]["message"])
+        self.assertFalse(att.exists())
+
+    def test_xml_cleanup_counts_in_dry_run(self):
+        """The XML cleanup used to report 0 in dry run, whatever it had found."""
+        for _i in range(12):
+            self.env["ir.attachment"].create(
+                {
+                    "name": "duplicate.xml",
+                    "res_model": "account.move",
+                    "res_id": self.move.id,
+                    "type": "binary",
+                    "datas": base64.b64encode(b"<xml/>"),
+                    "mimetype": "application/xml",
+                }
+            )
+        result = self.env["account.move"].cron_clean_xml_attachments(
+            limit=10, duplicates=10, max_attachments_to_delete=50, dry_run=True
+        )
+        self.assertTrue(result["dry_run"])
+        self.assertEqual(result["count"], 12)

--- a/deltatech_actions/views/res_config_settings_views.xml
+++ b/deltatech_actions/views/res_config_settings_views.xml
@@ -38,6 +38,11 @@
                             <label for="dt_actions_xml_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
                             <field name="dt_actions_xml_nextcall" class="oe_inline" />
                         </div>
+                        <div class="content-group">
+                            <button name="action_dt_actions_run_xml" type="object" string="Run now"
+                                class="btn-link ps-0" icon="fa-play"
+                                confirm="This runs the cleanup right now. With Dry run ticked nothing is deleted; with it unticked the deletion is permanent." />
+                        </div>
                     </setting>
 
                     <setting
@@ -66,6 +71,11 @@
                             <label for="dt_actions_invoice_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
                             <field name="dt_actions_invoice_pdf_nextcall" class="oe_inline" />
                         </div>
+                        <div class="content-group">
+                            <button name="action_dt_actions_run_invoice_pdf" type="object" string="Run now"
+                                class="btn-link ps-0" icon="fa-play"
+                                confirm="This runs the cleanup right now. With Dry run ticked nothing is deleted; with it unticked the deletion is permanent." />
+                        </div>
                     </setting>
 
                     <setting
@@ -93,6 +103,11 @@
                         <div class="content-group" invisible="not dt_actions_sale_pdf_active">
                             <label for="dt_actions_sale_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
                             <field name="dt_actions_sale_pdf_nextcall" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <button name="action_dt_actions_run_sale_pdf" type="object" string="Run now"
+                                class="btn-link ps-0" icon="fa-play"
+                                confirm="This runs the cleanup right now. With Dry run ticked nothing is deleted; with it unticked the deletion is permanent." />
                         </div>
                     </setting>
 
@@ -130,6 +145,11 @@
                             <label for="dt_actions_picking_pdf_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
                             <field name="dt_actions_picking_pdf_nextcall" class="oe_inline" />
                         </div>
+                        <div class="content-group">
+                            <button name="action_dt_actions_run_picking_pdf" type="object" string="Run now"
+                                class="btn-link ps-0" icon="fa-play"
+                                confirm="This runs the cleanup right now. With Dry run ticked nothing is deleted; with it unticked the deletion is permanent." />
+                        </div>
                     </setting>
 
                     <setting
@@ -161,6 +181,11 @@
                         <div class="content-group" invisible="not dt_actions_messages_active">
                             <label for="dt_actions_messages_nextcall" string="Next execution" class="col-lg-4 o_light_label" />
                             <field name="dt_actions_messages_nextcall" class="oe_inline" />
+                        </div>
+                        <div class="content-group">
+                            <button name="action_dt_actions_run_messages" type="object" string="Run now"
+                                class="btn-link ps-0" icon="fa-play"
+                                confirm="This runs the cleanup right now. With Dry run ticked nothing is deleted; with it unticked the deletion is permanent." />
                         </div>
                     </setting>
 


### PR DESCRIPTION
Continuare la #2857. Răspunde la întrebarea „dacă e pusă rulare de test, ce poate să vadă utilizatorul?" — până acum: nimic.

## Problema

Un dry run nu lăsa nicio urmă vizibilă: nimic în chatter, niciun rezultat salvat pe vreun câmp, iar singura urmă era o linie de log care spunea `Deleted 1832 attachments.` indiferent dacă ștergea sau nu. La curățarea XML-urilor duplicate era mai rău: logarea și numărătoarea erau *înăuntrul* lui `if not dry_run`, deci testul raporta invariabil `Deleted 0 attachments.` — imposibil de deosebit de „n-am găsit nimic de curățat".

## Ce aduce PR-ul

**1. Log onest**

`[DRY RUN] Would delete N attachments ...` în test, `Deleted ...` doar la rulare reală. Curățarea XML numără acum ce *ar* șterge (inclusiv truncherea la maximul pe factură), în loc să tacă.

**2. Buton „Rulează acum"**

Fiecare curățenie cu mod de test are un buton în Configurări generale: salvează setările așa cum sunt afișate, rulează curățarea pe loc și raportează rezultatul ca notificare — *„S-ar șterge 1832 înregistrări (512,4 MB). Nu s-a șters nimic."* Folositor pentru a dimensiona o curățenie înainte de a-i activa cronul.

Îmbinările de partneri **nu** au buton, intenționat: șterg date fără mod de test și fără cale de întoarcere, deci rămân doar pe cron. Butonul are confirmare, fiindcă cu dry run debifat ștergerea e definitivă.

Punctele de intrare ale cronurilor întorc acum un sumar uniform; cronurile în sine păstrează lista de rânduri pe care se bazează testele existente.

## Două bug-uri găsite în timpul testării

**Bifele booleene nu puteau fi debifate.** `res.config.settings.set_values()` apelează `set_param(key, False)` pentru o bifă scoasă, iar `set_param` **șterge** parametrul cu valoare falsy — deci următorul `get_param(key, "True")` readucea default-ul. Practic: *rularea de test nu putea fi oprită din interfață*, iar nici cele două filtre de stare ale curățării AWB. Cele 7 câmpuri nu mai folosesc `config_parameter=`; se citesc și se scriu explicit ca `"True"`/`"False"`.

Dovadă (shell, după fix):
```
după debifare    -> 'False'
reîncărcat în UI -> False
după rebifare    -> 'True'
```

**`tests/test_cron_from_settings.py` nu era importat** în `tests/__init__.py`, deci nu rula deloc. Adăugat, împreună cu teste pentru buton și pentru numărătoarea XML în dry run.

## Verificare

- `--test-tags=/deltatech_actions` pe `deltest19`: **0 failed, 0 errors of 24 tests** (erau 21 înainte).
- `-u --i18n-overwrite` pe `ptc19`, fără erori; butonul apare tradus („Rulează acum") în arch-ul RO din bază.
- `ro.po` / `.pot` regenerate: 107 intrări, 0 netraduse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)