### PR TITLE
[DOC] Noutăți 19.0 per modul + index de suită

### DIFF
--- a/NOUTATI_19.md
+++ b/NOUTATI_19.md
@@ -1,0 +1,108 @@
+# Ce e nou în 19.0 — Suita deltatech — module de bază pentru ERP
+
+Sinteză a noutăților față de versiunea 18.0, pe 47 module. Detaliile fiecărui modul sunt în
+`<modul>/readme/NOUTATI_19.md`.
+
+## Module noi în 19.0 (13)
+
+- **Câmp Markdown** (`deltatech_markdown_field`) — Editare vizuală pentru câmpurile de text lungi, cu bară de
+  instrumente (îngroșat, cursiv, titluri, liste, citate, blocuri de cod, linkuri), în timp ce în baza de date se….
+- **Formule în rețeta de fabricație** (`deltatech_mrp_bom_formula`) — Cantitatea unei componente se calculează din
+  atributele variantei fabricate, printr-o formulă, în locul repetării aceleiași componente pe câte o linie pentru
+  fiecare….
+- **Comasare parteneri în masă** (`deltatech_partner_merge`) — Comasează în minute partenerii duplicați pe același CUI,
+  în masă.
+- **Sincronizare preț în POS** (`deltatech_pos_price_sync`) — Schimbarea prețului ajunge instantaneu în sesiunile POS
+  deja deschise.
+- **Scor de vizibilitate a produsului pe site** (`deltatech_product_visibility`) — Un scor 0–100 de vizibilitate pentru
+  fiecare produs, afișat ca semafor colorat, cu defalcare pe criterii — dintr-o privire se vede cât de complet și de
+  găsibil este….
+- **Listă de prețuri pe proiect** (`deltatech_project_price_list`) — Listă de prețuri definită la nivel de proiect,
+  folosită automat la crearea comenzilor de vânzare din proiect sau din sarcini — managerul de proiect nu mai trebuie
+  să….
+- **Buton „Creează factură" la achiziții** (`deltatech_purchase_create_bill_button`) — Readuce butonul clasic „Creează
+  factură" pe comanda de achiziție.
+- **Cereri de ofertă din ofertă de vânzare** (`deltatech_sale_purchase_requisition`) — Buton pe oferta de vânzare care
+  generează cereri de ofertă către furnizori din liniile ofertei, cu legătura păstrată înapoi la ofertă.
+- **Unități de măsură secundare pe produs** (`deltatech_secondary_uom`) — Factori de conversie specifici fiecărui produs
+  între unitatea de bază și o unitate alternativă (după modelul SAP MARM).
+- **Cantitate multiplă la regulile de reaprovizionare** (`deltatech_stock_orderpoint_multiple`) — Readuce rotunjirea la
+  un multiplu pe regulile de reaprovizionare, câmp pe care Odoo l-a eliminat la trecerea la versiunea 19.0.
+- **Terrabit Connect (bază)** (`deltatech_tc`) — Puntea dintre Odoo din cloud și echipamentele din rețeaua locală a
+  clientului — casă de marcat, cântar, linie de sortare, PLC, server de etichete — pe care Odoo nu le….
+- **Logo după echipa de vânzare** (`deltatech_team_logo`) — Logo diferit în rapoartele PDF (factură, ofertă/comandă,
+  aviz de livrare) în funcție de echipa de vânzare a documentului — soluția pentru companiile care operează mai….
+- **Transport de configurări între medii** (`deltatech_transport_change`) — Export al modificărilor de configurare și
+  transportul lor între medii (dezvoltare → test → producție), urmărite prin git — configurările nu mai sunt reintroduse
+  manual….
+
+## Module cu funcționalități noi față de 18.0 (34)
+
+- **Acțiuni de curățare a bazei** (`deltatech_actions`) — Curățările se pornesc și se opresc din Setări.
+- **Procese de implementare** (`deltatech_business_process`) — Bibliotecă de procese alimentată din module și din
+  depozite git.
+- **Document de predare** (`deltatech_business_process_handover_document`) — Filtrare după etapa de implementare,
+  aliniată la etapele definibile de utilizator din modulul de procese — documentul de predare acoperă exact etapa
+  dorită.
+- **Prețurile concurenței** (`deltatech_competitors_price`) — Urmărirea prețurilor concurenței, prin extragerea automată
+  a datelor de pe paginile web ale acestora, cu preluare la cerere — comparația de preț se face în Odoo, nu în….
+- **Declarație de conformitate** (`deltatech_dc`) — Formatul tipărit al declarației a fost curățat (structură și stil),
+  deci documentul trimis clientului arată corect indiferent de lungimea denumirilor.
+- **Optimizare imagini** (`deltatech_image_optimize`) — Eliminarea imaginilor de produs duplicate.
+- **Facturarea livrărilor** (`deltatech_invoice_picking`) — Filtrarea livrărilor după „facturat" dă rezultate corecte în
+  toate combinațiile (facturat/nefacturat, egal/diferit), inclusiv după facturarea în lot — comportament….
+- **Readucerea facturii în ciornă** (`deltatech_invoice_to_draft`) — Modulul funcționează pe 19.0, adaptat la modul nou
+  în care Odoo 19 organizează grupurile de acces.
+- **Acoperirea stocului negativ** (`deltatech_move_negative_stock`) — Modulul funcționează pe 19.0, adaptat la
+  modificările Odoo 19 privind mișcările de stoc.
+- **Partener generic** (`deltatech_partner_generic`) — Partenerul generic este protejat împotriva modificărilor
+  accidentale.
+- **Codificare produse** (`deltatech_product_code`) — Verificarea unicității codurilor de bare ține cont de companie,
+  deci în bazele multi-companie nu mai raportează fals duplicate între companii diferite.
+- **Dimensiuni produs** (`deltatech_product_dimension`) — Modulul este complet aliniat cu versiunea 18.0 — aceleași
+  câmpuri, ecrane și traduceri.
+- **Linie suplimentară pe achiziție** (`deltatech_purchase_add_extra_line`) — Prețul introdus manual pe linia
+  suplimentară nu mai este rescris.
+- **Actualizare preț furnizor la recepție** (`deltatech_purchase_price`) — Migrarea datelor pe 19.0 folosește utilitarul
+  standard, deci prețurile devenite dependente de companie sunt convertite corect și replicate pe toate companiile din
+  bază —….
+- **Achiziții și stoc** (`deltatech_purchase_stock`) — Comenzile de achiziție generate de reaprovizionare rămân separate
+  de cele create manual de cumpărător — sunt marcate ca atare și nu se mai contopesc cu comenzile manuale….
+- **Strategii de depozitare** (`deltatech_putaway_strategy`) — Modulul este declarat Production/Stable, aliniat cu
+  versiunea 18.0 — capacitățile de locație și strategia extinsă de depozitare sunt disponibile fără restricții de….
+- **Cozi de sarcini** (`deltatech_queue_job`) — Sarcinile eșuate duplicate se anulează automat.
+- **Raport materiale de ambalare** (`deltatech_report_packaging`) — Evidența materialelor de ambalare consumate pentru
+  produsele facturate: configurare pe produs, urmărire pe liniile de factură și asistent de completare în masă — baza….
+- **Rapoarte PRN** (`deltatech_report_prn`) — Punct de extensie pentru tipărirea directă, care permite modulului
+  companion Zebra să intercepteze raportul și să îl trimită la imprimantă, cu revenire la descărcarea….
+- **Audit apeluri RPC** (`deltatech_rpc_audit`) — Auditarea acoperă și noul punct de acces /json/2.
+- **Ultima modificare pe comandă** (`deltatech_sale_activity_report`) — Comportamentul rămâne cel din 18.0, acum
+  acoperit de teste automate — se consemnează doar modificările făcute de utilizatori reali, nu cele generate de sistem.
+- **Linie suplimentară pe vânzare** (`deltatech_sale_add_extra_line`) — Prețul introdus manual pe linia suplimentară se
+  păstrează, în loc să fie readus tăcut la valoarea implicită.
+- **Analiza vânzărilor pe cotă de TVA** (`deltatech_sale_analysis_vat`) — Cota de TVA devine filtru și criteriu de
+  grupare în Analiza facturilor și în Analiza punctului de vânzare.
+- **Comisioane de vânzare** (`deltatech_sale_commission`) — Se aliniază la politica configurabilă de vânzare sub cost
+  din verificarea marjei — comisionul se calculează coerent cu regula aleasă de companie.
+- **Verificarea marjei la vânzare** (`deltatech_sale_margin`) — Reacția la vânzarea sub cost devine politică de
+  companie, aleasă din Setări: blocare (comportamentul de până acum), avertizare sau doar consemnare.
+- **Vânzare → achiziție** (`deltatech_sale_purchase`) — Anularea comenzii de vânzare elimină corect toate liniile de
+  achiziție generate (atâta timp cât comanda de achiziție e încă ciornă), nu doar o parte dintre ele.
+- **Închiderea stocului la dată** (`deltatech_stock_close`) — Modulul este disponibil pe 19.0, la paritate cu versiunea
+  18.0 — închiderea operațiunilor de stoc la o dată dată funcționează identic.
+- **Inventar (metoda clasică)** (`deltatech_stock_inventory`) — Nota de inventar este vizibilă implicit pe linie.
+- **Jurnal de activitate pe livrări** (`deltatech_stock_picking_activity_report`) — Descrierea operațiilor transferului
+  nu mai este trunchiată.
+- **Categorii publice în magazin** (`deltatech_website_category`) — Modulul este disponibil pe 19.0, cu arbore de
+  categorii încărcat la cerere — magazinele cu structuri mari de categorii se deschid rapid, iar ce oferă deja nucleul
+  Odoo….
+- **Localități pe site** (`deltatech_website_city`) — Lista de localități de la finalizarea comenzii se restrânge la
+  cele acceptate de curierul ales, atunci când curierul are catalog propriu de localități.
+- **Căutare după cod în magazin** (`deltatech_website_product_code`) — Căutare pe frază exactă pentru codurile care
+  conțin spații, plus eliminarea termenilor prea scurți din căutare — rezultate relevante pentru clienții care caută
+  după cod….
+- **Filtre de atribute în magazin** (`deltatech_website_sale_attribute_filter`) — Starea filtrelor se păstrează la
+  reselectare, deci clientul nu mai pierde criteriile alese când modifică un filtru.
+- **Optimizarea barei de căutare** (`deltatech_website_searchbar`) — Fără schimbări funcționale față de 18.0: bara de
+  căutare trimite mai puține cereri de completare automată, prin întârzierea sugestiilor și lungimea minimă a
+  termenului.

