### PR TITLE
[IMP] deltatech_putaway_strategy: per-reservation tracing to DEBUG

### DIFF
--- a/deltatech_putaway_strategy/__manifest__.py
+++ b/deltatech_putaway_strategy/__manifest__.py
@@ -1,6 +1,6 @@
 {
     "name": "Deltatech Putaway Strategy",
-    "version": "19.0.1.0.7",
+    "version": "19.0.1.0.8",
     "summary": "Location capacities and enhanced putaway strategy for Inventory",
     "author": "Deltatech, Terrabit",
     "website": "https://www.terrabit.ro",

--- a/deltatech_putaway_strategy/models/stock_move_line.py
+++ b/deltatech_putaway_strategy/models/stock_move_line.py
@@ -40,7 +40,10 @@ class StockMove(models.Model):
         lines_to_process = self.move_line_ids
 
         while lines_to_process:
-            _logger.info("Processing %d move lines", len(lines_to_process))
+            # per-reservation tracing: useful when debugging a putaway split, but it runs on
+            # every _action_assign - 8.150 lines in 16h of production, for nothing an operator
+            # or a reader of the log ever acts on. DEBUG keeps it available with --log-level.
+            _logger.debug("Processing %d move lines", len(lines_to_process))
             is_split, to_reprocess = lines_to_process._split_by_putaway_capacity()
             if is_split:
                 # Dacă am făcut split, verificăm să nu fi intrat într-o buclă infinită
@@ -55,7 +58,7 @@ class StockMove(models.Model):
         if lines_with_zero_qty:
             lines_with_zero_qty.unlink()
 
-        _logger.info("_action_assign executed in %.3f seconds", time.time() - start_time)
+        _logger.debug("_action_assign executed in %.3f seconds", time.time() - start_time)
         return res
 
     def _action_done(self, cancel_backorder=False):


### PR DESCRIPTION
Din analiza unui log de producție PTC (16 h): `deltatech_putaway_strategy` a scris **8.150 de linii INFO**, al doilea logger ca volum după werkzeug.

Ambele apar în `_action_assign`, deci la fiecare rezervare:

- `Processing %d move lines`
- `_action_assign executed in %.3f seconds` — în majoritatea cazurilor `0.000 seconds`

Sunt utile când depanezi un split de putaway și inutile în rest — exact ce înseamnă DEBUG. Rămân la un `--log-level` distanță.

WARNING-ul despre locația care nu mai e disponibilă rămâne neatins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)