### PR TITLE
[FIX] deltatech_purchase_ubl: surface SPV import warnings, shorten log (#9287)

### DIFF
--- a/deltatech_purchase_ubl/i18n/ro.po
+++ b/deltatech_purchase_ubl/i18n/ro.po
@@ -14,6 +14,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+"Language: ro\n"
 
 #. module: deltatech_purchase_ubl
 #: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
@@ -23,8 +24,8 @@ msgstr "<i class=\"fa fa-exclamation-triangle me-1\" title=\"Avertisment\"/>"
 #. module: deltatech_purchase_ubl
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
-msgid "Added %s lines to the purchase order from XML."
-msgstr "Adăugat %s linii la comanda de achiziție din XML."
+msgid "Added %s lines to the purchase order from source document."
+msgstr "Adăugat %s linii la comanda de achiziție din documentul sursă."
 
 #. module: deltatech_purchase_ubl
 #: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
@@ -68,8 +69,8 @@ msgstr ""
 #. module: deltatech_purchase_ubl
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
-msgid "Created products:\n"
-msgstr "Produse create:\n"
+msgid "Created products (%s):\n"
+msgstr "Produse create (%s):\n"
 
 #. module: deltatech_purchase_ubl
 #: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__display_name
@@ -141,12 +142,12 @@ msgstr ""
 #. module: deltatech_purchase_ubl
 #: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__log
 msgid "Log"
-msgstr ""
+msgstr "Jurnal"
 
 #. module: deltatech_purchase_ubl
 #: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__log_html
 msgid "Log Html"
-msgstr ""
+msgstr "Jurnal (HTML)"
 
 #. module: deltatech_purchase_ubl
 #. odoo-python
@@ -197,12 +198,13 @@ msgstr "Comandă de achiziție"
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid ""
-"Purchase order already has lines. XML import will update only the existing "
-"order lines; new lines from the XML will not be added to the purchase order."
+"Purchase order already has lines. Import will update only the existing "
+"order lines; new lines from the source document will not be added to the "
+"purchase order."
 msgstr ""
-"Comanda de achiziție are deja linii. Importul XML va actualiza doar liniile "
-"de comandă existente; noile linii din XML nu vor fi adăugate la comanda de "
-"achiziție."
+"Comanda de achiziție are deja linii. Importul va actualiza doar liniile de "
+"comandă existente; noile linii din documentul sursă nu vor fi adăugate la "
+"comanda de achiziție."
 
 #. module: deltatech_purchase_ubl
 #. odoo-python
@@ -215,10 +217,10 @@ msgstr "Recepție actualizată: %s"
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid ""
 "Receipt validation skipped: no purchase order was resolved from the context "
-"or XML."
+"or source document."
 msgstr ""
 "Validarea recepției a fost sărită: nu s-a rezolvat nicio comandă de "
-"achiziție din context sau XML."
+"achiziție din context sau din documentul sursă."
 
 #. module: deltatech_purchase_ubl
 #: model_terms:ir.ui.view,arch_db:deltatech_purchase_ubl.view_purchase_ubl_import_wizard
@@ -273,8 +275,8 @@ msgstr "Linii neasociate în comandă: %s"
 #. module: deltatech_purchase_ubl
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
-msgid "Unmatched products in XML: %s"
-msgstr "Produse negăsite în XML: %s"
+msgid "Unmatched products: %s"
+msgstr "Produse negăsite: %s"
 
 #. module: deltatech_purchase_ubl
 #: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__update_prices
@@ -284,14 +286,20 @@ msgstr "Actualizează prețurile furnizorului"
 #. module: deltatech_purchase_ubl
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
-msgid "Updated %s purchase order lines from XML."
-msgstr "Actualizat %s linii de comandă de achiziție din XML."
+msgid "Updated %s purchase order lines from source document."
+msgstr "Actualizat %s linii de comandă de achiziție din documentul sursă."
 
 #. module: deltatech_purchase_ubl
 #. odoo-python
-#: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
-msgid "Updated prices:\n"
-msgstr "Prețuri actualizate:\n"
+#: code:addons/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py:0
+msgid "Identified products and updated prices for %s line(s)."
+msgstr "Produse identificate și prețuri actualizate pentru %s linie(i)."
+
+#. module: deltatech_purchase_ubl
+#. odoo-python
+#: code:addons/deltatech_purchase_ubl/models/purchase_order.py:0
+msgid "SPV import needs review"
+msgstr "Import SPV necesită verificare"
 
 #. module: deltatech_purchase_ubl
 #: model:ir.model.fields,field_description:deltatech_purchase_ubl.field_purchase_ubl_import_wizard__validate_receipt
@@ -324,10 +332,10 @@ msgstr "Factură furnizor creată: %s"
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid ""
 "Vendor bill creation skipped: no purchase order was resolved from the "
-"context or XML."
+"context or source document."
 msgstr ""
 "Crearea facturii de furnizor a fost sărită: nu s-a rezolvat nicio comandă de"
-" achiziție din context sau XML."
+" achiziție din context sau din documentul sursă."
 
 #. module: deltatech_purchase_ubl
 #. odoo-python
@@ -360,12 +368,12 @@ msgstr "Vezi factura furnizor"
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid ""
-"Warning: Supplier VAT in XML (%(xml_vat)s) differs from order supplier "
-"(%(po_vat)s). Proceeded with order's vendor."
+"Warning: Supplier VAT in source document (%(xml_vat)s) differs from order "
+"supplier (%(po_vat)s). Proceeded with order's vendor."
 msgstr ""
-"Avertisment: Codul de TVA al furnizorului în XML (%(xml_vat)s) diferă de cel"
-" al furnizorului din comandă (%(po_vat)s). S-a procedat cu furnizorul din "
-"comandă."
+"Avertisment: Codul de TVA al furnizorului în documentul sursă (%(xml_vat)s) "
+"diferă de cel al furnizorului din comandă (%(po_vat)s). S-a procedat cu "
+"furnizorul din comandă."
 
 #. module: deltatech_purchase_ubl
 #. odoo-python
@@ -397,7 +405,7 @@ msgstr "Fișier XML"
 #. odoo-python
 #: code:addons/deltatech_purchase_ubl/wizard/ubl_import_wizard.py:0
 msgid "total"
-msgstr ""
+msgstr "total"
 
 #. module: deltatech_purchase_ubl
 #. odoo-python

--- a/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
+++ b/deltatech_purchase_ubl/models/purchase_invoice_import_mixin.py
@@ -33,6 +33,10 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
 
     log = fields.Text(readonly=True)
     log_html = fields.Html(readonly=True, sanitize=True)
+    # Set alongside log/log_html when at least one result message is a mismatch or an
+    # unmatched line (see _classify_message) - lets a headless caller (the SPV auto-import)
+    # decide whether the run needs a human's attention, without re-parsing the log text.
+    has_warning = fields.Boolean(readonly=True)
 
     # ------------------------------------------------------------
     # Helpers
@@ -763,9 +767,9 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
                 % {"xml_vat": supplier_vat or "-", "po_vat": partner.vat or "-"}
             )
         if updated:
