### PR TITLE
[FIX] deltatech_actions: cron parameters could never be changed

### DIFF
--- a/deltatech_actions/README.rst
+++ b/deltatech_actions/README.rst
@@ -58,103 +58,134 @@ Configuration
 =============
 
 All scheduled actions provided by this module are **disabled by
-default** and run in **dry mode** (``dry_run=True``), meaning they only
-log what would be deleted without making any changes. Before activating
-a cron job, review its parameters and switch ``dry_run`` to ``False``.
+default** (``active=False`` on the underlying ``ir.cron`` record, set
+once at install and never reset on upgrade), and the ones that delete
+data also default to **dry mode** (``dry_run``), meaning they only log
+what would be deleted without making any changes.
 
-To configure the scheduled actions, navigate to **Settings > Technical >
-Automation > Scheduled Actions**.
+Everything — including turning a cron **on** — lives in the **Database
+Cleanup** section of **Settings > General Settings**, visible to system
+administrators. Each cleanup is one setting whose title checkbox is
+wired directly to that cron's ``active`` field: this screen is the
+intended single place to activate any of them, instead of hunting down
+the matching entry in Settings > Technical > Automation > Scheduled
+Actions. Every cleanup that deletes data has a separate "Dry run (test
+mode, deletes nothing)" checkbox below it — review the parameters and
+switch dry run off *before* relying on it.
 
-Delete duplicate xml attachments
---------------------------------
+Once a cleanup is enabled, its **Next execution** date is shown (and can
+be changed) right there, the same way the automatic exchange-rate update
+does it — it is the cron's ``nextcall``, so there is no need to open the
+scheduled action to find out when it runs. A cleanup that has been
+disabled since install keeps an old ``nextcall``, so it fires on the
+first cron tick after you enable it; push the date forward if you want
+it to start later.
 
-Model: ``account.move``. Removes duplicate XML (EDI/ANAF) attachments on
-invoices.
+Each cleanup that has a dry-run mode also has a **Run now** button: it
+saves the settings as shown, runs that cleanup on the spot and reports
+the outcome as a notification — "1832 records (512.4 MB) would be
+deleted. Nothing was deleted." in dry run, or the same count as deleted
+for a real run. Use it to size a cleanup before enabling its cron. The
+partner merges have no such button on purpose: they delete data with no
+dry-run mode and no way back, so they stay cron-only.
 
-Parameters passed in the cron code field:
+The server log distinguishes the two modes as well — a dry run logs
+``[DRY RUN] Would delete N attachments ...`` instead of claiming a
+deletion.
 
-- ``limit`` — number of invoice groups to inspect per run (default:
-  ``10``)
-- ``duplicates`` — minimum number of same-name attachments before
-  deletion starts (default: ``10``)
-- ``max_attachments_to_delete`` — safety cap on attachments deleted per
-  run (default: ``50``)
-- ``dry_run`` — set to ``False`` to enable actual deletion (default:
-  ``True``)
+Duplicate XML attachments
+-------------------------
 
-Delete pdf invoice attachments
-------------------------------
+Cron: *Delete duplicate xml attachments*. Model: ``account.move``.
+Removes duplicate XML (EDI/ANAF) attachments on invoices.
 
-Model: ``account.move``. Removes old generated PDF attachments from
-invoices.
+Settings: invoices per run (default ``10``), minimum duplicates before
+deletion starts (default ``10``), max deletions per invoice (default
+``50``), older than N days (default ``30`` — a duplicate created today
+is never touched even if it already matches the threshold above), dry
+run (default on).
 
-Parameters:
+Invoice PDF cleanup
+-------------------
 
-- ``limit`` — maximum number of attachments to delete per run (default:
-  ``5000``)
-- ``pattern`` — name prefix filter, e.g. ``"INV/%"`` (empty string
-  matches all)
-- ``max_date_days`` — delete attachments older than this many days
-  (default: ``90``)
-- ``dry_run`` — set to ``False`` to enable actual deletion (default:
-  ``True``)
+Cron: *Delete pdf invoice attachments*. Model: ``account.move``. Removes
+old auto-generated invoice PDFs — **including the ones attached to the
+outgoing email message rather than to the invoice itself**. Sending an
+invoice by email ("Send & Print") attaches its PDF to that message
+(``ir_attachment.res_model='mail.message'``, with the message pointing
+at the invoice), not to the invoice directly; on a real deployment this
+is where the overwhelming majority of invoice PDFs actually lived (40k+
+out of ~41k, against a handful directly on ``account.move``), and every
+resend leaves its own copy behind. Both are searched.
 
-Delete pdf sale order attachments
----------------------------------
+Settings: attachments per run (default ``5000``), older than N days
+(default ``90``), name pattern (SQL ``LIKE``, empty = all), dry run
+(default on).
 
-Model: ``sale.order``. Removes old generated PDF attachments from sale
-orders.
+Sale order PDF cleanup
+----------------------
 
-Parameters: same as *Delete pdf invoice attachments* (pattern example:
-``"Pro forma/%"``).
+Cron: *Delete pdf sale order attachments*. Model: ``sale.order``.
+Removes old auto-generated sale order/quotation PDFs. Same settings
+shape as invoice PDF cleanup.
 
-Delete pdf pickings attachments
--------------------------------
+AWB label cleanup
+-----------------
 