--- a/NOUTATI_19.md
+++ b/NOUTATI_19.md
@@ -106,3 +106,69 @@ Sinteză a noutăților față de versiunea 18.0, pe 47 module. Detaliile fiecă
 - **Optimizarea barei de căutare** (`deltatech_website_searchbar`) — Fără schimbări funcționale față de 18.0: bara de
   căutare trimite mai puține cereri de completare automată, prin întârzierea sugestiilor și lungimea minimă a
   termenului.
+
+## Module de pe 18.0 fără corespondent în 19.0 (56)
+
+Pentru completitudine, în sens invers: module care există pe ramura 18.0 și nu au (încă) un echivalent pe 19.0.
+
+**Retrase deliberat (6)** — marcate obsolete/neinstalabile pe 18.0 sau înlocuite:
+
+- `deltatech_account_edi_ubl_gln` — Deltatech UBL GLN - Obsolete
+- `deltatech_print_bf` — Deltatech Print Invoice to ECR - Obsolete
+- `deltatech_restricted_access` — Restricted Access Obsolete
+- `deltatech_saleorder_type` — Terrabit - Sale Order Type - Obsolete
+- `deltatech_select_journal` — Deltatech Select Journal - Obsolete
+- `deltatech_stock_date` — Stock Date - Obsolete
+
+**Nemigrate încă (50)** — fără semnal de retragere; ultima modificare pe 18.0 în paranteze:
+
+- `deltatech_account_restrict_date` — Restrict account date (2025-11)
+- `deltatech_business_process_documentation` — Business process documentation (2026-07)
+- `deltatech_card_payment` — Deltatech Payment Method Card (2026-03)
+- `deltatech_cash` — Cash In / Out (2026-03)
+- `deltatech_change_uom` — Change Unit of measure (2025-11)
+- `deltatech_dummy_queue_job` — Deltatech Dummy Queue Job (2026-03)
+- `deltatech_invoice_color` — Deltatech Invoice Color (2025-11)
+- `deltatech_invoice_delivery` — Deltatech Invoice Delivery (2025-11)
+- `deltatech_invoice_payment` — Invoice Payment (2026-03)
+- `deltatech_maintenance` — Maintenance Extension (2026-03)
+- `deltatech_mrp_set_delivery` — Deltatech restrict incomplete set deliveries (2026-03)
+- `deltatech_packaging` — Packaging (2026-03)
+- `deltatech_partner_discount` — Deltatech partner discount (2025-11)
+- `deltatech_partner_minimal_aquisition` — Partner Minimal Aquisition (2026-03)
+- `deltatech_payment_report` — Deltatech Payment Report (2026-03)
+- `deltatech_payment_term_fix` — Payment Term Fix (2026-03)
+- `deltatech_payment_term_restrict` — Deltatech Payment Term Restrict (2025-11)
+- `deltatech_picking_number` — Picking Number (2025-11)
+- `deltatech_picking_split` — Picking Split (2026-03)
+- `deltatech_pos_time_interval` — POS Order Time Interval (2026-03)
+- `deltatech_price_change` — Price Change (2025-11)
+- `deltatech_price_modify_reception` — Price modify at the reception (2026-03)
+- `deltatech_pricelist_add_category` — Price List add Category (2025-11)
+- `deltatech_pricelist_vat_cost` — Base pricelist on cost with vat (2026-03)
+- `deltatech_product_category` — Products Category (2025-11)
+- `deltatech_product_margin` — Deltatech Product Margin (2026-07)
+- `deltatech_purchase_confirmation_reminder` — Purchase Confirmation Reminder (2026-03)
+- `deltatech_purchase_discount` — Deltatch Discount in purchase order line (2026-03)
+- `deltatech_purchase_price_history` — Purchase Price History (2025-11)
+- `deltatech_purchase_refund` — Refund Purchase (2026-03)
+- `deltatech_reccurent_task_activity` — Create activity on recurring task (2025-11)
+- `deltatech_replenish` — Deltatech Replenish (2026-03)
+- `deltatech_reset_en_names` — Product Reset EN Names (2026-03)
+- `deltatech_sale` — Sale Extension (2026-03)
+- `deltatech_sale_catalog_website` — Sale Catalog Website Categories & Image Zoom (2026-07)
+- `deltatech_sale_followup` — Sale Followup (2026-03)
+- `deltatech_sale_transfer` — Sale Prepare Transfer (2026-04)
+- `deltatech_stock_analytic` — Deltatech stock move analytic (2026-03)
+- `deltatech_stock_sn` — Stock Serial Number (2026-04)
+- `deltatech_transfer_product_to_product` — Transfer Product to Product (2025-11)
+- `deltatech_utils` — Deltatech Utils (2026-03)
+- `deltatech_warehouse` — MRP Warehouse (2026-03)
+- `deltatech_warehouse_access` — Warehouse Access (2026-03)
+- `deltatech_warranty` — Deltatech Warranty (2026-04)
+- `deltatech_website_access_design` — Website web designer access (2025-11)
+- `deltatech_website_delivery_address` — eCommerce Delivery Address (2026-03)
+- `deltatech_website_floating_widgets` — Website Floating Widgets (2026-05)
+- `deltatech_website_sale_wishlist` — eCommerce Wishlist (2026-03)
+- `deltatech_website_snippet_attribute_filter` — eCommerce Attribute Filter Snippet (2026-03)
+- `deltatech_website_texture_attributes` — eCommerce Attribute Texture (2026-03)

