### PR TITLE
[FIX] deltatech_actions: a NULL file_size killed the whole cleanup run

### DIFF
--- a/deltatech_actions/README.rst
+++ b/deltatech_actions/README.rst
@@ -215,6 +215,20 @@ To activate it, create a **Server Action** manually:
 Changelog
 =========
 
+19.0.0.9.0
+----------
+
+- A single attachment with a NULL ``file_size`` raised
+  ``TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'``
+  and killed the whole cleanup run. All three PDF cleanups summed
+  ``file_size`` with a bare ``+=``, and the column is nullable. Inside
+  the auto-vacuum job the failure is invisible: ``_run_vacuum_cleaner``
+  logs the exception, rolls the transaction back and moves on, so a
+  crashing cleanup is indistinguishable from one that had nothing to
+  delete. Found on a staging database where it had silently stopped the
+  sale order cleanup dead -- the cron reported success, ``done`` stayed
+  0, and not one attachment was removed.
+
 19.0.0.8.0
 ----------
 

--- a/deltatech_actions/__manifest__.py
+++ b/deltatech_actions/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Deltatech Actions",
     "category": "Other",
     "summary": "Cleaning and other actions",
-    "version": "19.0.0.8.0",
+    "version": "19.0.0.9.0",
     "author": "Terrabit, Dan Stoica",
     "website": "https://www.terrabit.ro",
     "license": "OPL-1",

--- a/deltatech_actions/models/account_move.py
+++ b/deltatech_actions/models/account_move.py
@@ -148,10 +148,11 @@ class AccountMove(models.Model):
         self.env.cr.execute(query, params=params)
         res = self.env.cr.fetchall()
         attachment_ids = [item[0] for item in res]
-        sizes = [item[1] for item in res]
-        sum_sizes = 0
-        for size in sizes:
-            sum_sizes += size
+        # `or 0`: ir_attachment.file_size is nullable, and a single NULL row used to
+        # raise TypeError here. Inside the autovacuum job that failure is invisible --
+        # _run_vacuum_cleaner logs the exception, rolls the transaction back and moves
+        # on, so a crashing cleanup looks exactly like one with nothing to delete.
+        sum_sizes = sum((item[1] or 0) for item in res)
         if not dry_run:
             attachments = self.env["ir.attachment"].browse(attachment_ids)
             try:

--- a/deltatech_actions/models/sale_order.py
+++ b/deltatech_actions/models/sale_order.py
@@ -89,10 +89,11 @@ class SaleOrder(models.Model):
         self.env.cr.execute(query, params=params)
         res = self.env.cr.fetchall()
         attachment_ids = [item[0] for item in res]
-        sizes = [item[1] for item in res]
-        sum_sizes = 0
-        for size in sizes:
-            sum_sizes += size
+        # `or 0`: ir_attachment.file_size is nullable, and a single NULL row used to
+        # raise TypeError here. Inside the autovacuum job that failure is invisible --
+        # _run_vacuum_cleaner logs the exception, rolls the transaction back and moves
+        # on, so a crashing cleanup looks exactly like one with nothing to delete.
+        sum_sizes = sum((item[1] or 0) for item in res)
         if not dry_run:
             attachments = self.env["ir.attachment"].browse(attachment_ids)
             try:

--- a/deltatech_actions/models/stock_picking.py
+++ b/deltatech_actions/models/stock_picking.py
@@ -90,10 +90,11 @@ class StockPicking(models.Model):
         self.env.cr.execute(query, params=params)
         res = self.env.cr.fetchall()
         attachment_ids = [item[0] for item in res]
-        sizes = [item[1] for item in res]
-        sum_sizes = 0
-        for size in sizes:
-            sum_sizes += size
+        # `or 0`: ir_attachment.file_size is nullable, and a single NULL row used to
+        # raise TypeError here. Inside the autovacuum job that failure is invisible --
+        # _run_vacuum_cleaner logs the exception, rolls the transaction back and moves
+        # on, so a crashing cleanup looks exactly like one with nothing to delete.
+        sum_sizes = sum((item[1] or 0) for item in res)
         if not dry_run:
             attachments = self.env["ir.attachment"].browse(attachment_ids)
             try:

--- a/deltatech_actions/readme/HISTORY.md
+++ b/deltatech_actions/readme/HISTORY.md
@@ -1,3 +1,14 @@
+## 19.0.0.9.0
+
+- A single attachment with a NULL `file_size` raised
+  `TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'` and killed the
+  whole cleanup run. All three PDF cleanups summed `file_size` with a bare `+=`, and
+  the column is nullable. Inside the auto-vacuum job the failure is invisible:
+  `_run_vacuum_cleaner` logs the exception, rolls the transaction back and moves on, so
+  a crashing cleanup is indistinguishable from one that had nothing to delete. Found on
+  a staging database where it had silently stopped the sale order cleanup dead -- the
+  cron reported success, `done` stayed 0, and not one attachment was removed.
+
 ## 19.0.0.8.0
 
 - Fixes a risk introduced in 19.0.0.7.0: the auto-vacuum hooks could get Odoo's