-            messages.append(_("Updated prices:\n") + "\n".join(updated))
+            messages.append(_("Identified products and updated prices for %s line(s).") % len(updated))
         if created:
-            messages.append(_("Created products:\n") + "\n".join(created))
+            messages.append(_("Created products (%s):\n") % len(created) + "\n".join(created))
         if order and updated_lines_count:
             messages.append(_("Updated %s purchase order lines from source document.") % updated_lines_count)
         if order and added_count:
@@ -788,6 +792,13 @@ class PurchaseInvoiceImportMixin(models.AbstractModel):
 
         self.log = "\n".join(messages)
         self.log_html = self._build_log_html(messages)
+        # Deliberately narrower than "any warning/danger-classified message": routine steps
+        # of an unattended import (bill creation skipped because the order isn't confirmed
+        # yet, no receipt to validate) also classify as "warning" via _classify_message's
+        # generic keywords, and would otherwise fire on every successful headless import.
+        # Only the two signals discussed on tichet #9287 count here: a total that doesn't
+        # add up, and lines the matcher couldn't place.
+        self.has_warning = bool((total_check and not total_check["matches"]) or (order and not_found))
         self.state = "done"
 
         action = {

--- a/deltatech_purchase_ubl/models/purchase_order.py
+++ b/deltatech_purchase_ubl/models/purchase_order.py
@@ -67,9 +67,26 @@ class PurchaseOrder(models.Model):
                     )
                     wiz = wiz.with_context(active_model="purchase.order", active_id=order.id)
                     wiz.action_import()