--- a/deltatech_actions/readme/NOUTATI_19.md
+++ b/deltatech_actions/readme/NOUTATI_19.md
@@ -1,0 +1,11 @@
+# Ce e nou în 19.0 — Acțiuni de curățare a bazei
+
+## Funcționalități noi
+- **Curățările se pornesc și se opresc din Setări.** Până acum din Setări se puteau doar regla parametrii, iar activarea propriu-zisă cerea un drum până în meniurile tehnice.
+- **Data următoarei rulări este afișată** lângă fiecare curățare, deci se vede dacă mecanismul chiar merge.
+- **Rulare în gol care spune ce ar șterge**, cu rezultatul consemnat pe document, plus buton „Rulează acum". Înainte, o rulare de probă nu lăsa nicio urmă vizibilă.
+- **Filtru de vechime și pentru curățarea documentelor XML duplicate** — singura curățare care ștergea duplicatele indiferent cât de recente erau (implicit 30 de zile).
+- **O copie restaurată se curăță singură.** Pe mediile de test restaurate din producție, toate sarcinile programate sunt oprite automat; curățarea se agață acum de singurul mecanism care rămâne activ, deci funcționează și acolo.
+
+## Îmbunătățiri
+- **Setări mai clare** (etichete scurte, explicații mutate lângă câmp) și **traduceri în română**.

