### PR TITLE
[FIX] deltatech_actions: autovacuum cleanups could get autovacuum disabled

### DIFF
--- a/deltatech_actions/README.rst
+++ b/deltatech_actions/README.rst
@@ -215,6 +215,27 @@ To activate it, create a **Server Action** manually:
 Changelog
 =========
 
+19.0.0.8.0
+----------
+
+- Fixes a risk introduced in 19.0.0.7.0: the auto-vacuum hooks could get
+  Odoo's own auto-vacuum job deactivated. ``_run_vacuum_cleaner``
+  reports progress as ``_commit_progress()`` with no arguments, so the
+  cron's ``done`` counter stays at zero however much the vacuum methods
+  deleted; ``ir.cron._process_job`` then treats a job as failed when it
+  timed out ``CONSECUTIVE_TIMEOUT_FOR_FAILURE`` times *and* ``done`` is
+  zero, and ``_update_failure_count`` deactivates a cron that failed 5
+  times over 7 days. A cleanup with a large backlog is exactly what
+  pushes the job over its time limit run after run -- and switching off
+  ``base.autovacuum_job`` would take ``_gc_file_store`` and every other
+  core vacuum with it. The hooks now report the real batch size, which
+  keeps ``done`` non-zero and makes that verdict impossible.
+- The hooks also stop asking to be requeued when the run has less time
+  left than one and a half times the batch just done, so a batch is
+  never cut off partway. Observed on a staging build: three consecutive
+  auto-vacuum runs at 15:13, 15:17 and 15:33 with ``timed_out_counter``
+  climbing 1, 2 -- one short of the failure threshold.
+
 19.0.0.7.0
 ----------
 

--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.7.0",
+    "version": "19.0.0.8.0",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/models/cleanup_summary.py
+++ b/deltatech_actions/models/cleanup_summary.py
@@ -39,19 +39,59 @@ def autovacuum_run(model, from_settings, limit_param):
     is set, which is what a staging database does in its own neutralize.sql.
 
     Returns ``(done, remaining)`` -- the shape ``_run_vacuum_cleaner`` uses to