-                    # Optional: post log on PO for traceability
-                    if wiz.log:
-                        order.message_post(body=wiz.log)
+                    # Post the color-coded log (matched/updated lines in green, mismatches
+                    # and unmatched lines in red/orange) so the warning stands out in the
+                    # chatter instead of blending into a wall of plain text (tichet #9287).
+                    if wiz.log_html:
+                        order.message_post(body=wiz.log_html)
+                    # A chatter note alone gets buried among the automated SPV cron's other
+                    # traffic (tichet #9287: a total mismatch and 4 unmatched lines sat
+                    # unnoticed in the chatter for hours). Schedule a visible to-do instead,
+                    # so a total mismatch or unmatched line surfaces on the buyer's activities.
+                    # Guarded on summary to avoid piling up duplicates when the SPV cron
+                    # reprocesses the same message (observed ~10x in one morning).
+                    if wiz.has_warning:
+                        summary = self.env._("SPV import needs review")
+                        if not order.activity_ids.filtered(lambda a: a.summary == summary):
+                            order.activity_schedule(
+                                "mail.mail_activity_data_todo",
+                                summary=summary,
+                                note=wiz.log_html or wiz.log,
+                                user_id=order.user_id.id or self.env.uid,
+                            )
                 except Exception:
                     # Swallow exceptions to not break message posting; errors will be visible in server logs
                     continue

--- a/deltatech_purchase_ubl/tests/test_process_attachments.py
+++ b/deltatech_purchase_ubl/tests/test_process_attachments.py
@@ -157,3 +157,74 @@ class TestProcessAttachmentsForPost(TransactionCase):
             products_before,
             "No new product should have been created",
         )