-Model: ``stock.picking``. Removes old generated PDF (and octet-stream)
-attachments from stock pickings.
+Cron: *Delete pdf pickings attachments*. Model: ``stock.picking``.
+Clears the carrier AWB label PDF (``label_attachment`` field) on old,
+finished deliveries. On a real deployment this field alone accounted for
+**~36 GB across ~150k pickings** — by far the largest single filestore
+consumer, well ahead of anything invoice-related.
 
-Parameters: same as *Delete pdf invoice attachments* (default pattern:
-``"Label%"``).
+The label is regenerable on demand: ``carrier_generate_label()`` (in
+``deltatech_delivery``) re-fetches it from the courier's API via
+``carrier_tracking_ref`` whenever ``label_attachment`` is empty, and
+``has_awb`` stays ``True`` regardless, so nothing looks different in the
+picking's UI. The remaining risk is entirely on the courier's side: for
+a shipment old enough, its API may no longer have the label on file —
+**confirm the actual retention window with the courier(s) in use before
+enabling the scheduled action.**
 
-Delete mail messages
+Settings: attachments per run (default ``5000``), older than N days
+(default ``180``), name pattern (SQL ``LIKE``, empty = all — real label
+filenames vary a lot by carrier, from the carrier's own report name to a
+raw tracking number or the field's technical name, so a narrow pattern
+like ``"Label%"`` silently matches only some of them), "only finished
+deliveries" and "only cancelled deliveries" toggles (both on by default,
+so a delivery still in progress is never touched), dry run (default on).
+
+Old messages cleanup
 --------------------
 
-Model: ``mail.message``. Removes old chatter messages and their linked
-attachments, excluding ANAF/XML/ZIP/plain-text attachments.
+Cron: *Delete mail messages*. Model: ``mail.message``. Removes old
+chatter messages and their non-XML/ZIP/plain-text attachments (ANAF
+documents are always kept regardless of this setting).
 
-Parameters:
+Settings: messages per run (default ``5000``), older than N days
+(default ``90``), subject pattern (SQL ``LIKE``, empty = all), excluded
+models (comma-separated ``LIKE`` patterns, default
+``business.%,project.%,helpdesk.%`` — these keep their full message
+history), dry run (default on).
 
-- ``limit`` — maximum messages to delete per run (default: ``5000``)
-- ``pattern`` — optional subject filter, e.g. ``"Facturx%"`` (default:
-  ``"%"`` = all)
-- ``max_date_days`` — delete messages older than this many days
-  (default: ``90``)
-- ``exclude_models`` — list of model name patterns to skip, e.g.
-  ``["business.%", "project.%", "helpdesk.%"]``
-- ``dry_run`` — set to ``False`` to enable actual deletion (default:
-  ``True``)
+Duplicate contacts / companies
+------------------------------
 
-Create missing reordering rules (0/0)
--------------------------------------
+Two crons: *Merge duplicate contacts by email* (individual contacts
+sharing the same e-mail) and *Merge duplicate companies by VAT*
+(companies sharing the same VAT number), both via Odoo's built-in
+``base.partner.merge.automatic.wizard``.
+
+Settings: contact groups per run (default ``10``), company groups per
+run (default ``10``). These two crons perform the merge directly — there
+is no dry-run mode.
+
+Missing reordering rules
+------------------------
 
 Model: ``product.product``. Creates stock reordering rules for storable
 products that have none. Requires the ``deltatech_auto_reorder_rule``
-module to be installed. No extra parameters.
-
-Merge duplicate contacts by email
----------------------------------
-
-Model: ``res.partner``. Merges individual contacts (non-company, no VAT)
-that share the same e-mail address, using Odoo's built-in
-``base.partner.merge.automatic.wizard``. Parameter: ``limit`` (pairs
-merged per run, default: ``10``).
-
-Merge duplicate companies by VAT
---------------------------------
-
-Model: ``res.partner``. Merges company records that share the same VAT
-number. Parameter: ``limit`` (pairs merged per run, default: ``10``).
+module to be installed. Only setting: Enabled.
 
 Normalize company names
 -----------------------
@@ -162,7 +193,7 @@ Normalize company names
 Model: ``res.partner``. Standardizes legal-form suffixes in company
 names (e.g. ``srl`` → ``S.R.L.``, ``sa`` → ``S.A.``, ``pfa`` →
 ``P.F.A.``, ``ii`` → ``I.I.``). Processes up to 500 records per cron
-run. No extra parameters to configure.
+run. Only setting: Enabled.
 
 Force-cancel server action
 --------------------------
@@ -180,6 +211,36 @@ To activate it, create a **Server Action** manually:
 3. Set action type to *Execute Python Code* and call
    ``record.force_cancel_order_and_moves()``.
 4. Add the action to the sale order's *Action* menu if needed.