--- a/deltatech_business_process/readme/NOUTATI_19.md
+++ b/deltatech_business_process/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Procese de implementare
+
+## Funcționalități noi
+- **Bibliotecă de procese alimentată din module și din depozite git.** Orice modul instalat poate contribui cu procese de implementare, iar sursele externe se sincronizează automat din Setări — nu mai e nevoie să fie scrise manual în fiecare bază.
+- **Etape de implementare definite de utilizator.** Etapele nu mai sunt o listă fixă: fiecare companie își poate defini propriile etape, păstrând comportamentul standard pentru cele existente.
+- **Grupare pe arie funcțională și fluxuri separate**, plus fișe și capturi de ecran atașate proceselor.

--- a/deltatech_business_process_handover_document/readme/NOUTATI_19.md
+++ b/deltatech_business_process_handover_document/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Document de predare
+
+## Ce e nou față de 18.0
+- **Filtrare după etapa de implementare**, aliniată la etapele definibile de utilizator din modulul de procese — documentul de predare acoperă exact etapa dorită.

--- a/deltatech_competitors_price/readme/NOUTATI_19.md
+++ b/deltatech_competitors_price/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Prețurile concurenței
+
+## Ce e nou față de 18.0
+- **Urmărirea prețurilor concurenței**, prin extragerea automată a datelor de pe paginile web ale acestora, cu preluare la cerere — comparația de preț se face în Odoo, nu în fișiere separate.

--- a/deltatech_dc/readme/NOUTATI_19.md
+++ b/deltatech_dc/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Declarație de conformitate
+
+## Îmbunătățiri
+- **Formatul tipărit al declarației a fost curățat** (structură și stil), deci documentul trimis clientului arată corect indiferent de lungimea denumirilor.

--- a/deltatech_image_optimize/readme/NOUTATI_19.md
+++ b/deltatech_image_optimize/readme/NOUTATI_19.md
@@ -1,0 +1,7 @@
+# Ce e nou în 19.0 — Optimizare imagini
+
+## Funcționalități noi
+- **Eliminarea imaginilor de produs duplicate.** Sunt găsite imaginile identice octet cu octet și păstrată una singură — pe cataloagele importate din mai multe surse recuperează spațiu important, fără risc de a pierde o imagine unică.
+
+## Îmbunătățiri
+- **Avertisment explicit că opțiunea de conversie forțată la JPEG este ireversibilă** (transparența devine negru, iar imaginea originală nu mai poate fi recuperată).

