### PR TITLE
[IMP] check_po_vs_pot: lint-curat, ca toate copiile din suite să fie identice

### DIFF
--- a/scripts/check_po_vs_pot.py
+++ b/scripts/check_po_vs_pot.py
@@ -45,6 +45,9 @@ Atentie la doua capcane ale regenerarii:
     resincronizat, altfel apar orfane noi.
 """
 
+# pylint: disable=print-used
+# `print` este interfata unui hook de pre-commit: pre-commit capteaza stdout/stderr
+# si le arata utilizatorului. Un logger nu ar aparea nicaieri.
 import os
 import subprocess
 import sys
@@ -95,8 +98,10 @@ def verifica(cale_po):
     if vechi_txt is not None:
         try:
             noi -= traduse(polib.pofile(vechi_txt))
-        except Exception:  # noqa: BLE001 - .po vechi nevalid: verificam tot
-            pass
+        except Exception as e:  # noqa: BLE001 - versiunea din HEAD e nevalida
+            # Nu putem calcula ce s-a adaugat acum, deci verificam TOT fisierul:
+            # mai bine un fals pozitiv explicat decat o traducere pierduta tacut.
+            print(f"{cale_po}: versiunea din HEAD nu se poate citi ({e}); verific tot fisierul", file=sys.stderr)
 
     return sorted(noi - ids_pot)
 


### PR DESCRIPTION
Urmare la #2875, ca precondiție pentru replicarea hook-ului în celelalte suite.

Scriptul e **duplicat** în fiecare suită (convenția hook-urilor locale, „preluata din deltatech"), deci divergența între copii e principalul risc de întreținere. La replicare a ieșit că `pylint_odoo` e configurat mai strict în `dhongu/l10n-romania` decât aici și respingea scriptul, iar `ruff format` îi schimba formatarea — deci copia de acolo ar fi diferit de asta.

## Ce se schimbă

- **`# pylint: disable=print-used`** la nivel de modul, cu motivul scris: `print` **este** interfața unui hook de pre-commit — pre-commit captează stdout/stderr și le arată utilizatorului, iar un logger nu ar apărea nicăieri. (Aceeași capcană ca la conversiile print→logger care rup tăcut ieșirea.)
- **`except ... pass` înlocuit cu un mesaj pe stderr**: dacă versiunea din HEAD a fișierului `.po` nu se poate citi, verificăm TOT fișierul și spunem de ce — mai bine un fals pozitiv explicat decât o traducere pierdută în tăcere. Rezolvă și `except-pass` din pylint.
- Formatarea impusă de `ruff format`.

Fără schimbare de comportament: hook-ul pică pe o traducere nouă absentă din `.pot` și trece pe un `.po` curat, verificat după modificare.

## Efect

Cele **11** copii ale scriptului devin byte-identice (`shasum a55a9579d8f7`) — această suită plus cele 10 din PR-urile de replicare:

`bitshop` · `bitshop_delivery` · `bitshop_ent` · `bitshop_marketplace` · `bitshop_vendor` · `deltatech_service` · `deltatech_stock_valuation` · `l10n-romania` · `l10n_ro_ent` · `terrabit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