+
+Changelog
+=========
+
+19.0.0.6.0
+----------
+
+- Cron code no longer carries call arguments. The cleanup crons ship in
+  a ``noupdate="1"`` data file, so the ``code`` field of an
+  already-created cron is frozen the day the database is created --
+  every later change to those arguments was silently ignored. Measured
+  on a production instance: the module reported 19.0.0.5.0 while its AWB
+  label cron was still running
+  ``cron_clean_generated_pdfs(limit=50, pattern="Label%", max_date_days=90)``,
+  a limit five times smaller than the daily inflow and a pattern
+  matching less than 60% of the real label names, with not a single
+  ``deltatech_actions.*`` system parameter in the database. Nothing
+  failed and nothing was logged: the crons ran green every night and
+  deleted almost nothing.
+- Added a migration that rewrites the ``code`` of existing crons to the
+  parameterless ``*_from_settings()`` entry points. To keep the switch
+  from changing what a cron deletes, the arguments found in the old code
+  are copied into the matching system parameters first: an argument
+  written explicitly in the old call wins, one the old call never passed
+  keeps the module default. Parameters already set from the Settings
+  screen are never overwritten, and a cron edited by hand is left
+  untouched with a warning in the log.
+- Added tests asserting that no cron in the data file passes arguments
+  and that every method it names exists, so the problem cannot come back
+  unnoticed.
 
 Bug Tracker
 ===========

