### PR TITLE
[IMP] deltatech_partner_generic: protect the generic partner (backport 19.0)

### DIFF
--- a/deltatech_partner_generic/README.rst
+++ b/deltatech_partner_generic/README.rst
@@ -39,6 +39,9 @@ Features:
 - Helps simplify data entry for businesses that handle many one-time or
   anonymous customers.
 - Fully integrated with Odoo's standard accounting and sales settings.
+- Optionally protect the generic partner against accidental changes:
+  once the protection is enabled, users can no longer rename, archive or
+  delete it.
 
 Usage:
 ------
@@ -48,6 +51,24 @@ Usage:
 3. Select an existing partner (e.g., "Generic Customer") or create a new
    one to serve as the default.
 4. This partner will then be used as a fallback in the relevant modules.
+
+Protecting the generic partner:
+-------------------------------
+
+The generic partner is reachable from every sales document, so it is
+easily mistaken for a normal customer and edited by accident. Tick
+**Protect Generic Partner** in the same settings section to prevent
+this: the contact form then shows a warning banner and any change is
+refused when saving.
+
+The protection is disabled by default, so existing databases keep their
+current behaviour. Users who legitimately have to change the partner are
+given the **Generic Partner: Editor** group; Settings administrators
+already have it.
+
+Writes performed by Odoo itself — chatter, activities, portal signup
+tokens, geolocation — stay allowed, as do automated flows running with
+elevated rights.
 
 **Table of contents**
 

