### PR TITLE
[DOC] Noutăți 19.0: deltatech_stock_analytic + inventar recalculat

### DIFF
--- a/NOUTATI_19.md
+++ b/NOUTATI_19.md
@@ -1,9 +1,9 @@
 # Ce e nou în 19.0 — Suita deltatech — module de bază pentru ERP
 
-Sinteză a noutăților față de versiunea 18.0, pe 51 module. Detaliile fiecărui modul sunt în
+Sinteză a noutăților față de versiunea 18.0, pe 52 module. Detaliile fiecărui modul sunt în
 `<modul>/readme/NOUTATI_19.md`.
 
-## Module noi în 19.0 (16)
+## Module noi în 19.0 (17)
 
 - **Câmp Markdown** (`deltatech_markdown_field`) — Editare vizuală pentru câmpurile de text lungi, cu bară de
   instrumente (îngroșat, cursiv, titluri, liste, citate, blocuri de cod, linkuri), în timp ce în baza de date se….
@@ -28,6 +28,8 @@ Sinteză a noutăților față de versiunea 18.0, pe 51 module. Detaliile fiecă
   generează cereri de ofertă către furnizori din liniile ofertei, cu legătura păstrată înapoi la ofertă.
 - **Unități de măsură secundare pe produs** (`deltatech_secondary_uom`) — Factori de conversie specifici fiecărui produs
   între unitatea de bază și o unitate alternativă (după modelul SAP MARM).
+- **Analitic din mișcările de stoc** (`deltatech_stock_analytic`) — Linii analitice generate automat din mișcările de
+  stoc, în momentul în care mișcarea ajunge în starea „Efectuat" — fără note manuale și fără evidență paralelă.
 - **Cantitate multiplă la regulile de reaprovizionare** (`deltatech_stock_orderpoint_multiple`) — Readuce rotunjirea la
   un multiplu pe regulile de reaprovizionare, câmp pe care Odoo l-a eliminat la trecerea la versiunea 19.0.
 - **Terrabit Connect (bază)** (`deltatech_tc`) — Puntea dintre Odoo din cloud și echipamentele din rețeaua locală a
@@ -113,3 +115,65 @@ Sinteză a noutăților față de versiunea 18.0, pe 51 module. Detaliile fiecă
 - **Optimizarea barei de căutare** (`deltatech_website_searchbar`) — Fără schimbări funcționale față de 18.0: bara de
   căutare trimite mai puține cereri de completare automată, prin întârzierea sugestiilor și lungimea minimă a
   termenului.