--- a/deltatech_invoice_picking/readme/NOUTATI_19.md
+++ b/deltatech_invoice_picking/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Facturarea livrărilor
+
+## Îmbunătățiri
+- **Filtrarea livrărilor după „facturat" dă rezultate corecte** în toate combinațiile (facturat/nefacturat, egal/diferit), inclusiv după facturarea în lot — comportament acoperit acum de test automat.

--- a/deltatech_invoice_to_draft/readme/NOUTATI_19.md
+++ b/deltatech_invoice_to_draft/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Readucerea facturii în ciornă
+
+## Ce e nou față de 18.0
+- **Modulul funcționează pe 19.0**, adaptat la modul nou în care Odoo 19 organizează grupurile de acces. Restricția rămâne aceeași: doar utilizatorii dintr-un grup dedicat pot readuce un document în ciornă.

--- a/deltatech_markdown_field/readme/NOUTATI_19.md
+++ b/deltatech_markdown_field/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Câmp Markdown
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Editare vizuală pentru câmpurile de text lungi**, cu bară de instrumente (îngroșat, cursiv, titluri, liste, citate, blocuri de cod, linkuri), în timp ce în baza de date se salvează Markdown curat — deci conținutul rămâne portabil și lizibil și în afara Odoo.

--- a/deltatech_move_negative_stock/readme/NOUTATI_19.md
+++ b/deltatech_move_negative_stock/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Acoperirea stocului negativ
+
+## Ce e nou față de 18.0
+- **Modulul funcționează pe 19.0**, adaptat la modificările Odoo 19 privind mișcările de stoc. Acoperirea stocului negativ dintr-o altă locație se comportă la fel ca înainte.

--- a/deltatech_mrp_bom_formula/readme/NOUTATI_19.md
+++ b/deltatech_mrp_bom_formula/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Formule în rețeta de fabricație
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Cantitatea unei componente se calculează din atributele variantei fabricate**, printr-o formulă, în locul repetării aceleiași componente pe câte o linie pentru fiecare combinație de atribute. Pentru produsele configurabile (dimensiuni, grosimi, culori) rețeta devine una singură, întreținută într-un singur loc.

--- a/deltatech_partner_generic/readme/NOUTATI_19.md
+++ b/deltatech_partner_generic/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Partener generic
+
+## Îmbunătățiri
+- **Partenerul generic este protejat împotriva modificărilor accidentale.** Fiind accesibil din orice document de vânzare, era ușor confundat cu un client obișnuit și redenumit, completat cu un CUI sau arhivat — cu efect asupra tuturor documentelor care îl folosesc.

--- a/deltatech_partner_merge/readme/NOUTATI_19.md
+++ b/deltatech_partner_merge/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Comasare parteneri în masă
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Comasează în minute partenerii duplicați pe același CUI**, în masă. Asistentul standard din Odoo parcurge pereche cu pereche toate coloanele care referă un partener, ceea ce face operațiunea impracticabilă pe bazele mari; aici comasarea se face pe loturi.

--- a/deltatech_pos_price_sync/readme/NOUTATI_19.md
+++ b/deltatech_pos_price_sync/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Sincronizare preț în POS
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Schimbarea prețului ajunge instantaneu în sesiunile POS deja deschise.** O sesiune deschisă nu reciteste prețurile, deci casierul continua să vândă la prețul vechi — nici măcar reîncărcarea paginii nu ajuta. Acum, modificarea prețului de vânzare sau a costului unui produs disponibil în POS este împinsă live către toate casele deschise.

--- a/deltatech_product_code/readme/NOUTATI_19.md
+++ b/deltatech_product_code/readme/NOUTATI_19.md
@@ -1,0 +1,5 @@
+# Ce e nou în 19.0 — Codificare produse
+
+## Îmbunătățiri
+- **Verificarea unicității codurilor de bare ține cont de companie**, deci în bazele multi-companie nu mai raportează fals duplicate între companii diferite.
+- **Verificarea este disponibilă și la nivel de variantă de produs**, nu doar de șablon.

--- a/deltatech_product_dimension/readme/NOUTATI_19.md
+++ b/deltatech_product_dimension/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Dimensiuni produs
+
+## Stare în 19.0
+Modulul este **complet aliniat cu versiunea 18.0** — aceleași câmpuri, ecrane și traduceri. Nu sunt funcționalități noi față de 18.0.

--- a/deltatech_product_visibility/readme/NOUTATI_19.md
+++ b/deltatech_product_visibility/readme/NOUTATI_19.md
@@ -1,0 +1,7 @@
+# Ce e nou în 19.0 — Scor de vizibilitate a produsului pe site
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Un scor 0–100 de vizibilitate pentru fiecare produs**, afișat ca semafor colorat, cu defalcare pe criterii — dintr-o privire se vede cât de complet și de găsibil este produsul în magazinul online.
+- Util pentru prioritizarea muncii de completare a catalogului: se începe cu produsele roșii, nu la întâmplare.