--- a/deltatech_partner_generic/__manifest__.py
+++ b/deltatech_partner_generic/__manifest__.py
@@ -4,14 +4,19 @@
 
 {
     "name": "Deltatech Generic Partner",
-    "version": "18.0.1.0.0",
+    "version": "18.0.1.1.0",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "summary": "Gneric partner",
     "category": "Generic Modules",
     "depends": ["sale"],
     "license": "LGPL-3",
-    "data": ["data/data.xml", "views/res_config_settings_views.xml"],
+    "data": [
+        "security/res_groups.xml",
+        "data/data.xml",
+        "views/res_config_settings_views.xml",
+        "views/res_partner_views.xml",
+    ],
     "images": ["static/description/main_screenshot.png"],
     "development_status": "Mature",
     "maintainers": ["dhongu"],

--- a/deltatech_partner_generic/i18n/ro.po
+++ b/deltatech_partner_generic/i18n/ro.po
@@ -27,6 +27,15 @@ msgstr ""
 "specifice companiei.\" groups=\"base.group_multi_company\"/>"
 
 #. module: deltatech_partner_generic
+#: model:res.groups,comment:deltatech_partner_generic.group_generic_partner_editor
+msgid ""
+"Allowed to modify or delete the generic partner of a company that protects "
+"it."
+msgstr ""
+"Are dreptul să modifice sau să șteargă partenerul generic al unei companii "
+"care îl protejează."
+
+#. module: deltatech_partner_generic
 #: model:ir.model,name:deltatech_partner_generic.model_res_company
 msgid "Companies"
 msgstr "Companii"
@@ -37,12 +46,71 @@ msgid "Config Settings"
 msgstr "Setări de configurare"
 
 #. module: deltatech_partner_generic
+#: model:ir.model,name:deltatech_partner_generic.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: deltatech_partner_generic
 #: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_company__generic_partner_id
 #: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_config_settings__generic_partner_id
 msgid "Generic Partner"
 msgstr "Partener generic"
 
 #. module: deltatech_partner_generic
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_partner__generic_partner_locked
+msgid "Generic Partner Protected"
+msgstr "Partener generic protejat"
+
+#. module: deltatech_partner_generic
+#: model:res.groups,name:deltatech_partner_generic.group_generic_partner_editor
+msgid "Generic Partner: Editor"
+msgstr "Partener generic: Editor"
+
+#. module: deltatech_partner_generic
 #: model_terms:ir.ui.view,arch_db:deltatech_partner_generic.res_config_settings_view_form
 msgid "Generic partner"
 msgstr "Partener generic"
+
+#. module: deltatech_partner_generic
+#: model:ir.model.fields,help:deltatech_partner_generic.field_res_company__lock_generic_partner
+msgid ""
+"Prevent users from modifying or deleting the generic partner. Members of the"
+" Generic Partner: Editor group are not affected."
+msgstr ""
+"Împiedică utilizatorii să modifice sau să șteargă partenerul generic. "
+"Membrii grupului Partener generic: Editor nu sunt afectați."
+
+#. module: deltatech_partner_generic
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_company__lock_generic_partner
+#: model:ir.model.fields,field_description:deltatech_partner_generic.field_res_config_settings__lock_generic_partner
+msgid "Protect Generic Partner"
+msgstr "Protejează partenerul generic"
+
+#. module: deltatech_partner_generic
+#: model:ir.model.fields,help:deltatech_partner_generic.field_res_partner__generic_partner_locked
+msgid ""
+"Technical field: this partner is the generic partner of a company that "
+"protects it, and the current user is not allowed to modify it."
+msgstr ""
+"Câmp tehnic: partenerul este partenerul generic al unei companii care îl "
+"protejează, iar utilizatorul curent nu are dreptul să îl modifice."
+
+#. module: deltatech_partner_generic
+#. odoo-python
+#: code:addons/deltatech_partner_generic/models/res_partner.py:0
+msgid ""
+"The generic partner “%(name)s” is protected and cannot be modified. Ask an "
+"administrator if this partner really has to be changed."
+msgstr ""
+"Partenerul generic „%(name)s” este protejat și nu poate fi modificat. "
+"Solicită unui administrator dacă acest partener trebuie într-adevăr "
+"schimbat."
+
+#. module: deltatech_partner_generic
+#: model_terms:ir.ui.view,arch_db:deltatech_partner_generic.view_partner_form
+msgid ""
+"This is the generic partner used for anonymous customers. It is\n"
+"                    protected: changes made here cannot be saved."
+msgstr ""
+"Acesta este partenerul generic folosit pentru clienții neidentificați. Este\n"
+"                    protejat: modificările făcute aici nu pot fi salvate."

--- a/deltatech_partner_generic/models/__init__.py
+++ b/deltatech_partner_generic/models/__init__.py
@@ -4,3 +4,4 @@
 
 from . import res_company
 from . import res_config_settings
+from . import res_partner

--- a/deltatech_partner_generic/models/res_company.py
+++ b/deltatech_partner_generic/models/res_company.py
@@ -2,10 +2,38 @@
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
 
-from odoo import fields, models
+from odoo import api, fields, models
+
+# Changing one of these invalidates res.partner._get_protected_generic_partner_ids
+PROTECTION_FIELDS = frozenset({"generic_partner_id", "lock_generic_partner"})
 
 
 class ResCompany(models.Model):
     _inherit = "res.company"
 
     generic_partner_id = fields.Many2one("res.partner", "Generic Partner")
+    lock_generic_partner = fields.Boolean(
+        string="Protect Generic Partner",
+        help="Prevent users from modifying or deleting the generic partner. "
+        "Members of the Generic Partner: Editor group are not affected.",
+    )
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        companies = super().create(vals_list)
+        if any(PROTECTION_FIELDS & set(vals) for vals in vals_list):
+            self.env.registry.clear_cache()
+        return companies
+
+    def write(self, vals):
+        result = super().write(vals)
+        if PROTECTION_FIELDS & set(vals):
+            self.env.registry.clear_cache()
+        return result
+
+    def unlink(self):
+        clear = any(self.mapped("generic_partner_id"))
+        result = super().unlink()
+        if clear:
+            self.env.registry.clear_cache()
+        return result

--- a/deltatech_partner_generic/models/res_config_settings.py
+++ b/deltatech_partner_generic/models/res_config_settings.py
@@ -12,5 +12,10 @@ class ResConfigSettings(models.TransientModel):
         "res.partner",
         "Generic Partner",
         related="company_id.generic_partner_id",
+        readonly=False,
         # config_parameter="sale.partner_generic_id"
+    )
+    lock_generic_partner = fields.Boolean(
+        related="company_id.lock_generic_partner",
+        readonly=False,
     )

