### PR TITLE
[FIX] deltatech_purchase_ubl: bump versiune pentru câmpul has_warning

### DIFF
--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "19.0.1.3.0",
+    "version": "19.0.1.4.0",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",


### PR DESCRIPTION
## Problemă

Pe baza **Romchim**, wizardul de import UBL crapă:

```
psycopg2.errors.UndefinedColumn: column "has_warning" of relation "purchase_ubl_import_wizard" does not exist
```

## Cauză

Commitul 21faf7ebd (PR #9287, „surface SPV import warnings") a adăugat câmpul `has_warning` pe `purchase.invoice.import.mixin` (`models/purchase_invoice_import_mixin.py:39`), dar a lăsat versiunea manifestului neschimbată — `19.0.1.3.0`, aceeași ca înainte de commit.

Fără bump de versiune Odoo nu declanșează upgrade la deploy, așa că pe instanțele care au primit codul nou coloana nu se creează în tabela wizardului, iar `_write_multi` eșuează la flush.

## Fix

Bump la `19.0.1.4.0`, ca upgrade-ul să ruleze automat pe toate instanțele.

Pe bazele deja afectate (Romchim), până la deploy remediul este un upgrade manual al modulului.

🤖 Generated with [Claude Code](https://claude.com/claude-code)