--- a/deltatech_actions/static/description/index.html
+++ b/deltatech_actions/static/description/index.html
@@ -135,6 +135,17 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
 </div>
 <div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
+<h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.9.0</h2>
+<ul>
+<li>A single attachment with a NULL <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">file_size</code> raised
+  <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'</code> and killed the
+  whole cleanup run. All three PDF cleanups summed <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">file_size</code> with a bare <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">+=</code>, and
+  the column is nullable. Inside the auto-vacuum job the failure is invisible:
+  <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">_run_vacuum_cleaner</code> logs the exception, rolls the transaction back and moves on, so
+  a crashing cleanup is indistinguishable from one that had nothing to delete. Found on
+  a staging database where it had silently stopped the sale order cleanup dead -- the
+  cron reported success, <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">done</code> stayed 0, and not one attachment was removed.</li>
+</ul>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.8.0</h2>
 <ul>
 <li>Fixes a risk introduced in 19.0.0.7.0: the auto-vacuum hooks could get Odoo's

--- a/deltatech_actions/tests/test_autovacuum_cleanup.py
+++ b/deltatech_actions/tests/test_autovacuum_cleanup.py
@@ -134,3 +134,50 @@ class TestAutovacuumCleanup(TransactionCase):
             with self.subTest(model=model):
                 func = type(self.env[model])._gc_generated_pdfs
                 self.assertTrue(is_autovacuum(func), f"{model}._gc_generated_pdfs is not an autovacuum method")
+
+
+@tagged("post_install", "-at_install")
+class TestNullFileSize(TransactionCase):
+    """ir_attachment.file_size is nullable, and the cleanups sum it to report how much
+    they freed. A single NULL row used to raise TypeError -- and inside the autovacuum
+    job that failure is invisible: _run_vacuum_cleaner logs the exception, rolls the
+    transaction back and moves on, so a crashing cleanup is indistinguishable from one
+    with nothing to delete. Found on a real staging database, where it silently stopped
+    the sale order cleanup dead.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.icp = cls.env["ir.config_parameter"].sudo()
+        cls.partner = cls.env["res.partner"].create({"name": "Null Size Customer"})
+        cls.order = cls.env["sale.order"].create({"partner_id": cls.partner.id})
+
+    def test_cleanup_survives_a_null_file_size(self):
+        att = self.env["ir.attachment"].create(
+            {
+                "name": "Oferta - S9999.pdf",
+                "res_model": "sale.order",
+                "res_id": self.order.id,
+                "type": "binary",
+                "datas": base64.b64encode(b"pdf"),
+                "mimetype": "application/pdf",
+            }
+        )
+        past = datetime.utcnow() - timedelta(days=200)
+        self.env.cr.execute(
+            "UPDATE ir_attachment SET create_date = %s, file_size = NULL WHERE id = %s",
+            (past, att.id),
+        )
+        self.env["ir.attachment"].invalidate_model(["create_date", "file_size"])
+
+        self.icp.set_param("deltatech_actions.sale_pdf_dry_run", "False")
+        self.icp.set_param("deltatech_actions.sale_pdf_limit", "10")
+        self.icp.set_param("deltatech_actions.sale_pdf_max_date_days", "90")
+        self.icp.set_param("deltatech_actions.sale_pdf_pattern", "")
+
+        summary = self.env["sale.order"].cron_clean_generated_pdfs_from_settings()
+
+        self.assertEqual(summary["count"], 1)
+        self.assertEqual(summary["size"], 0, "a NULL size must count as zero, not blow up")
+        self.assertFalse(att.exists())


### PR DESCRIPTION
## Problema

Toate cele trei curățări de PDF-uri însumau `ir_attachment.file_size` cu un `+=` simplu, iar coloana e **nullable**. Un singur rând cu NULL era de ajuns:

```
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```

Partea urâtă: **în job-ul de auto-vacuum eșecul e invizibil.** `_run_vacuum_cleaner` prinde excepția, o loghează, face `rollback` și trece la următoarea metodă — deci o curățare care crapă e indistinguibilă de una care nu avea ce șterge: cronul raportează succes, `done` rămâne 0, și nu se șterge nici un atașament.

## Cum a fost găsit

Pe o bază de staging, urmărind exact acest simptom. Curățarea de etichete AWB rămăsese legitim fără candidați (cei rămași erau pe livrări care nu sunt `done`/`cancel`), dar curățarea pe `sale.order` era **moartă** din cauza asta — și nimic nu spunea nimic. A ieșit la lumină doar apelând metoda prin RPC, unde traceback-ul nu e înghițit.

## Corecția

`sum((item[1] or 0) for item in res)` în toate trei, cu un comentariu care spune de ce contează `or 0` — pentru că altfel arată ca o precauție inutilă.

## Verificat

**57 de teste, 0 eșecuri.** Test nou care creează un atașament cu `file_size = NULL` prin SQL și verifică că curățarea îl șterge și raportează dimensiunea 0 în loc să crape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)