--- a/deltatech_project_price_list/readme/NOUTATI_19.md
+++ b/deltatech_project_price_list/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Listă de prețuri pe proiect
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Listă de prețuri definită la nivel de proiect**, folosită automat la crearea comenzilor de vânzare din proiect sau din sarcini — managerul de proiect nu mai trebuie să corecteze manual prețul pe fiecare comandă generată.

--- a/deltatech_purchase_add_extra_line/readme/NOUTATI_19.md
+++ b/deltatech_purchase_add_extra_line/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Linie suplimentară pe achiziție
+
+## Îmbunătățiri
+- **Prețul introdus manual pe linia suplimentară nu mai este rescris.** Până acum, orice recalculare îl readucea la valoarea implicită, tăcut — inclusiv pe fluxurile fără recalculare vizibilă, unde ajungea greșit pe document.

--- a/deltatech_purchase_create_bill_button/readme/NOUTATI_19.md
+++ b/deltatech_purchase_create_bill_button/readme/NOUTATI_19.md
@@ -1,0 +1,7 @@
+# Ce e nou în 19.0 — Buton „Creează factură" la achiziții
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Readuce butonul clasic „Creează factură" pe comanda de achiziție.** În Odoo 19 butonul a fost înlocuit cu un mecanism de încărcare care cere selectarea unui fișier înainte de a putea crea factura — o schimbare care încetinește operatorii care introduc facturile manual.
+- **Copiază referința furnizorului** pe factura creată.

--- a/deltatech_purchase_price/readme/NOUTATI_19.md
+++ b/deltatech_purchase_price/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Actualizare preț furnizor la recepție
+
+## Îmbunătățiri
+- **Migrarea datelor pe 19.0 folosește utilitarul standard**, deci prețurile devenite dependente de companie sunt convertite corect și replicate pe toate companiile din bază — fără pierderi la actualizare.

--- a/deltatech_purchase_stock/readme/NOUTATI_19.md
+++ b/deltatech_purchase_stock/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Achiziții și stoc
+
+## Ce e nou față de 18.0
+- **Comenzile de achiziție generate de reaprovizionare rămân separate de cele create manual de cumpărător** — sunt marcate ca atare și nu se mai contopesc cu comenzile manuale în curs.

--- a/deltatech_putaway_strategy/readme/NOUTATI_19.md
+++ b/deltatech_putaway_strategy/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Strategii de depozitare
+
+## Stare în 19.0
+Modulul este declarat **Production/Stable**, aliniat cu versiunea 18.0 — capacitățile de locație și strategia extinsă de depozitare sunt disponibile fără restricții de maturitate pentru modulele care depind de el.

--- a/deltatech_queue_job/readme/NOUTATI_19.md
+++ b/deltatech_queue_job/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Cozi de sarcini
+
+## Funcționalități noi
+- **Sarcinile eșuate duplicate se anulează automat.** Când apare o sarcină nouă cu aceeași identitate, cele vechi rămase în eroare trec în „anulat" — lista de erori arată problemele reale, nu istoricul aceleiași operațiuni reluate.

--- a/deltatech_report_packaging/readme/NOUTATI_19.md
+++ b/deltatech_report_packaging/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Raport materiale de ambalare
+
+## Ce e nou față de 18.0
+- **Evidența materialelor de ambalare consumate pentru produsele facturate**: configurare pe produs, urmărire pe liniile de factură și asistent de completare în masă — baza pentru raportările de ambalaje.

--- a/deltatech_report_prn/readme/NOUTATI_19.md
+++ b/deltatech_report_prn/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Rapoarte PRN
+
+## Ce e nou față de 18.0
+- **Punct de extensie pentru tipărirea directă**, care permite modulului companion Zebra să intercepteze raportul și să îl trimită la imprimantă, cu revenire la descărcarea clasică atunci când tipărirea directă nu e disponibilă.

--- a/deltatech_rpc_audit/readme/NOUTATI_19.md
+++ b/deltatech_rpc_audit/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Audit apeluri RPC
+
+## Funcționalități noi
+- **Auditarea acoperă și noul punct de acces `/json/2`.** Odoo 19 a marcat vechile puncte de acces ca depășite, deci integrările vor migra treptat; fără această completare, pista de audit ar fi amuțit exact atunci când traficul s-ar fi mutat.

--- a/deltatech_sale_activity_report/readme/NOUTATI_19.md
+++ b/deltatech_sale_activity_report/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Ultima modificare pe comandă
+
+## Stare în 19.0
+Comportamentul rămâne cel din 18.0, acum acoperit de teste automate — se consemnează doar modificările făcute de utilizatori reali, nu cele generate de sistem.

--- a/deltatech_sale_add_extra_line/readme/NOUTATI_19.md
+++ b/deltatech_sale_add_extra_line/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Linie suplimentară pe vânzare
+
+## Îmbunătățiri
+- **Prețul introdus manual pe linia suplimentară se păstrează**, în loc să fie readus tăcut la valoarea implicită.
+- **Punct de extensie pentru produsul liniei suplimentare**, astfel încât un modul de client să poată decide nu doar prețul, ci și dacă linia apare — util pentru regulile comerciale specifice.
+- **Traducere în română** a blocului de configurare și explicații corecte pe câmpuri.