--- a/deltatech_partner_generic/models/res_partner.py
+++ b/deltatech_partner_generic/models/res_partner.py
@@ -1,0 +1,91 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo import api, fields, models, tools
+from odoo.exceptions import UserError
+
+EDITOR_GROUP = "deltatech_partner_generic.group_generic_partner_editor"
+
+# Fields written by standard Odoo flows (chatter, activities, portal signup,
+# GeoIP, website) that must keep working on a protected partner.
+TECHNICAL_FIELDS = frozenset(
+    {
+        "activity_ids",
+        "date_localization",
+        "generic_partner_locked",
+        "last_website_so_id",
+        "message_bounce",
+        "message_follower_ids",
+        "message_ids",
+        "message_main_attachment_id",
+        "message_partner_ids",
+        "partner_gid",
+        "signup_expiration",
+        "signup_token",
+        "signup_type",
+    }
+)
+
+
+class ResPartner(models.Model):
+    _inherit = "res.partner"
+
+    generic_partner_locked = fields.Boolean(
+        string="Generic Partner Protected",
+        compute="_compute_generic_partner_locked",
+        help="Technical field: this partner is the generic partner of a company "
+        "that protects it, and the current user is not allowed to modify it.",
+    )
+
+    @api.model
+    @tools.ormcache()
+    def _get_protected_generic_partner_ids(self):
+        """Ids of the generic partners of the companies that ask for protection.
+
+        Cached: this runs on every write() on any partner, which is a hot path.
+        ``res.company`` invalidates the cache when the setting changes.
+
+        Searched in sudo on purpose: the partner must stay protected even for a
+        user who has no access to the company that declared it.
+        """
+        companies = self.env["res.company"].sudo().search([("lock_generic_partner", "=", True)])
+        return frozenset(companies.generic_partner_id.ids)
+
+    def _generic_partners_to_protect(self):
+        """Subset of ``self`` the current user is not allowed to touch."""
+        protected_ids = self._get_protected_generic_partner_ids()
+        # Nothing is protected on most databases: leave before touching acl.
+        if not protected_ids or self.env.su:
+            return self.browse()
+        common = protected_ids.intersection(self.ids)
+        if not common or self.env.user.has_group(EDITOR_GROUP):
+            return self.browse()
+        return self.browse(common)
+
+    @api.depends_context("uid", "su")
+    def _compute_generic_partner_locked(self):
+        protected = self._generic_partners_to_protect()
+        for partner in self:
+            partner.generic_partner_locked = partner in protected
+
+    def _raise_generic_partner_locked(self, protected):
+        raise UserError(
+            self.env._(
+                "The generic partner “%(name)s” is protected and cannot be modified. "
+                "Ask an administrator if this partner really has to be changed.",
+                name=protected[0].sudo().display_name,
+            )
+        )
+
+    def write(self, vals):
+        protected = self._generic_partners_to_protect()
+        if protected and not set(vals) <= TECHNICAL_FIELDS:
+            self._raise_generic_partner_locked(protected)
+        return super().write(vals)
+
+    def unlink(self):
+        protected = self._generic_partners_to_protect()
+        if protected:
+            self._raise_generic_partner_locked(protected)
+        return super().unlink()

--- a/deltatech_partner_generic/readme/DESCRIPTION.md
+++ b/deltatech_partner_generic/readme/DESCRIPTION.md
@@ -10,6 +10,8 @@ Features:
 - Automatically handles the selection of this partner in various business flows such as sales and invoicing.
 - Helps simplify data entry for businesses that handle many one-time or anonymous customers.
 - Fully integrated with Odoo's standard accounting and sales settings.
+- Optionally protect the generic partner against accidental changes: once the
+  protection is enabled, users can no longer rename, archive or delete it.
 
 Usage:
 ------
@@ -18,3 +20,18 @@ Usage:
 2. Locate the "Generic Partner" configuration section.
 3. Select an existing partner (e.g., "Generic Customer") or create a new one to serve as the default.
 4. This partner will then be used as a fallback in the relevant modules.
+
+Protecting the generic partner:
+-------------------------------
+
+The generic partner is reachable from every sales document, so it is easily
+mistaken for a normal customer and edited by accident. Tick **Protect Generic
+Partner** in the same settings section to prevent this: the contact form then
+shows a warning banner and any change is refused when saving.
+
+The protection is disabled by default, so existing databases keep their current
+behaviour. Users who legitimately have to change the partner are given the
+**Generic Partner: Editor** group; Settings administrators already have it.
+
+Writes performed by Odoo itself — chatter, activities, portal signup tokens,
+geolocation — stay allowed, as do automated flows running with elevated rights.

--- a/deltatech_partner_generic/security/res_groups.xml
+++ b/deltatech_partner_generic/security/res_groups.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="group_generic_partner_editor" model="res.groups">
+        <field name="name">Generic Partner: Editor</field>
+        <field name="comment">Allowed to modify or delete the generic partner of a company that protects it.</field>
+    </record>
+
+    <!-- Settings administrators keep the ability to fix the generic partner. -->
+    <record id="base.group_system" model="res.groups">
+        <field name="implied_ids" eval="[(4, ref('group_generic_partner_editor'))]" />
+    </record>
+
+</odoo>