+
+## Module de pe 18.0 fără corespondent în 19.0 (52)
+
+Pentru completitudine, în sens invers: module care există pe ramura 18.0 și nu au (încă) un echivalent pe 19.0.
+
+**Retrase deliberat (6)** — marcate obsolete/neinstalabile pe 18.0 sau înlocuite:
+
+- `deltatech_account_edi_ubl_gln` — Deltatech UBL GLN - Obsolete
+- `deltatech_print_bf` — Deltatech Print Invoice to ECR - Obsolete
+- `deltatech_restricted_access` — Restricted Access Obsolete
+- `deltatech_saleorder_type` — Terrabit - Sale Order Type - Obsolete
+- `deltatech_select_journal` — Deltatech Select Journal - Obsolete
+- `deltatech_stock_date` — Stock Date - Obsolete
+
+**Nemigrate încă (46)** — ultima modificare de cod în paranteze:
+
+- `deltatech_account_restrict_date` — Restrict account date (2024-10)
+- `deltatech_business_process_documentation` — Business process documentation (2025-06)
+- `deltatech_card_payment` — Deltatech Payment Method Card (2025-06)
+- `deltatech_cash` — Cash In / Out (2025-01)
+- `deltatech_change_uom` — Change Unit of measure (2025-06)
+- `deltatech_dummy_queue_job` — Deltatech Dummy Queue Job (2026-03)
+- `deltatech_invoice_color` — Deltatech Invoice Color (2025-06)
+- `deltatech_invoice_delivery` — Deltatech Invoice Delivery (2024-10)
+- `deltatech_invoice_payment` — Invoice Payment (2025-06)
+- `deltatech_maintenance` — Maintenance Extension (2026-01)
+- `deltatech_mrp_set_delivery` — Deltatech restrict incomplete set deliveries (2025-10)
+- `deltatech_packaging` — Packaging (2024-11)
+- `deltatech_partner_discount` — Deltatech partner discount (2025-06)
+- `deltatech_partner_minimal_aquisition` — Partner Minimal Aquisition (2025-03)
+- `deltatech_payment_report` — Deltatech Payment Report (2025-03)
+- `deltatech_payment_term_fix` — Payment Term Fix (2024-11)
+- `deltatech_payment_term_restrict` — Deltatech Payment Term Restrict (2025-03)
+- `deltatech_picking_number` — Picking Number (2025-06)
+- `deltatech_pos_time_interval` — POS Order Time Interval (2025-10)
+- `deltatech_price_change` — Price Change (2025-10)
+- `deltatech_price_modify_reception` — Price modify at the reception (2025-03)
+- `deltatech_pricelist_add_category` — Price List add Category (2025-03)
+- `deltatech_pricelist_vat_cost` — Base pricelist on cost with vat (2025-10)
+- `deltatech_product_category` — Products Category (2025-03)
+- `deltatech_product_margin` — Deltatech Product Margin (2025-03)
+- `deltatech_purchase_confirmation_reminder` — Purchase Confirmation Reminder (2025-03)
+- `deltatech_purchase_discount` — Deltatch Discount in purchase order line (2026-03)
+- `deltatech_purchase_price_history` — Purchase Price History (2025-03)
+- `deltatech_purchase_refund` — Refund Purchase (2025-10)
+- `deltatech_reccurent_task_activity` — Create activity on recurring task (2025-03)
+- `deltatech_replenish` — Deltatech Replenish (2025-03)
+- `deltatech_reset_en_names` — Product Reset EN Names (2025-10)
+- `deltatech_sale` — Sale Extension (2025-08)
+- `deltatech_sale_catalog_website` — Sale Catalog Website Categories & Image Zoom (2026-07)
+- `deltatech_sale_followup` — Sale Followup (2024-11)
+- `deltatech_sale_transfer` — Sale Prepare Transfer (2026-04)
+- `deltatech_stock_sn` — Stock Serial Number (2026-04)
+- `deltatech_transfer_product_to_product` — Transfer Product to Product (2024-10)
+- `deltatech_utils` — Deltatech Utils (2025-01)
+- `deltatech_warehouse` — MRP Warehouse (2025-01)
+- `deltatech_warehouse_access` — Warehouse Access (2025-03)
+- `deltatech_website_access_design` — Website web designer access (2025-01)
+- `deltatech_website_delivery_address` — eCommerce Delivery Address (2025-01)
+- `deltatech_website_floating_widgets` — Website Floating Widgets (2026-05)
+- `deltatech_website_snippet_attribute_filter` — eCommerce Attribute Filter Snippet (2025-04)
+- `deltatech_website_texture_attributes` — eCommerce Attribute Texture (2025-04)

--- a/deltatech_stock_analytic/readme/NOUTATI_19.md
+++ b/deltatech_stock_analytic/readme/NOUTATI_19.md
@@ -1,0 +1,8 @@
+# Ce e nou în 19.0 — Analitic din mișcările de stoc
+
+**Modul nou în 19.0.**
+
+## Ce aduce
+- **Linii analitice generate automat din mișcările de stoc**, în momentul în care mișcarea ajunge în starea „Efectuat" — fără note manuale și fără evidență paralelă.
+- **Impactul analitic se înregistrează pe ambele capete ale mișcării**, sursă și destinație, deci transferurile între gestiuni sau între centre de cost se văd corect de ambele părți.
+- Util companiilor care urmăresc costurile pe centre de cost sau pe proiecte și au nevoie ca transferurile și ajustările de stoc să apară în contabilitatea de gestiune, nu doar în cea financiară.


### PR DESCRIPTION
Actualizare a documentației de noutăți după migrarea `deltatech_stock_analytic` (30.08).

- fișier de noutăți pentru modulul migrat;
- inventarul invers recalculat: **93 → 92** module fără corespondent, **83 → 82** nemigrate;
- pe `bitshop_ent`, scoasă intrarea `l10n_ro_intrastat` — e modul Odoo Enterprise, nu unul retras de noi;
- pe `bitshop_marketplace`, indexul preia textul actualizat al `deltatech_marketplace_delivery`.

Doar fișiere de documentație.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