--- a/deltatech_sale_analysis_vat/readme/NOUTATI_19.md
+++ b/deltatech_sale_analysis_vat/readme/NOUTATI_19.md
@@ -1,0 +1,8 @@
+# Ce e nou în 19.0 — Analiza vânzărilor pe cotă de TVA
+
+## Funcționalități noi
+- **Cota de TVA devine filtru și criteriu de grupare** în Analiza facturilor și în Analiza punctului de vânzare.
+- **Facturile emise pe baza unui bon fiscal sunt marcate**, astfel încât cifra de afaceri a perioadei să poată fi citită fără dublarea vânzărilor deja înregistrate prin bon.
+
+## Îmbunătățiri
+- **Filtrele noi sunt traduse în română**, deci sunt utilizabile și pe o interfață în limba română.

--- a/deltatech_sale_commission/readme/NOUTATI_19.md
+++ b/deltatech_sale_commission/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Comisioane de vânzare
+
+## Ce e nou față de 18.0
+- **Se aliniază la politica configurabilă de vânzare sub cost** din verificarea marjei — comisionul se calculează coerent cu regula aleasă de companie.

--- a/deltatech_sale_margin/readme/NOUTATI_19.md
+++ b/deltatech_sale_margin/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Verificarea marjei la vânzare
+
+## Funcționalități noi
+- **Reacția la vânzarea sub cost devine politică de companie**, aleasă din Setări: blocare (comportamentul de până acum), avertizare sau doar consemnare. Companiile care acceptă ocazional vânzarea sub cost nu mai trebuie să dezactiveze complet verificarea.

--- a/deltatech_sale_purchase/readme/NOUTATI_19.md
+++ b/deltatech_sale_purchase/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Vânzare → achiziție
+
+## Îmbunătățiri
+- **Anularea comenzii de vânzare elimină corect toate liniile de achiziție generate** (atâta timp cât comanda de achiziție e încă ciornă), nu doar o parte dintre ele.

--- a/deltatech_sale_purchase_requisition/readme/NOUTATI_19.md
+++ b/deltatech_sale_purchase_requisition/readme/NOUTATI_19.md
@@ -1,0 +1,7 @@
+# Ce e nou în 19.0 — Cereri de ofertă din ofertă de vânzare
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Buton pe oferta de vânzare care generează cereri de ofertă către furnizori** din liniile ofertei, cu legătura păstrată înapoi la ofertă.
+- **Funcționează cu comenzile de achiziție alternative**, deci se pot compara mai mulți furnizori pentru aceeași cerere înainte de a decide.

--- a/deltatech_secondary_uom/readme/NOUTATI_19.md
+++ b/deltatech_secondary_uom/readme/NOUTATI_19.md
@@ -1,0 +1,7 @@
+# Ce e nou în 19.0 — Unități de măsură secundare pe produs
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Factori de conversie specifici fiecărui produs** între unitatea de bază și o unitate alternativă (după modelul SAP MARM). În Odoo standard factorul aparține unității de măsură, deci nu poți avea kilograme diferite pe metru pătrat de la produs la produs.
+- **Cantitățile se pot introduce în unitatea alternativă** (kg, m², bucăți de ambalaj) pe liniile de vânzare, pe liniile de achiziție și pe mișcările de stoc, cu conversie automată.

--- a/deltatech_stock_close/readme/NOUTATI_19.md
+++ b/deltatech_stock_close/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Închiderea stocului la dată
+
+## Ce e nou față de 18.0
+- **Modulul este disponibil pe 19.0**, la paritate cu versiunea 18.0 — închiderea operațiunilor de stoc la o dată dată funcționează identic.

--- a/deltatech_stock_inventory/readme/NOUTATI_19.md
+++ b/deltatech_stock_inventory/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Inventar (metoda clasică)
+
+## Îmbunătățiri
+- **Nota de inventar este vizibilă implicit pe linie.** Fiind ascunsă în meniul de coloane opționale, motivul unei corecții de cantitate nu se înregistra aproape niciodată; nota devine denumirea mișcării generate, deci explicația rămâne pe document.

--- a/deltatech_stock_orderpoint_multiple/readme/NOUTATI_19.md
+++ b/deltatech_stock_orderpoint_multiple/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Cantitate multiplă la regulile de reaprovizionare
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Readuce rotunjirea la un multiplu pe regulile de reaprovizionare**, câmp pe care Odoo l-a eliminat la trecerea la versiunea 19.0. Pentru companiile care comandă în paleți, baxuri sau multipli de ambalare, propunerile de reaprovizionare rămân realizabile.

--- a/deltatech_stock_picking_activity_report/readme/NOUTATI_19.md
+++ b/deltatech_stock_picking_activity_report/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Jurnal de activitate pe livrări
+
+## Îmbunătățiri
+- **Descrierea operațiilor transferului nu mai este trunchiată.** Plafonul unic de 200 de caractere tăia exact informația utilă a modulului — la un client, peste jumătate din liniile de operații depășeau limita. Câmpurile cu linii multiple au acum plafon separat.