--- a/deltatech_partner_generic/static/description/index.html
+++ b/deltatech_partner_generic/static/description/index.html
@@ -385,6 +385,9 @@ business flows such as sales and invoicing.</li>
 <li>Helps simplify data entry for businesses that handle many one-time or
 anonymous customers.</li>
 <li>Fully integrated with Odoo’s standard accounting and sales settings.</li>
+<li>Optionally protect the generic partner against accidental changes:
+once the protection is enabled, users can no longer rename, archive or
+delete it.</li>
 </ul>
 </div>
 <div class="section" id="usage">
@@ -396,6 +399,21 @@ anonymous customers.</li>
 one to serve as the default.</li>
 <li>This partner will then be used as a fallback in the relevant modules.</li>
 </ol>
+</div>
+<div class="section" id="protecting-the-generic-partner">
+<h2>Protecting the generic partner:</h2>
+<p>The generic partner is reachable from every sales document, so it is
+easily mistaken for a normal customer and edited by accident. Tick
+<strong>Protect Generic Partner</strong> in the same settings section to prevent
+this: the contact form then shows a warning banner and any change is
+refused when saving.</p>
+<p>The protection is disabled by default, so existing databases keep their
+current behaviour. Users who legitimately have to change the partner are
+given the <strong>Generic Partner: Editor</strong> group; Settings administrators
+already have it.</p>
+<p>Writes performed by Odoo itself — chatter, activities, portal signup
+tokens, geolocation — stay allowed, as do automated flows running with
+elevated rights.</p>
 <p><strong>Table of contents</strong></p>
 </div>
 </div>

--- a/deltatech_partner_generic/tests/__init__.py
+++ b/deltatech_partner_generic/tests/__init__.py
@@ -1,3 +1,5 @@
 # ©  2008-2021 Deltatech
 #              Dorin Hongu <dhongu(@)gmail(.)com
 # See README.rst file on addons root folder for license details
+
+from . import test_partner_generic_lock