--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.5.0",
+    "version": "19.0.0.6.0",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/migrations/19.0.0.6.0/post-migration.py
+++ b/deltatech_actions/migrations/19.0.0.6.0/post-migration.py
@@ -1,0 +1,218 @@
+# ©  2026 Terrabit
+# See README.rst file on addons root folder for license details
+"""Move the cleanup crons off hardcoded call arguments.
+
+The cron records ship in ``data/ir_cron_data.xml``, which is ``noupdate="1"``
+-- deliberately, so an upgrade never re-enables a cron the customer turned off,
+nor resets its schedule. The side effect is that the ``code`` field of an
+already-created cron is frozen at whatever the module wrote the day it was
+installed. So when 19.0.0.3.0 replaced the argument-carrying calls with
+parameterless ``*_from_settings()`` entry points, every existing database kept
+running the old inline arguments, and the Settings screen became decorative:
+its values are read only by ``*_from_settings()``, which nothing called.
+
+Measured on a production instance (PTC, 27.08.2026): module reported
+19.0.0.5.0, yet the AWB label cron was still executing
+``cron_clean_generated_pdfs(limit=50, pattern="Label%", max_date_days=90)``
+-- a limit 5x smaller than the daily inflow and a pattern that misses 42% of
+the real label names -- while ``ir.config_parameter`` held zero
+``deltatech_actions.*`` keys. Nothing failed, nothing was logged: the crons ran
+green every night and deleted almost nothing.
+
+This script rewrites the ``code`` of the existing records, and -- so the switch
+does not silently change what the cron deletes -- first copies the arguments it
+finds in the old code into the matching system parameters. Rule: an argument
+written explicitly in the old call wins; an argument the old call did not pass
+keeps the module default (which, where they differ, only ever narrows the
+deletion set -- e.g. AWB labels are now restricted to done/cancelled
+transfers). Parameters already present in the database are never overwritten.
+"""
+
+import ast
+import logging
+
+_logger = logging.getLogger(__name__)
+
+PREFIX = "deltatech_actions."
+
+# xml_id -> (new parameterless code, {old kwarg: system parameter suffix})
+CRONS = {
+    "ir_cron_delete_xml_attachments": (
+        "# parameters: Settings > General Settings > Database Cleanup > Duplicate XML attachments\n"
+        "model.cron_clean_xml_attachments_from_settings()",
+        {
+            "limit": "xml_limit",
+            "duplicates": "xml_duplicates",
+            "max_attachments_to_delete": "xml_max_delete",
+            "max_date_days": "xml_max_date_days",
+            "dry_run": "xml_dry_run",
+        },
+    ),
+    "ir_cron_delete_pdf_attachments_invoice": (
+        "# parameters: Settings > General Settings > Database Cleanup > Invoice PDF cleanup\n"
+        "model.cron_clean_generated_pdfs_from_settings()",
+        {
+            "limit": "invoice_pdf_limit",
+            "pattern": "invoice_pdf_pattern",
+            "max_date_days": "invoice_pdf_max_date_days",
+            "dry_run": "invoice_pdf_dry_run",
+        },
+    ),
+    "ir_cron_delete_pdf_attachments_sale_order": (
+        "# parameters: Settings > General Settings > Database Cleanup > Sale order PDF cleanup\n"
+        "model.cron_clean_generated_pdfs_from_settings()",
+        {
+            "limit": "sale_pdf_limit",
+            "pattern": "sale_pdf_pattern",
+            "max_date_days": "sale_pdf_max_date_days",
+            "dry_run": "sale_pdf_dry_run",
+        },
+    ),
+    "ir_cron_delete_pdf_attachments_stock_picking": (
+        "# parameters: Settings > General Settings > Database Cleanup > AWB label cleanup\n"
+        "model.cron_clean_generated_pdfs_from_settings()",
+        {
+            "limit": "picking_pdf_limit",
+            "pattern": "picking_pdf_pattern",
+            "max_date_days": "picking_pdf_max_date_days",
+            "dry_run": "picking_pdf_dry_run",
+        },
+    ),
+    "ir_cron_delete_mail_messages": (
+        "# parameters: Settings > General Settings > Database Cleanup > Old messages cleanup\n"
+        "model.cron_clean_old_messages_from_settings()",
+        {
+            "limit": "messages_limit",
+            "pattern": "messages_pattern",
+            "max_date_days": "messages_max_date_days",
+            "dry_run": "messages_dry_run",
+            "exclude_models": "messages_exclude_models",
+        },
+    ),
+    "ir_cron_merge_contacts": (
+        "# parameters: Settings > General Settings > Database Cleanup > Duplicate contacts merge\n"
+        "model._cron_merge_duplicate_contacts_from_settings()",
+        {"limit": "merge_contacts_limit"},
+    ),
+    "ir_cron_merge_companies": (
+        "# parameters: Settings > General Settings > Database Cleanup > Duplicate companies merge\n"
+        "model._cron_merge_duplicate_companies_from_settings()",
+        {"limit": "merge_companies_limit"},
+    ),
+}
+
+
+def _parse_old_kwargs(code):
+    """Return the keyword arguments of the call in ``code``, or None if the code
+    is not a plain single call we can read. Comment lines are dropped first --
+    the shipped code carries a leading ``# params:`` block."""
+    body = "\n".join(line for line in (code or "").splitlines() if line.strip() and not line.strip().startswith("#"))
+    if not body.strip():
+        return None
+    try:
+        tree = ast.parse(body.strip())
+    except SyntaxError:
+        return None
+    calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call)]
+    if len(calls) != 1:
+        # Hand-edited cron with several statements: leave the arguments alone
+        # rather than guess which call is the relevant one.
+        return None
+    kwargs = {}
+    for keyword in calls[0].keywords:
+        if not keyword.arg:
+            continue
+        try:
+            kwargs[keyword.arg] = ast.literal_eval(keyword.value)
+        except (ValueError, SyntaxError):
+            _logger.warning("Cannot read cron argument %s, it keeps the module default", keyword.arg)
+    return kwargs
+
+
+def _as_param(value):
+    if isinstance(value, bool):
+        return "True" if value else "False"
+    if isinstance(value, (list, tuple)):
+        return ",".join(str(item) for item in value)
+    return str(value)
+
+
+def _code_location(cr, cron_id):
+    """Return (table, row id) holding the cron's ``code``.
+
+    Since 19.0 ``ir.cron`` delegates to ``ir.actions.server``, so ``code`` is a
+    column of ``ir_act_server``, reachable only through
+    ``ir_cron.ir_actions_server_id`` -- ``UPDATE ir_cron SET code`` fails
+    outright. The older layout is still handled, so this script does not break
+    if it is ever replayed on a pre-delegation database.
+    """
+    cr.execute(
+        """SELECT 1 FROM information_schema.columns
+           WHERE table_name = 'ir_cron' AND column_name = 'code'"""
+    )
+    if cr.fetchone():
+        return "ir_cron", cron_id
+    cr.execute("SELECT ir_actions_server_id FROM ir_cron WHERE id = %s", (cron_id,))
+    row = cr.fetchone()
+    return ("ir_act_server", row[0]) if row and row[0] else (None, None)
+
+
+def migrate(cr, version):
+    if not version:
+        return
+
+    for xml_id, (new_code, param_map) in CRONS.items():
+        cr.execute(
+            "SELECT res_id FROM ir_model_data WHERE module = 'deltatech_actions' AND name = %s",
+            (xml_id,),
+        )
+        row = cr.fetchone()
+        if not row:
+            continue
+        cron_id = row[0]
+
+        table, code_id = _code_location(cr, cron_id)
+        if not table:
+            continue
+        # Table name comes from _code_location, never from data.
+        cr.execute(f"SELECT code FROM {table} WHERE id = %s", (code_id,))  # pylint: disable=sql-injection
+        row = cr.fetchone()
+        if not row:
+            continue
+        old_code = row[0] or ""
+        if "_from_settings" in old_code:
+            continue
+
+        kwargs = _parse_old_kwargs(old_code)
+        if kwargs is None:
+            _logger.warning(
+                "Cron %s was edited by hand and is left untouched; its arguments must be moved "
+                "to Settings > General Settings > Database Cleanup manually:\n%s",
+                xml_id,
+                old_code.strip(),
+            )
+            continue
+
+        seeded = {}
+        for kwarg, suffix in param_map.items():
+            if kwarg not in kwargs:
+                continue
+            key = PREFIX + suffix
+            cr.execute("SELECT id FROM ir_config_parameter WHERE key = %s", (key,))
+            if cr.fetchone():
+                # Someone already set it from the Settings screen: their value wins.
+                continue
+            value = _as_param(kwargs[kwarg])
+            cr.execute(
+                """INSERT INTO ir_config_parameter (key, value, create_uid, write_uid, create_date, write_date)
+                   VALUES (%s, %s, 1, 1, NOW(), NOW())""",
+                (key, value),
+            )
+            seeded[suffix] = value
+
+        cr.execute(f"UPDATE {table} SET code = %s WHERE id = %s", (new_code, code_id))  # pylint: disable=sql-injection
+        _logger.info(
+            "Cron %s now reads its parameters from Settings; carried over: %s",
+            xml_id,
+            ", ".join(f"{k}={v}" for k, v in sorted(seeded.items())) or "nothing (module defaults apply)",
+        )