--- a/deltatech_tc/readme/NOUTATI_19.md
+++ b/deltatech_tc/readme/NOUTATI_19.md
@@ -1,0 +1,9 @@
+# Ce e nou în 19.0 — Terrabit Connect (bază)
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Puntea dintre Odoo din cloud și echipamentele din rețeaua locală a clientului** — casă de marcat, cântar, linie de sortare, PLC, server de etichete — pe care Odoo nu le poate accesa direct.
+- **Registru de stații de lucru**, fiecare cu cheia ei de acces, cu ultima conectare și cu informațiile raportate (versiune de agent, sistem de operare, funcții active).
+- **Apel HTTP în rețeaua clientului.** Stația interoghează periodic Odoo, iar canalul e refolosit în sens invers: Odoo poate cere stației să apeleze un echipament local și să întoarcă răspunsul.
+- **Actualizare automată a agentului**, cu descărcarea versiunii noi prin Odoo (care păstrează acreditările), fără ca agentul instalat la client să dețină vreo cheie.

--- a/deltatech_team_logo/readme/NOUTATI_19.md
+++ b/deltatech_team_logo/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Logo după echipa de vânzare
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Logo diferit în rapoartele PDF** (factură, ofertă/comandă, aviz de livrare) în funcție de echipa de vânzare a documentului — soluția pentru companiile care operează mai multe branduri dintr-o singură bază.

--- a/deltatech_transport_change/readme/NOUTATI_19.md
+++ b/deltatech_transport_change/readme/NOUTATI_19.md
@@ -1,0 +1,6 @@
+# Ce e nou în 19.0 — Transport de configurări între medii
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Export al modificărilor de configurare și transportul lor între medii** (dezvoltare → test → producție), urmărite prin git — configurările nu mai sunt reintroduse manual în fiecare mediu, cu riscul de a diferi.

--- a/deltatech_website_category/readme/NOUTATI_19.md
+++ b/deltatech_website_category/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Categorii publice în magazin
+
+## Ce e nou față de 18.0
+- **Modulul este disponibil pe 19.0**, cu **arbore de categorii încărcat la cerere** — magazinele cu structuri mari de categorii se deschid rapid, iar ce oferă deja nucleul Odoo 19 nu mai este duplicat.

--- a/deltatech_website_city/readme/NOUTATI_19.md
+++ b/deltatech_website_city/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Localități pe site
+
+## Funcționalități noi
+- **Lista de localități de la finalizarea comenzii se restrânge la cele acceptate de curierul ales**, atunci când curierul are catalog propriu de localități. Se elimină astfel comenzile plasate cu localități pe care curierul le refuză la emiterea AWB-ului.

--- a/deltatech_website_product_code/readme/NOUTATI_19.md
+++ b/deltatech_website_product_code/readme/NOUTATI_19.md
@@ -1,0 +1,5 @@
+# Ce e nou în 19.0 — Căutare după cod în magazin
+
+## Funcționalități noi
+- **Căutare pe frază exactă pentru codurile care conțin spații**, plus eliminarea termenilor prea scurți din căutare — rezultate relevante pentru clienții care caută după cod de produs.
+- **Setarea este vizibilă în interfață**, sub Website → Configurare → Setări, nu doar în parametrii tehnici de sistem.

--- a/deltatech_website_sale_attribute_filter/readme/NOUTATI_19.md
+++ b/deltatech_website_sale_attribute_filter/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Filtre de atribute în magazin
+
+## Îmbunătățiri
+- **Starea filtrelor se păstrează la reselectare**, deci clientul nu mai pierde criteriile alese când modifică un filtru.

--- a/deltatech_website_searchbar/readme/NOUTATI_19.md
+++ b/deltatech_website_searchbar/readme/NOUTATI_19.md
@@ -1,0 +1,4 @@
+# Ce e nou în 19.0 — Optimizarea barei de căutare
+
+## Stare în 19.0
+Fără schimbări funcționale față de 18.0: bara de căutare trimite mai puține cereri de completare automată, prin întârzierea sugestiilor și lungimea minimă a termenului.


### PR DESCRIPTION
Adaugă `readme/NOUTATI_19.md` pentru fiecare modul cu noutăți funcționale față de 18.0, scris pentru prezentare către client, plus indexul de suită `NOUTATI_19.md`.

**Cum au fost stabilite noutățile**
- Module prezente pe `origin/19.0` și absente pe `origin/18.0` → module noi.
- Pentru restul: commit-uri `[ADD]`/`[IMP]` de pe `origin/19.0` neajunse pe `origin/18.0`, cu echivalență pe **patch-id**, ca o modificare replayată la migrare cu alt SHA să nu apară drept noutate.
- Excluse: documentație, traduceri, teste, reformatări și commit-urile care ating toată suita (generator README, banere Apps Store).

Doar fișiere de documentație — niciun cod atins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