-    requeue a method inside the same run, so a large backlog is cleared in one
-    pass instead of one batch per day, within the cron's own time budget.
+    requeue a method inside the same run, so a large backlog is cleared over
+    consecutive batches instead of one per day.
+
+    Two things guard the autovacuum job itself, and they are not optional.
+
+    ``_run_vacuum_cleaner`` reports progress as ``_commit_progress()`` -- with no
+    arguments, so ``processed`` is 0 and the cron's ``done`` counter stays at
+    zero no matter how much work the vacuum methods did. Meanwhile
+    ``ir.cron._process_job`` treats a job as failed when
+    ``timed_out_counter >= CONSECUTIVE_TIMEOUT_FOR_FAILURE and not job['done']``,
+    and ``_update_failure_count`` deactivates a cron that failed 5 times over 7
+    days. A cleanup with a large backlog is exactly what pushes the job over its
+    time limit, run after run -- so left alone it could get Odoo's own
+    autovacuum switched off, taking ``_gc_file_store`` and every other core
+    vacuum with it. Reporting the real count keeps ``done`` non-zero, which
+    makes that verdict impossible.
+
+    And the requeue only happens while there is comfortably time for another
+    batch of the same size, measured on the batch just done, so the method stops
+    asking for more work instead of being cut off mid-run.
     """
+    import time  # noqa: PLC0415 -- keep this module importable without Odoo
+
     from odoo.tools import str2bool  # noqa: PLC0415 -- avoids an import cycle at module load
 
     icp = model.env["ir.config_parameter"].sudo()
     if not str2bool(icp.get_param("deltatech_actions.autovacuum_enabled", "False")):
         return None
     limit = int(icp.get_param(limit_param, 5000))
+
+    start = time.monotonic()
     summary = getattr(model, from_settings)() or {}
+    elapsed = time.monotonic() - start
     count = summary.get("count") or 0
+
+    # Report the batch on the cron (see the docstring: this is what keeps the
+    # autovacuum job from being deactivated) and read how long the run has left.
+    # Only when actually running inside a cron: outside one there is no progress
+    # record and no time limit, and _commit_progress() would commit the caller's
+    # transaction -- surprising from a shell, and forbidden in a test.
+    if model.env.context.get("ir_cron_progress_id"):
+        time_left = model.env["ir.cron"]._commit_progress(count)
+    else:
+        time_left = float("inf")
+
     # A dry run selects the same rows on every call, so it must never ask to be
-    # requeued -- the autovacuum job would spin on it until the cron runs out of
+    # requeued -- the autovacuum job would spin on it until the cron ran out of
     # time, starving the other vacuum methods.
-    remaining = bool(count >= limit and not summary.get("dry_run"))
+    remaining = bool(
+        count >= limit
+        and not summary.get("dry_run")
+        # Half again the time this batch took: enough headroom that the next one
+        # finishes inside the run rather than being killed partway.
+        and time_left > elapsed * 1.5
+    )
     return count, remaining

--- a/deltatech_actions/readme/HISTORY.md
+++ b/deltatech_actions/readme/HISTORY.md
@@ -1,3 +1,22 @@
+## 19.0.0.8.0
+
+- Fixes a risk introduced in 19.0.0.7.0: the auto-vacuum hooks could get Odoo's
+  own auto-vacuum job deactivated. `_run_vacuum_cleaner` reports progress as
+  `_commit_progress()` with no arguments, so the cron's `done` counter stays at
+  zero however much the vacuum methods deleted; `ir.cron._process_job` then
+  treats a job as failed when it timed out `CONSECUTIVE_TIMEOUT_FOR_FAILURE`
+  times *and* `done` is zero, and `_update_failure_count` deactivates a cron
+  that failed 5 times over 7 days. A cleanup with a large backlog is exactly
+  what pushes the job over its time limit run after run -- and switching off
+  `base.autovacuum_job` would take `_gc_file_store` and every other core vacuum
+  with it. The hooks now report the real batch size, which keeps `done`
+  non-zero and makes that verdict impossible.
+- The hooks also stop asking to be requeued when the run has less time left than
+  one and a half times the batch just done, so a batch is never cut off partway.
+  Observed on a staging build: three consecutive auto-vacuum runs at 15:13,
+  15:17 and 15:33 with `timed_out_counter` climbing 1, 2 -- one short of the
+  failure threshold.
+
 ## 19.0.0.7.0
 
 - The invoice, sale order and AWB label cleanups can now also run from Odoo's daily

--- a/deltatech_actions/static/description/index.html
+++ b/deltatech_actions/static/description/index.html
@@ -135,6 +135,25 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
 </div>
 <div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.8.0</h2>
+<ul>
+<li>Fixes a risk introduced in 19.0.0.7.0: the auto-vacuum hooks could get Odoo's
+  own auto-vacuum job deactivated. <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">_run_vacuum_cleaner</code> reports progress as
+  <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">_commit_progress()</code> with no arguments, so the cron's <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">done</code> counter stays at
+  zero however much the vacuum methods deleted; <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ir.cron._process_job</code> then
+  treats a job as failed when it timed out <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">CONSECUTIVE_TIMEOUT_FOR_FAILURE</code>
+  times <em>and</em> <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">done</code> is zero, and <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">_update_failure_count</code> deactivates a cron
+  that failed 5 times over 7 days. A cleanup with a large backlog is exactly
+  what pushes the job over its time limit run after run -- and switching off
+  <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">base.autovacuum_job</code> would take <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">_gc_file_store</code> and every other core vacuum
+  with it. The hooks now report the real batch size, which keeps <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">done</code>
+  non-zero and makes that verdict impossible.</li>
+<li>The hooks also stop asking to be requeued when the run has less time left than
+  one and a half times the batch just done, so a batch is never cut off partway.
+  Observed on a staging build: three consecutive auto-vacuum runs at 15:13,
+  15:17 and 15:33 with <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">timed_out_counter</code> climbing 1, 2 -- one short of the
+  failure threshold.</li>
+</ul>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.7.0</h2>
 <ul>
 <li>The invoice, sale order and AWB label cleanups can now also run from Odoo's daily

--- a/deltatech_actions/tests/test_autovacuum_cleanup.py
+++ b/deltatech_actions/tests/test_autovacuum_cleanup.py
@@ -10,6 +10,7 @@ therefore the only order-independent way a restored copy can tidy itself up.
 
 import base64
 from datetime import datetime, timedelta
+from unittest.mock import patch
 
 from odoo.tests.common import TransactionCase, tagged
 
@@ -76,6 +77,54 @@ class TestAutovacuumCleanup(TransactionCase):
         self.assertEqual(done, 1)
         self.assertFalse(remaining, "a dry run must never report work remaining")
         self.assertTrue(att.exists(), "a dry run must not delete")
+
+    def test_reports_the_batch_on_the_cron(self):
+        """_run_vacuum_cleaner reports progress as _commit_progress() with no
+        arguments, so the cron's `done` counter stays at zero however much the
+        vacuum methods deleted. ir.cron._process_job then treats a job as failed
+        when it timed out CONSECUTIVE_TIMEOUT_FOR_FAILURE times *and* done is
+        zero, and _update_failure_count deactivates a cron that failed 5 times
+        over 7 days -- which would switch Odoo's own autovacuum off, taking
+        _gc_file_store with it. Reporting the real count makes that impossible.
+        """
+        self.icp.set_param("deltatech_actions.autovacuum_enabled", "True")
+        self.icp.set_param("deltatech_actions.sale_pdf_dry_run", "False")
+        self.icp.set_param("deltatech_actions.sale_pdf_limit", "5")
+        self.icp.set_param("deltatech_actions.sale_pdf_max_date_days", "90")
+        self._old_pdf("Oferta - S0005.pdf")
+        reported = []
+
+        def spy(cron_self, processed=0, **kwargs):
+            # Does not call through: the real _commit_progress() commits, which a
+            # test cursor forbids.
+            reported.append(processed)
+            return float("inf")
+
+        # ir_cron_progress_id in the context is how the hook knows it is inside a
+        # cron run; without it there is nothing to report progress to.
+        orders = self.env["sale.order"].with_context(ir_cron_progress_id=1, cron_id=1)
+        with patch.object(type(self.env["ir.cron"]), "_commit_progress", spy):
+            done, _remaining = orders._gc_generated_pdfs()
+
+        self.assertEqual(done, 1)
+        self.assertEqual(reported, [1], "the batch size must reach the cron's progress counter")
+
+    def test_no_requeue_when_the_run_is_nearly_out_of_time(self):
+        """Asking for a requeue with seconds left only gets the next batch killed
+        partway, and pushes the job over its time limit."""
+        self.icp.set_param("deltatech_actions.autovacuum_enabled", "True")
+        self.icp.set_param("deltatech_actions.sale_pdf_dry_run", "False")
+        self.icp.set_param("deltatech_actions.sale_pdf_limit", "1")
+        self.icp.set_param("deltatech_actions.sale_pdf_max_date_days", "90")
+        self._old_pdf("Oferta - S0006.pdf")
+        self._old_pdf("Oferta - S0007.pdf")
+
+        orders = self.env["sale.order"].with_context(ir_cron_progress_id=1, cron_id=1)
+        with patch.object(type(self.env["ir.cron"]), "_commit_progress", lambda *a, **kw: 0.0):
+            done, remaining = orders._gc_generated_pdfs()
+
+        self.assertEqual(done, 1, "the batch still runs")
+        self.assertFalse(remaining, "must not ask for another batch with no time left")
 
     def test_hooks_are_registered_as_autovacuum(self):
         """_run_vacuum_cleaner finds these only through the decorator."""


### PR DESCRIPTION
Corectează un risc introdus de mine în **19.0.0.7.0** (#2862), găsit pe staging în timp ce urmăream de ce jobul se oprea după un lot.

## Problema

`_run_vacuum_cleaner` raportează progresul ca `_commit_progress()` — **fără argumente**, deci `processed` e 0 și contorul `done` al cronului rămâne zero, oricât ar fi șters metodele de vacuum. Iar `ir.cron._process_job` consideră jobul eșuat când:

```python
job['timed_out_counter'] >= CONSECUTIVE_TIMEOUT_FOR_FAILURE   # 3
and not job['done']
```

iar `_update_failure_count` **dezactivează** un cron care a eșuat de 5 ori în 7 zile.

O curățare cu coadă mare e exact ce împinge jobul peste limita de timp, rulare după rulare. Consecința: s-ar putea ajunge ca `base.autovacuum_job` să fie oprit — luând cu el `_gc_file_store` și toate celelalte vacuum-uri din core. Pe o bază neutralizată e singurul cron rămas, deci ar rămâne complet fără curățenie.

Observat pe un build de staging cu ~55.000 de atașamente în coadă: trei rulări consecutive de auto-vacuum la 15:13, 15:17 și 15:33, cu `timed_out_counter` urcând 1, 2 — **la una de prag**.

## Corecția

1. Cârligele raportează dimensiunea reală a lotului, deci `done` devine nenul și verdictul de mai sus devine imposibil.
2. Nu mai cer requeue când în rulare a rămas mai puțin de o dată și jumătate timpul lotului abia terminat — deci un lot nu e niciodată tăiat la mijloc.
3. Progresul se raportează **doar** când suntem chiar într-o rulare de cron (verificat pe `ir_cron_progress_id` din context): în afara ei nu există înregistrare de progres și nici limită de timp, iar `_commit_progress()` ar comite tranzacția apelantului — surprinzător dintr-un shell, și interzis într-un test. Suita de teste a prins exact asta.

## Verificat

**54 de teste, 0 eșecuri.** Două teste noi: că dimensiunea lotului ajunge în contorul de progres al cronului, și că nu se cere requeue când nu mai e timp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)