--- a/deltatech_actions/readme/HISTORY.md
+++ b/deltatech_actions/readme/HISTORY.md
@@ -1,0 +1,21 @@
+## 19.0.0.6.0
+
+- Cron code no longer carries call arguments. The cleanup crons ship in a
+  `noupdate="1"` data file, so the `code` field of an already-created cron is
+  frozen the day the database is created -- every later change to those
+  arguments was silently ignored. Measured on a production instance: the module
+  reported 19.0.0.5.0 while its AWB label cron was still running
+  `cron_clean_generated_pdfs(limit=50, pattern="Label%", max_date_days=90)`, a
+  limit five times smaller than the daily inflow and a pattern matching less
+  than 60% of the real label names, with not a single `deltatech_actions.*`
+  system parameter in the database. Nothing failed and nothing was logged: the
+  crons ran green every night and deleted almost nothing.
+- Added a migration that rewrites the `code` of existing crons to the
+  parameterless `*_from_settings()` entry points. To keep the switch from
+  changing what a cron deletes, the arguments found in the old code are copied
+  into the matching system parameters first: an argument written explicitly in
+  the old call wins, one the old call never passed keeps the module default.
+  Parameters already set from the Settings screen are never overwritten, and a
+  cron edited by hand is left untouched with a warning in the log.
+- Added tests asserting that no cron in the data file passes arguments and that
+  every method it names exists, so the problem cannot come back unnoticed.

--- a/deltatech_actions/static/description/index.html
+++ b/deltatech_actions/static/description/index.html
@@ -25,6 +25,11 @@
        data-bs-toggle="pill" data-bs-target="#tb-panel-configure" href="#tb-panel-configure"
        style="padding:10px 22px;">Configuration</a>
   </li>
+  <li class="nav-item mx-1 mb-2">
+    <a class="nav-link fw-semibold rounded-pill border" id="tb-tab-versions"
+       data-bs-toggle="pill" data-bs-target="#tb-panel-versions" href="#tb-panel-versions"
+       style="padding:10px 22px;">Versions</a>
+  </li>
 </ul>
 <div class="tab-content">
 <div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
@@ -37,58 +42,85 @@ All jobs are <strong>disabled by default</strong> and run in <strong>dry mode</s
 </div>
 <div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
