### PR TITLE
[FIX] deltatech_partner_generic: do not send an invite when creating test users

### DIFF
--- a/deltatech_partner_generic/tests/test_partner_generic_lock.py
+++ b/deltatech_partner_generic/tests/test_partner_generic_lock.py
@@ -22,7 +22,11 @@ class TestPartnerGenericLock(TransactionCase):
             cls.env.ref("base.group_user").id,
             cls.env.ref("base.group_partner_manager").id,
         ]
-        cls.plain_user = cls.env["res.users"].create(
+        # no_reset_password: creating a user that has an email sends the
+        # "New User Invite" mail, which cannot be rendered when web.base.url is
+        # not set (as on a bare CI database).
+        users = cls.env["res.users"].with_context(no_reset_password=True)
+        cls.plain_user = users.create(
             {
                 "name": "Plain user",
                 "login": "generic.lock.plain.user",
@@ -32,7 +36,7 @@ class TestPartnerGenericLock(TransactionCase):
             }
         )
         editor_group = cls.env.ref("deltatech_partner_generic.group_generic_partner_editor")
-        cls.editor_user = cls.env["res.users"].create(
+        cls.editor_user = users.create(
             {
                 "name": "Editor user",
                 "login": "generic.lock.editor.user",


### PR DESCRIPTION
Repară CI-ul roșu pe `18.0` lăsat de #2883 (backportul protecției partenerului generic).

## Ce s-a rupt

Backportul a adăugat `email` pe userii de test, ca `message_post` să poată calcula un autor — pe 18.0
`_message_compute_author(raise_on_email=True)` refuză altfel. Dar crearea unui `res.users` **care are
email** trimite și mailul „New User Invite", iar randarea acelui șablon are nevoie de `web.base.url`.
Pe o bază unde parametrul nu e setat — cum e baza curată din CI — `url_join` primește `False` și crapă:

```
TypeError: Cannot mix str and bytes arguments (got (False, '/web/signup?db=odoo&signup_email=...'))
```

Eroarea omoară `setUpClass`, deci toată clasa de teste: `0 failed, 1 error(s) of 492 tests`.

## Fix

Userii se creează cu `no_reset_password=True`, modul standard de a sări invitația în teste.

## De ce nu s-a prins înainte de merge

Rularea locală a fost verde pentru că baza de dezvoltare avea `web.base.url` setat — parametrul se
completează la prima cerere HTTP. CI-ul instalează de la zero și nu face nicio cerere, deci parametrul
lipsește. Diferența nu ține de versiunea de Odoo, ci de starea bazei.

Reprodus local prin ștergerea parametrului:

```
psql -d test18_pgl -c "DELETE FROM ir_config_parameter WHERE key='web.base.url';"
```

Fără fix: exact același `TypeError`, `setUpClass` picat. Cu fix: **13/13 verzi**, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)