+
+    def test_unmatched_line_schedules_activity_instead_of_silent_chatter_note(self):
+        """Tichet #9287 (continuare): a plain chatter note is easy to miss among the SPV
+        cron's other automated traffic — an unmatched line (or a total mismatch) must
+        surface as a to-do activity on the purchase order, not just as log text."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "company_id": self.company.id,
+                "date_order": "2025-01-01 00:00:00",
+                "partner_ref": "ATT-EXT-PO-REF-WARN",
+            }
+        )
+        xml = _xml_invoice(order_ref=po.name)
+        att = self.env["ir.attachment"].create(
+            {
+                "name": "invoice_attach_warning.xml",
+                "datas": b64encode(xml),
+                "mimetype": "application/xml",
+                "res_model": "purchase.order",
+                "res_id": po.id,
+            }
+        )
+
+        po.with_context(purchase_ubl_no_new_products=True)._process_attachments_for_post([], [att.id], {})
+
+        activities = po.activity_ids.filtered(lambda a: a.summary == "SPV import needs review")
+        self.assertTrue(activities, "An unmatched line must schedule a review activity on the PO")
+
+        # Reprocessing the same attachment (the SPV cron is known to retry) must not pile up
+        # duplicate activities.
+        po.with_context(purchase_ubl_no_new_products=True)._process_attachments_for_post([], [att.id], {})
+        activities_after = po.activity_ids.filtered(lambda a: a.summary == "SPV import needs review")
+        self.assertEqual(len(activities_after), 1, "Reprocessing must not create duplicate review activities")
+
+    def test_matched_import_does_not_schedule_activity(self):
+        """A clean import (everything matched, totals agree) must not create noise."""
+        po = self.env["purchase.order"].create(
+            {
+                "partner_id": self.vendor.id,
+                "company_id": self.company.id,
+                "date_order": "2025-01-01 00:00:00",
+                "partner_ref": "ATT-EXT-PO-REF-CLEAN",
+            }
+        )
+        existing_product = self.env["product.product"].create({"name": "Matched Product", "type": "consu"})
+        self.env["product.supplierinfo"].create(
+            {
+                "partner_id": self.vendor.id,
+                "product_tmpl_id": existing_product.product_tmpl_id.id,
+                "product_id": existing_product.id,
+                "product_code": "VEND-ATT-NEW",
+            }
+        )
+        xml = _xml_invoice(order_ref=po.name)
+        att = self.env["ir.attachment"].create(
+            {
+                "name": "invoice_attach_clean.xml",
+                "datas": b64encode(xml),
+                "mimetype": "application/xml",
+                "res_model": "purchase.order",
+                "res_id": po.id,
+            }
+        )
+
+        po._process_attachments_for_post([], [att.id], {})
+
+        self.assertFalse(
+            po.activity_ids.filtered(lambda a: a.summary == "SPV import needs review"),
+            "A fully matched import must not schedule a review activity",
+        )


### PR DESCRIPTION
## Summary
- Continuare tichet helpdesk #9287 (Damira): mecanismul de verificare total/linii neasociate din importul automat SPV exista deja, dar ajungea doar ca notă text simplu pe chatter-ul PO-ului — ușor de ratat printre reprocesările automate ale cron-ului SPV (același mesaj poate fi reprocesat de ~10 ori într-o dimineață). Confirmat pe producția Damira: PO CA11998 avea o diferență de total de 1161.78 RON și 4 coduri de furnizor neasociate, nesesizate ore în șir.
- `_process_attachments_for_post` postează acum log-ul colorat (`log_html`, deja construit de mixin) în loc de text simplu, și programează o activitate „To-do" pe cumpărător când importul are un total nepotrivit sau linii neasociate reale — deduplicat pe `summary`, ca reprocesările cron-ului să nu creeze activități duplicate.
- Câmp nou `has_warning`, calculat strict din verificarea de total + liniile neasociate — nu din scanarea generică pe cuvinte-cheie (`_classify_message`), care marca și pași de rutină ai unei comenzi neconfirmate (creare factură sărită, nicio recepție de validat) și ar fi declanșat avertisment la orice import automat reușit.
- Linia „Prețuri actualizate" scurtată de la o listă cu fiecare produs la un simplu număr de linii.
- `i18n/ro.po` adus la zi (mai multe `msgid` erau desincronizate de codul curent de dinainte de generalizarea la „documentul sursă") și completate traducerile rămase goale.

Decizie de business luată explicit cu Dorin: **nu** se creează automat produse pentru liniile neasociate — asta ar reintroduce exact regresia rezolvată în #9315 (produse duplicate create tăcut, confirmat pe producția Romchim). Se păstrează „lasă linia neasociată, dar fă avertismentul vizibil".

## Test plan
- [x] `deltatech_purchase_ubl` + `l10n_ro_message_spv_purchase`: 70 teste, 0 failed, 0 error (inclusiv 2 teste noi: activitate programată la avertisment real + fără duplicare la reprocesare, și „import curat nu creează zgomot")
- [x] pre-commit (ruff, pylint_odoo, check .po) — toate trec

🤖 Generated with [Claude Code](https://claude.com/claude-code)