-<p>All scheduled actions provided by this module are <strong>disabled by default</strong> and run in <strong>dry mode</strong>
-(<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">dry_run=True</code>), meaning they only log what would be deleted without making any changes.
-Before activating a cron job, review its parameters and switch <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">dry_run</code> to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">False</code>.</p>
-<p>To configure the scheduled actions, navigate to <strong>Settings &gt; Technical &gt; Automation &gt; Scheduled Actions</strong>.</p>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Delete duplicate xml attachments</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move</code>. Removes duplicate XML (EDI/ANAF) attachments on invoices.</p>
-<p>Parameters passed in the cron code field:</p>
-<ul>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">limit</code> — number of invoice groups to inspect per run (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">duplicates</code> — minimum number of same-name attachments before deletion starts (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">max_attachments_to_delete</code> — safety cap on attachments deleted per run (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">50</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">dry_run</code> — set to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">False</code> to enable actual deletion (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">True</code>)</li>
-</ul>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Delete pdf invoice attachments</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move</code>. Removes old generated PDF attachments from invoices.</p>
-<p>Parameters:</p>
-<ul>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">limit</code> — maximum number of attachments to delete per run (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">5000</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">pattern</code> — name prefix filter, e.g. <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">"INV/%"</code> (empty string matches all)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">max_date_days</code> — delete attachments older than this many days (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">90</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">dry_run</code> — set to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">False</code> to enable actual deletion (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">True</code>)</li>
-</ul>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Delete pdf sale order attachments</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">sale.order</code>. Removes old generated PDF attachments from sale orders.</p>
-<p>Parameters: same as <em>Delete pdf invoice attachments</em> (pattern example: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">"Pro forma/%"</code>).</p>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Delete pdf pickings attachments</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">stock.picking</code>. Removes old generated PDF (and octet-stream) attachments from stock pickings.</p>
-<p>Parameters: same as <em>Delete pdf invoice attachments</em> (default pattern: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">"Label%"</code>).</p>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Delete mail messages</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">mail.message</code>. Removes old chatter messages and their linked attachments, excluding
-ANAF/XML/ZIP/plain-text attachments.</p>
-<p>Parameters:</p>
-<ul>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">limit</code> — maximum messages to delete per run (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">5000</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">pattern</code> — optional subject filter, e.g. <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">"Facturx%"</code> (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">"%"</code> = all)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">max_date_days</code> — delete messages older than this many days (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">90</code>)</li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">exclude_models</code> — list of model name patterns to skip, e.g. <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">["business.%", "project.%", "helpdesk.%"]</code></li>
-<li><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">dry_run</code> — set to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">False</code> to enable actual deletion (default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">True</code>)</li>
-</ul>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Create missing reordering rules (0/0)</h2>
+<p>All scheduled actions provided by this module are <strong>disabled by default</strong> (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">active=False</code> on the
+underlying <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ir.cron</code> record, set once at install and never reset on upgrade), and the ones that
+delete data also default to <strong>dry mode</strong> (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">dry_run</code>), meaning they only log what would be deleted
+without making any changes.</p>
+<p>Everything — including turning a cron <strong>on</strong> — lives in the <strong>Database Cleanup</strong> section of
+<strong>Settings &gt; General Settings</strong>, visible to system administrators. Each cleanup is one setting
+whose title checkbox is wired directly to that cron's <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">active</code> field: this screen is the intended
+single place to activate any of them, instead of hunting down the matching entry in Settings &gt;
+Technical &gt; Automation &gt; Scheduled Actions. Every cleanup that deletes data has a separate
+"Dry run (test mode, deletes nothing)" checkbox below it — review the parameters and switch dry
+run off <em>before</em> relying on it.</p>
+<p>Once a cleanup is enabled, its <strong>Next execution</strong> date is shown (and can be changed) right there,
+the same way the automatic exchange-rate update does it — it is the cron's <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">nextcall</code>, so there is
+no need to open the scheduled action to find out when it runs. A cleanup that has been disabled
+since install keeps an old <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">nextcall</code>, so it fires on the first cron tick after you enable it;
+push the date forward if you want it to start later.</p>
+<p>Each cleanup that has a dry-run mode also has a <strong>Run now</strong> button: it saves the settings as shown,
+runs that cleanup on the spot and reports the outcome as a notification — "1832 records (512.4 MB)
+would be deleted. Nothing was deleted." in dry run, or the same count as deleted for a real run.
+Use it to size a cleanup before enabling its cron. The partner merges have no such button on
+purpose: they delete data with no dry-run mode and no way back, so they stay cron-only.</p>
+<p>The server log distinguishes the two modes as well — a dry run logs <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">[DRY RUN] Would delete N
+attachments ...</code> instead of claiming a deletion.</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Duplicate XML attachments</h2>
+<p>Cron: <em>Delete duplicate xml attachments</em>. Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move</code>. Removes duplicate XML (EDI/ANAF)
+attachments on invoices.</p>
+<p>Settings: invoices per run (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>), minimum duplicates before deletion starts (default
+<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>), max deletions per invoice (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">50</code>), older than N days (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">30</code> — a duplicate
+created today is never touched even if it already matches the threshold above), dry run (default
+on).</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Invoice PDF cleanup</h2>
+<p>Cron: <em>Delete pdf invoice attachments</em>. Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move</code>. Removes old auto-generated invoice
+PDFs — <strong>including the ones attached to the outgoing email message rather than to the invoice
+itself</strong>. Sending an invoice by email ("Send &amp; Print") attaches its PDF to that message
+(<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ir_attachment.res_model='mail.message'</code>, with the message pointing at the invoice), not to the
+invoice directly; on a real deployment this is where the overwhelming majority of invoice PDFs
+actually lived (40k+ out of ~41k, against a handful directly on <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move</code>), and every resend
+leaves its own copy behind. Both are searched.</p>
+<p>Settings: attachments per run (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">5000</code>), older than N days (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">90</code>), name pattern
+(SQL <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">LIKE</code>, empty = all), dry run (default on).</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Sale order PDF cleanup</h2>
+<p>Cron: <em>Delete pdf sale order attachments</em>. Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">sale.order</code>. Removes old auto-generated sale
+order/quotation PDFs. Same settings shape as invoice PDF cleanup.</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">AWB label cleanup</h2>
+<p>Cron: <em>Delete pdf pickings attachments</em>. Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">stock.picking</code>. Clears the carrier AWB label PDF
+(<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">label_attachment</code> field) on old, finished deliveries. On a real deployment this field alone
+accounted for <strong>~36 GB across ~150k pickings</strong> — by far the largest single filestore consumer,
+well ahead of anything invoice-related.</p>
+<p>The label is regenerable on demand: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">carrier_generate_label()</code> (in <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_delivery</code>) re-fetches
+it from the courier's API via <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">carrier_tracking_ref</code> whenever <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">label_attachment</code> is empty, and
+<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">has_awb</code> stays <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">True</code> regardless, so nothing looks different in the picking's UI. The remaining
+risk is entirely on the courier's side: for a shipment old enough, its API may no longer have the
+label on file — <strong>confirm the actual retention window with the courier(s) in use before enabling
+the scheduled action.</strong></p>
+<p>Settings: attachments per run (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">5000</code>), older than N days (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">180</code>), name pattern
+(SQL <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">LIKE</code>, empty = all — real label filenames vary a lot by carrier, from the carrier's own
+report name to a raw tracking number or the field's technical name, so a narrow pattern like
+<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">"Label%"</code> silently matches only some of them), "only finished deliveries" and "only cancelled
+deliveries" toggles (both on by default, so a delivery still in progress is never touched), dry
+run (default on).</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Old messages cleanup</h2>
+<p>Cron: <em>Delete mail messages</em>. Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">mail.message</code>. Removes old chatter messages and their
+non-XML/ZIP/plain-text attachments (ANAF documents are always kept regardless of this setting).</p>
+<p>Settings: messages per run (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">5000</code>), older than N days (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">90</code>), subject pattern
+(SQL <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">LIKE</code>, empty = all), excluded models (comma-separated <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">LIKE</code> patterns, default
+<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">business.%,project.%,helpdesk.%</code> — these keep their full message history), dry run (default on).</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Duplicate contacts / companies</h2>
+<p>Two crons: <em>Merge duplicate contacts by email</em> (individual contacts sharing the same e-mail) and
+<em>Merge duplicate companies by VAT</em> (companies sharing the same VAT number), both via Odoo's
+built-in <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">base.partner.merge.automatic.wizard</code>.</p>
+<p>Settings: contact groups per run (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>), company groups per run (default <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>). These two
+crons perform the merge directly — there is no dry-run mode.</p>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Missing reordering rules</h2>
 <p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">product.product</code>. Creates stock reordering rules for storable products that have none.
-Requires the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_auto_reorder_rule</code> module to be installed. No extra parameters.</p>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Merge duplicate contacts by email</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">res.partner</code>. Merges individual contacts (non-company, no VAT) that share the same e-mail address,
-using Odoo's built-in <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">base.partner.merge.automatic.wizard</code>. Parameter: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">limit</code> (pairs merged per run, default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>).</p>
-<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Merge duplicate companies by VAT</h2>
-<p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">res.partner</code>. Merges company records that share the same VAT number.
-Parameter: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">limit</code> (pairs merged per run, default: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">10</code>).</p>
+Requires the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_auto_reorder_rule</code> module to be installed. Only setting: Enabled.</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Normalize company names</h2>
 <p>Model: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">res.partner</code>. Standardizes legal-form suffixes in company names
 (e.g. <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">srl</code> → <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">S.R.L.</code>, <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">sa</code> → <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">S.A.</code>, <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">pfa</code> → <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">P.F.A.</code>, <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ii</code> → <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">I.I.</code>).
-Processes up to 500 records per cron run. No extra parameters to configure.</p>
+Processes up to 500 records per cron run. Only setting: Enabled.</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Force-cancel server action</h2>
 <p>The method <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">force_cancel_order_and_moves</code> on <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">sale.order</code> cancels a confirmed sale order together
 with all its linked stock pickings, stock moves, stock move lines and account moves by writing their
@@ -100,6 +132,31 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
 <li>Set action type to <em>Execute Python Code</em> and call <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">record.force_cancel_order_and_moves()</code>.</li>
 <li>Add the action to the sale order's <em>Action</em> menu if needed.</li>
 </ol>
+</div>
+<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.6.0</h2>
+<ul>
+<li>Cron code no longer carries call arguments. The cleanup crons ship in a
+  <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">noupdate="1"</code> data file, so the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">code</code> field of an already-created cron is
+  frozen the day the database is created -- every later change to those
+  arguments was silently ignored. Measured on a production instance: the module
+  reported 19.0.0.5.0 while its AWB label cron was still running
+  <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">cron_clean_generated_pdfs(limit=50, pattern="Label%", max_date_days=90)</code>, a
+  limit five times smaller than the daily inflow and a pattern matching less
+  than 60% of the real label names, with not a single <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_actions.*</code>
+  system parameter in the database. Nothing failed and nothing was logged: the
+  crons ran green every night and deleted almost nothing.</li>
+<li>Added a migration that rewrites the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">code</code> of existing crons to the
+  parameterless <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">*_from_settings()</code> entry points. To keep the switch from
+  changing what a cron deletes, the arguments found in the old code are copied
+  into the matching system parameters first: an argument written explicitly in
+  the old call wins, one the old call never passed keeps the module default.
+  Parameters already set from the Settings screen are never overwritten, and a
+  cron edited by hand is left untouched with a warning in the log.</li>
+<li>Added tests asserting that no cron in the data file passes arguments and that
+  every method it names exists, so the problem cannot come back unnoticed.</li>
+</ul>
 </div>
 </div>
 

--- a/deltatech_actions/tests/__init__.py
+++ b/deltatech_actions/tests/__init__.py
@@ -7,3 +7,4 @@ from . import test_invoice_cron_pdfs
 from . import test_res_partner
 from . import test_cron_from_settings
 from . import test_run_now_button
+from . import test_cron_code_parameterless

--- a/deltatech_actions/tests/test_cron_code_parameterless.py
+++ b/deltatech_actions/tests/test_cron_code_parameterless.py
@@ -1,0 +1,74 @@
+# © 2026 Deltatech
+# See README.rst file on addons root folder for license details
+"""The cron records live in a ``noupdate="1"`` data file, so their ``code`` is
+frozen the day a database is created: any argument written there can never be
+changed again without a migration script. Measured on a production instance,
+that froze an AWB label cron at ``limit=50, pattern="Label%"`` for months while
+the module reported a version whose code no longer had those arguments.
+
+The rule that keeps this from coming back is: cron code carries no arguments,
+every parameter is read from Settings. These tests guard that rule.
+"""
+
+import ast
+
+from odoo.tests.common import TransactionCase, tagged
+
+CRON_XML_IDS = [
+    "ir_cron_delete_xml_attachments",
+    "ir_cron_delete_pdf_attachments_invoice",
+    "ir_cron_delete_pdf_attachments_sale_order",
+    "ir_cron_delete_pdf_attachments_stock_picking",
+    "ir_cron_delete_mail_messages",
+    "ir_cron_merge_contacts",
+    "ir_cron_merge_companies",
+    "cron_normalize_company_names",
+    "ir_cron_create_missing_reordering_rules",
+]
+
+
+@tagged("post_install", "-at_install")
+class TestCronCodeParameterless(TransactionCase):
+    def test_cron_code_passes_no_arguments(self):
+        for xml_id in CRON_XML_IDS:
+            cron = self.env.ref(f"deltatech_actions.{xml_id}", raise_if_not_found=False)
+            if not cron:
+                continue
+            with self.subTest(xml_id=xml_id):
+                body = "\n".join(
+                    line
+                    for line in (cron.sudo().code or "").splitlines()
+                    if line.strip() and not line.strip().startswith("#")
+                )
+                calls = [node for node in ast.walk(ast.parse(body)) if isinstance(node, ast.Call)]
+                self.assertTrue(calls, f"{xml_id}: cron code calls nothing")
+                for call in calls:
+                    arguments = [ast.unparse(arg) for arg in call.args]
+                    arguments += [f"{kw.arg}=..." for kw in call.keywords]
+                    self.assertFalse(
+                        arguments,
+                        f"{xml_id}: cron code must not carry arguments ({', '.join(arguments)}) -- a "
+                        f"noupdate data file freezes them forever. Read them from Settings instead, "
+                        f"in a *_from_settings() entry point.",
+                    )
+
+    def test_from_settings_entry_points_exist(self):
+        """A parameterless call is only useful if the method it names is really
+        there -- a typo in the data file surfaces as a cron failing at 2 a.m."""
+        for xml_id in CRON_XML_IDS:
+            cron = self.env.ref(f"deltatech_actions.{xml_id}", raise_if_not_found=False)
+            if not cron:
+                continue
+            with self.subTest(xml_id=xml_id):
+                body = "\n".join(
+                    line
+                    for line in (cron.sudo().code or "").splitlines()
+                    if line.strip() and not line.strip().startswith("#")
+                )
+                model = self.env[cron.model_id.model]
+                for call in [node for node in ast.walk(ast.parse(body)) if isinstance(node, ast.Call)]:
+                    method = ast.unparse(call.func).split(".")[-1]
+                    self.assertTrue(
+                        hasattr(model, method),
+                        f"{xml_id}: {cron.model_id.model} has no method {method}()",
+                    )


### PR DESCRIPTION
## Problema

Cronurile de curățare sunt livrate în `data/ir_cron_data.xml`, declarat `noupdate="1"` — deliberat, ca un upgrade să nu reactiveze un cron oprit de client și să nu-i reseteze programul. Efectul secundar: câmpul `code` al unui cron deja creat e **îngheţat din ziua în care a fost creată baza**.

Așa că atunci când 19.0.0.3.0 a înlocuit apelurile cu argumente prin puncte de intrare fără parametri (`*_from_settings()`), fiecare bază existentă a continuat să ruleze argumentele vechi, iar ecranul de configurare a devenit **decorativ** — valorile lui sunt citite exclusiv de `*_from_settings()`, pe care nu-l apela nimeni. `res_config_settings.set_values()` scrie doar `active` și `nextcall`, niciodată `code`.

Măsurat pe o instanță de producție: modulul raporta 19.0.0.5.0, iar cronul de etichete AWB rula în continuare

```
cron_clean_generated_pdfs(limit=50, pattern="Label%", max_date_days=90)
```

— o limită de 5 ori mai mică decât intrarea zilnică și un pattern care ratează peste 40% din numele reale de etichete (se numesc literal `label_attachment` când integrarea de curier nu pune nume de raport, iar `LIKE` în SQL e case-sensitive) — cu **zero** parametri de sistem `deltatech_actions.*` în bază.

Eroare complet tăcută: cronurile rulau verde în fiecare noapte și nu ștergeau practic nimic, în timp ce 36 GB de etichete AWB expirate stăteau pe disc.

## Soluția

O migrare care rescrie `code` pe cronurile existente către apelul fără parametri.

Ca să **nu schimbe tăcut** ce șterge un cron, migrarea preia întâi argumentele din codul vechi în parametrii de sistem corespondenți (parsare cu `ast`):

- un argument scris explicit în apelul vechi **câștigă**;
- un argument care nu era pasat păstrează default-ul de modul (care, acolo unde diferă, doar restrânge setul de ștergere — ex. etichetele AWB sunt acum limitate la livrări `done`/`cancel`);
- un parametru pus deja din ecranul de configurare **nu e suprascris niciodată**;
- un cron editat de mână (mai multe instrucțiuni) e lăsat neatins, cu warning în log.

Deci după upgrade comportamentul e **identic** cu cel de dinainte; diferența e că de acum setările au efect.

## De reținut pentru scripturi similare

Din 19.0, `ir.cron` delegă către `ir.actions.server`, deci `code` stă în `ir_act_server` și `UPDATE ir_cron SET code` **crapă** (`column "code" of relation "ir_cron" does not exist`). Migrarea trece prin `ir_cron.ir_actions_server_id`, cu fallback pe schema veche.

## Prevenire

Două teste noi care nu lasă problema să revină: niciun cron din fișierul de date nu are voie să paseze argumente, și fiecare metodă numită în `code` trebuie să existe pe model.

## Verificat

- **46 de teste, 0 eșecuri, 0 erori** (`-i deltatech_actions --test-tags=/deltatech_actions`)
- migrarea rulată **end-to-end** cu `odoo-bin -u deltatech_actions` pe o bază de test cu `latest_version` coborât manual la 19.0.0.5.0 și codul cronului înlocuit cu cel de pe producție → cod rescris corect, parametri preluați (`picking_pdf_limit=50`, `picking_pdf_pattern=Label%`, `picking_pdf_max_date_days=90`, `picking_pdf_dry_run=False`)
- rerulare: **idempotentă** — a doua trecere nu mai modifică nimic
- `pre-commit` trece pe fișierele atinse

🤖 Generated with [Claude Code](https://claude.com/claude-code)