--- a/deltatech_partner_generic/tests/test_partner_generic_lock.py
+++ b/deltatech_partner_generic/tests/test_partner_generic_lock.py
@@ -1,0 +1,135 @@
+# ©  2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com
+# See README.rst file on addons root folder for license details
+
+from odoo.exceptions import UserError
+from odoo.tests import TransactionCase, tagged
+
+
+@tagged("post_install", "-at_install")
+class TestPartnerGenericLock(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.generic_partner = cls.env["res.partner"].create({"name": "Generic"})
+        cls.regular_partner = cls.env["res.partner"].create({"name": "Regular customer"})
+        cls.env.company.generic_partner_id = cls.generic_partner
+        cls.env.company.lock_generic_partner = True
+
+        # Contact creation rights are needed to write on partners at all; they
+        # do not grant the right to touch the generic partner.
+        base_groups = [
+            cls.env.ref("base.group_user").id,
+            cls.env.ref("base.group_partner_manager").id,
+        ]
+        cls.plain_user = cls.env["res.users"].create(
+            {
+                "name": "Plain user",
+                "login": "generic.lock.plain.user",
+                # message_post refuses to compute an author without an email
+                "email": "generic.lock.plain.user@example.com",
+                "groups_id": [(6, 0, base_groups)],
+            }
+        )
+        editor_group = cls.env.ref("deltatech_partner_generic.group_generic_partner_editor")
+        cls.editor_user = cls.env["res.users"].create(
+            {
+                "name": "Editor user",
+                "login": "generic.lock.editor.user",
+                "email": "generic.lock.editor.user@example.com",
+                "groups_id": [(6, 0, base_groups + [editor_group.id])],
+            }
+        )
+
+    def test_plain_user_cannot_write_generic_partner(self):
+        partner = self.generic_partner.with_user(self.plain_user)
+        with self.assertRaises(UserError):
+            partner.write({"name": "Renamed"})
+        self.assertEqual(self.generic_partner.name, "Generic")
+
+    def test_plain_user_cannot_archive_generic_partner(self):
+        partner = self.generic_partner.with_user(self.plain_user)
+        with self.assertRaises(UserError):
+            partner.write({"active": False})
+        self.assertTrue(self.generic_partner.active)
+
+    def test_plain_user_cannot_unlink_generic_partner(self):
+        partner = self.generic_partner.with_user(self.plain_user)
+        with self.assertRaises(UserError):
+            partner.unlink()
+        self.assertTrue(self.generic_partner.exists())
+
+    def test_plain_user_can_write_regular_partner(self):
+        self.regular_partner.with_user(self.plain_user).write({"name": "Renamed"})
+        self.assertEqual(self.regular_partner.name, "Renamed")
+
+    def test_editor_user_can_write_generic_partner(self):
+        self.generic_partner.with_user(self.editor_user).write({"name": "Renamed"})
+        self.assertEqual(self.generic_partner.name, "Renamed")
+
+    def test_chatter_still_works_on_generic_partner(self):
+        """Technical writes must not be blocked, otherwise the chatter breaks."""
+        partner = self.generic_partner.with_user(self.plain_user)
+        partner.message_post(body="A note on the generic partner")
+        self.assertTrue(self.generic_partner.message_ids)
+
+    def test_locked_flag_depends_on_the_user(self):
+        self.assertTrue(self.generic_partner.with_user(self.plain_user).generic_partner_locked)
+        self.assertFalse(self.generic_partner.with_user(self.editor_user).generic_partner_locked)
+        self.assertFalse(self.regular_partner.with_user(self.plain_user).generic_partner_locked)
+
+    def test_sudo_is_not_blocked(self):
+        """Automated flows running in sudo must keep writing."""
+        self.generic_partner.sudo().write({"ref": "SET-BY-AUTOMATION"})
+        self.assertEqual(self.generic_partner.ref, "SET-BY-AUTOMATION")
+
+    def test_protection_is_off_by_default(self):
+        """Databases that do not ask for the lock keep the old behaviour."""
+        self.env.company.lock_generic_partner = False
+        self.generic_partner.invalidate_recordset(["generic_partner_locked"])
+        partner = self.generic_partner.with_user(self.plain_user)
+        self.assertFalse(partner.generic_partner_locked)
+        partner.write({"name": "Renamed"})
+        self.assertEqual(self.generic_partner.name, "Renamed")
+
+    def test_setting_is_writable_from_the_configuration_screen(self):
+        """The related fields must not be readonly, or the settings never save."""
+        settings = self.env["res.config.settings"].create(
+            {
+                "generic_partner_id": self.regular_partner.id,
+                "lock_generic_partner": False,
+            }
+        )
+        settings.execute()
+        self.assertEqual(self.env.company.generic_partner_id, self.regular_partner)
+        self.assertFalse(self.env.company.lock_generic_partner)
+
+    def test_enabling_the_setting_takes_effect_immediately(self):
+        """The protected ids are cached: res.company must invalidate them."""
+        self.env.company.lock_generic_partner = False
+        partner = self.generic_partner.with_user(self.plain_user)
+        partner.write({"name": "Allowed while unlocked"})
+
+        self.env.company.lock_generic_partner = True
+
+        with self.assertRaises(UserError):
+            partner.write({"name": "Blocked now"})
+
+    def test_disabling_the_setting_takes_effect_immediately(self):
+        partner = self.generic_partner.with_user(self.plain_user)
+        with self.assertRaises(UserError):
+            partner.write({"name": "Blocked"})
+
+        self.env.company.lock_generic_partner = False
+
+        partner.write({"name": "Allowed again"})
+        self.assertEqual(self.generic_partner.name, "Allowed again")
+
+    def test_changing_the_generic_partner_takes_effect_immediately(self):
+        self.env.company.generic_partner_id = self.regular_partner
+
+        # the former generic partner is free again...
+        self.generic_partner.with_user(self.plain_user).write({"name": "Free"})
+        # ...and the new one is protected
+        with self.assertRaises(UserError):
+            self.regular_partner.with_user(self.plain_user).write({"name": "Blocked"})

--- a/deltatech_partner_generic/views/res_config_settings_views.xml
+++ b/deltatech_partner_generic/views/res_config_settings_views.xml
@@ -21,6 +21,10 @@
                             <div class="mt16">
                                 <field name="generic_partner_id" class="o_light_label" />
                             </div>
+                            <div class="mt16">
+                                <field name="lock_generic_partner" class="o_light_label" />
+                                <label for="lock_generic_partner" />
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/deltatech_partner_generic/views/res_partner_views.xml
+++ b/deltatech_partner_generic/views/res_partner_views.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_partner_form" model="ir.ui.view">
+        <field name="name">res.partner.form.generic.lock</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form" />
+        <field name="arch" type="xml">
+            <xpath expr="/form/sheet" position="before">
+                <field name="generic_partner_locked" invisible="1" />
+                <div class="alert alert-info mb-0" role="alert" invisible="not generic_partner_locked">
+                    This is the generic partner used for anonymous customers. It is
+                    protected: changes made here cannot be saved.
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Backport pe `18.0` al protecției partenerului generic livrate pe `19.0` în #2865
(commit `d2e87a16b`). Cerut pentru **Yatas**, care rulează Odoo 18 — tichet helpdesk **#9345**.

## Ce face

Setare nouă pe companie **Protect Generic Partner** (`lock_generic_partner`), în Setări → Vânzări,
lângă alegerea partenerului generic, **implicit oprită**. Când e bifată, partenerul generic nu poate
fi modificat, arhivat sau șters: banner de avertizare pe fișa de contact și respingerea salvării cu
mesaj explicit. Grupul nou **Generic Partner: Editor**, implicat automat de *Administration: Settings*,
permite corecția când chiar e nevoie.

Scrierile tehnice ale Odoo — chatter, activități, token de portal, geolocalizare — rămân permise, iar
`sudo()` nu e blocat, deci fluxurile automate merg în continuare.

`res.partner.write()` e drum foarte circulat, deci lista partenerilor protejați se citește printr-un
`ormcache` pe care `res.company` îl golește la schimbarea setării: costul devine o interogare per
proces de lucru, nu una per scriere.

## Bug preexistent reparat, prezent și pe 18.0

Câmpul `generic_partner_id` din ecranul de setări era declarat **fără `readonly=False`**. Odoo sare
peste câmpurile related readonly când salvează setările, deci **partenerul ales în Setări nu ajungea
niciodată pe companie** — ecranul raporta succes, valoarea nu se salva. Bug-ul e independent de
protecție și e prezent pe 18.0 dinainte de acest PR, deci **la clienții cu modulul instalat pe 18
`res.company.generic_partner_id` e foarte probabil gol**. Merită verificat înainte de a testa
protecția: fără partener setat, nu are ce proteja.

## Diferențe față de originalul de pe 19.0, toate deliberate

| | 19.0 | aici |
|---|---|---|
| grupuri pe `res.users` | `group_ids` | `groups_id` — adaptat în teste |
| email pe userii de test | nu era nevoie | **adăugat**: pe 18.0 `message_post` refuză să calculeze autorul fără email, iar `test_chatter_still_works_on_generic_partner` da eroare pe o bază fără configurare de mail |
| versiune | `19.0.2.0.0` | **`18.0.1.1.0`** — bump-ul la 2.0.0 pe 19 aparține fuziunii `deltatech_generic_partner_restriction` (`99b6ea3c2`), care nu face parte din backport |
| `depends` | `["account", "sale"]` | `["sale"]` — `account` vine din aceeași fuziune |
| pre-migration `19.0.2.0.0` | prezent | **exclus** — ține strict de fuziune |
| licență | OPL-1 | **LGPL-3**, ca pe branch-ul 18.0 |

Restul codului — `res_company.py`, `res_partner.py`, `security/res_groups.xml`, ambele view-uri — e
identic cu 19.0. Toate primitivele folosite există pe 18.0: `Registry.clear_cache()`
(`odoo/modules/registry.py:773`), `env._` (`odoo/api.py:788`), `ormcache` din `odoo.tools`,
`depends_context`, `env.su`, `has_group`. Ancora din ecranul de setări
(`//setting[@id='sales_settings_invoicing_policy']`) există în `sale` pe 18 și e deja folosită de
versiunea 18.0 a modulului.

## Verificat

- **13/13 teste verzi** pe o bază Odoo 18 curată (`test18_pgl`, `--without-demo=all`), atât la
  instalare curată cât și la `-u`.
- `pre-commit` curat pe cele 14 fișiere schimbate.

## Configurare la client

Modulul e deja instalat la Yatas (`18.0.1.0.0`, prin `terrabit_yatas`). După update: Setări → Vânzări
→ alege partenerul „Generic" (verifică întâi dacă e chiar setat, vezi bug-ul de mai sus) și bifează
*Protect Generic Partner*. Cine trebuie să îl poată edita primește grupul *Generic Partner: Editor*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)