### PR TITLE
[IMP] pre-commit: blochează traducerile pe care Odoo le-ar ignora în silențiu

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,12 @@ repos:
         entry: scripts/check_module_images.py
         language: python
         files: '__manifest__\.py$'
+      - id: check-po-vs-pot
+        name: Traducerile din .po trebuie sa existe in .pot (altfel Odoo le ignora)
+        entry: scripts/check_po_vs_pot.py
+        language: python
+        files: '[a-zA-Z0-9_]*/i18n/[a-zA-Z_]*\.po$'
+        additional_dependencies: ["polib"]
   - repo: https://github.com/sbidoul/whool
     rev: v1.3
     hooks:

--- a/scripts/check_po_vs_pot.py
+++ b/scripts/check_po_vs_pot.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+# scripts/check_po_vs_pot.py
+"""Blocheaza traducerile care ar fi ignorate in silentiu de Odoo.
+
+Odoo NU citeste `i18n/<lang>.po` de unul singur: `PoFileReader.__init__` il
+fuzioneaza mai intai cu `i18n/<modul>.pot`, ca sa foloseasca referintele `#:`
+din .pot (mai actuale decat cele din .po):
+
+    pot_path = get_pot_path(source.name)      # i18n/ro.po -> i18n/<modul>.pot
+    if pot_path:
+        self.pofile.merge(polib.pofile(pot_path))
+
+`polib.merge()` are semantica lui `msgmerge`: marcheaza **obsolete** orice
+intrare din .po care nu exista in .pot, iar `__iter__` face
+`if entry.obsolete: continue`. Efect: **orice msgid tradus in .po dar absent
+din .pot este sarit in tacere.**
+
+Nimic nu semnaleaza problema: Odoo logheaza `loading translation file ...
+ro.po`, `msgfmt -c` e curat, referintele `#:` sunt corecte, iar traducerile
+VECHI functioneaza - doar cele noi nu, pentru ca doar ele lipsesc din .pot.
+
+Hook-ul verifica DOAR intrarile adaugate in commit-ul curent (fata de HEAD),
+ca sa nu blocheze commituri din cauza vechiturilor deja existente in .po:
+un .po poate contine, legitim, traduceri pentru termeni ai altor module sau
+termeni morti, care nu vor aparea niciodata in .pot-ul propriu.
+
+Un modul FARA .pot nu e afectat (fuziunea nu are loc), deci trece.
+
+Reparare, cand hook-ul se plange: regenereaza .pot. `--i18n-export` nu mai
+exista in Odoo 19, deci prin shell-ul Odoo, cu modulul instalat:
+
+    m = env["ir.module.module"].search([("name", "=", "<modul>")])
+    w = env["base.language.export"].create(
+        {"format": "po", "modules": [(6, 0, m.ids)], "lang": "__new__"})
+    w.act_getfile()
+    open("<modul>/i18n/<modul>.pot", "wb").write(base64.b64decode(w.data))
+
+Atentie la doua capcane ale regenerarii:
+  - exportul reflecta ce e INSTALAT in baza: termenii contribuiti prin module
+    frati neinstalati nu ies, deci rescrierea poate SARACI .pot. Scrie uniunea
+    nou + vechi (un msgid in plus in .pot e inofensiv, unul lipsa anuleaza
+    traducerea);
+  - regenerarea schimba segmentarea termenilor de view (iconita `<i .../>` se
+    fuzioneaza cu `<span>`-ul intr-un singur msgid), deci .po trebuie
+    resincronizat, altfel apar orfane noi.
+"""
+
+import os
+import subprocess
+import sys
+
+import polib
+
+MAX_AFISATE = 12
+
+
+def versiune_din_head(cale):
+    """Contine .po-ul din HEAD, sau None daca fisierul e nou in acest commit."""
+    director = os.path.dirname(cale) or "."
+    radacina = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        cwd=director,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if not radacina:
+        return None
+    rel = os.path.relpath(os.path.abspath(cale), radacina)
+    rezultat = subprocess.run(["git", "show", f"HEAD:{rel}"], cwd=radacina, capture_output=True, text=True)
+    if rezultat.returncode != 0:
+        return None
+    return rezultat.stdout
+
+
+def traduse(pofile):
+    return {e.msgid for e in pofile if e.msgid and e.msgstr and not e.obsolete}
+
+
+def verifica(cale_po):
+    """Intoarce lista msgid-urilor adaugate acum care ar fi ignorate de Odoo."""
+    i18n = os.path.dirname(cale_po)
+    modul = os.path.basename(os.path.dirname(i18n))
+    cale_pot = os.path.join(i18n, modul + ".pot")
+    if not os.path.exists(cale_pot):
+        return []  # fara .pot nu se face fuziunea, deci nu se pierde nimic
+
+    try:
+        ids_pot = {e.msgid for e in polib.pofile(cale_pot)}
+        noi = traduse(polib.pofile(cale_po))
+    except OSError as e:
+        print(f"{cale_po}: nu s-a putut citi ({e})", file=sys.stderr)
+        return []
+
+    vechi_txt = versiune_din_head(cale_po)
+    if vechi_txt is not None:
+        try:
+            noi -= traduse(polib.pofile(vechi_txt))
+        except Exception:  # noqa: BLE001 - .po vechi nevalid: verificam tot
+            pass
+
+    return sorted(noi - ids_pot)
+
+
+def main(argv):
+    probleme = {}
+    for cale in argv:
+        lipsa = verifica(cale)
+        if lipsa:
+            probleme[cale] = lipsa
+    if not probleme:
+        return 0
+
+    print("Traduceri care ar fi IGNORATE in silentiu de Odoo:\n", file=sys.stderr)
+    for cale, lipsa in probleme.items():
+        modul = os.path.basename(os.path.dirname(os.path.dirname(cale)))
+        print(f"  {cale} ({len(lipsa)} intrari absente din {modul}.pot):", file=sys.stderr)
+        for msgid in lipsa[:MAX_AFISATE]:
+            print(f"      {msgid[:96]!r}", file=sys.stderr)
+        if len(lipsa) > MAX_AFISATE:
+            print(f"      ... si alte {len(lipsa) - MAX_AFISATE}", file=sys.stderr)
+        print(file=sys.stderr)
+    print(
+        "Cauza: Odoo fuzioneaza .po cu .pot si marcheaza obsolete (deci sare)\n"
+        "intrarile absente din .pot. Traducerile de mai sus nu vor ajunge NICIODATA\n"
+        "in baza de date, desi fisierul pare corect si msgfmt nu se plange.\n"
+        "Reparare: regenereaza i18n/<modul>.pot (vezi antetul scripts/check_po_vs_pot.py).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## De ce

Odoo **nu citește `i18n/<lang>.po` de unul singur**. `PoFileReader.__init__` îl fuzionează mai întâi cu `i18n/<modul>.pot`, ca să folosească referințele `#:` din .pot (mai actuale decât cele din .po):

```python
pot_path = get_pot_path(source.name)      # i18n/ro.po -> i18n/<modul>.pot
if pot_path:
    self.pofile.merge(polib.pofile(pot_path))
```

`polib.merge()` are semantica lui `msgmerge`: marchează **obsolete** orice intrare din .po absentă din .pot, iar `__iter__` face `if entry.obsolete: continue`. Deci **orice msgid tradus în .po dar absent din .pot nu ajunge niciodată în bază.**

Eșecul e complet silențios, și de asta merită un hook:

- Odoo loghează `module X: loading translation file .../i18n/ro.po for language ro_RO` — fișierul chiar se citește;
- `msgfmt -c` e curat;
- referințele `#:` sunt corecte;
- **traducerile vechi funcționează** — doar cele noi nu, pentru că doar ele lipsesc din .pot. Același fișier, două comportamente: exact ce face diagnosticul contraintuitiv.

Cazul real: în `deltatech_purchase_ubl` tot wizardul de previzualizare (`Supplier Code`, `Match Type`, `By name`, `Not found`, bannerul) și titlul activității `SPV import needs review` apăreau în engleză pe interfața RO, cu `.pot` vechi de o săptămână față de `ro.po`. Reparat în #2874; hook-ul previne repetarea.

## Ce verifică, și ce NU

Verifică **doar intrările adăugate în commit-ul curent**, față de HEAD. Un `.po` poate conține legitim traduceri pentru termeni ai altor module (ex. `deltatech_sale_xls/i18n/ro.po` are referințe către `deltatech_purchase_xls`) sau termeni morți după redenumiri — pe suita asta sunt peste 700 de astfel de intrări. Un hook care s-ar plânge de ele ar fi doar zgomot pe care toată lumea ar învăța să-l ignore.

Un modul **fără** `.pot` trece: fără `.pot` fuziunea nu are loc, deci nu se pierde nimic. (Paradoxal, un `.pot` prezent dar învechit e mai rău decât unul absent.)

## Verificat

| Scenariu | Rezultat |
|---|---|
Toate cele 182 `.po` ale suitei, prin framework | trece, fără fals pozitiv |
Traducere nouă absentă din `.pot` | **pică**, cu msgid-urile listate |
Modul fără `.pot` | trece |
`deltatech_sale_xls` (24 orfane preexistente) | trece |

## Reparare, când hook-ul se plânge

Procedura completă e în antetul `scripts/check_po_vs_pot.py`, inclusiv cele două capcane ale regenerării `.pot`, ambele întâlnite pe teren:

1. `--i18n-export` **nu mai există în Odoo 19** — regenerarea se face cu wizardul `base.language.export` prin shell, cu modulul instalat;
2. exportul reflectă ce e **instalat în bază**: termenii contribuiți prin module frați neinstalați nu ies, deci rescrierea pură poate *sărăci* `.pot` și pierde alte traduceri (prins pe `l10n_ro_config`: „Romania - CAEN Code"). Scrie **uniunea** nou + vechi — un msgid în plus în `.pot` e inofensiv, unul lipsă anulează traducerea;
3. regenerarea schimbă **segmentarea** termenilor de view (iconița `<i .../>` se fuzionează cu `<span>`-ul într-un singur msgid), deci `.po` trebuie resincronizat, altfel apar orfane noi.

## De propagat

Hook-ul e local, deci trăiește doar în această suită. Aceeași problemă poate apărea în `bitshop`, `l10n_ro_ent`, `l10n-romania`, `terrabit` etc. — spuneți dacă îl replic (convenția „preluata din deltatech" a celorlalte hook-uri locale sugerează că deltatech e sursa canonică).

Menționez separat: în `l10n_ro_ent` există 13 module (`l10n_ro_profit_tax`, `l10n_ro_cbam`, `l10n_ro_reges`, `l10n_ro_inventory_register` ș.a., ~795 intrări) unde `.pot` are msgid-uri **românești** iar `ro.po` traduce din engleză — sunt `ro.po` pregătite pentru convenția Odoo (stringuri EN în cod) fără ca codul să fi fost convertit. Nu e problema asta, interfața e oricum RO, dar blochează publicarea corectă pe Apps Store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
