### PR TITLE
[FIX] deltatech_purchase_ubl: bump 19.0.1.4.1 ca traducerile să fie auditabile

### DIFF
--- a/deltatech_purchase_ubl/README.rst
+++ b/deltatech_purchase_ubl/README.rst
@@ -79,6 +79,24 @@ Changelog
 Changelog
 =========
 
+[19.0.1.4.1] - 2026-09-02
+-------------------------
+
+Fixed
+~~~~~
+
+- **Version bump so a build can be told apart by its translations.** The
+  RO translation fix of 19.0.1.4.0 (regenerated ``.pot``, resynced
+  ``ro.po``) landed *without* touching ``__manifest__.py``, so code from
+  before and after it both report ``19.0.1.4.0``. On a customer database
+  ``ir.module.module.latest_version`` therefore proved nothing about
+  whether the translations were actually on disk — a Romchim check had
+  to fall back to reading ``code_translations`` in a shell. Python code
+  translations are read from ``i18n/*.po`` on disk at runtime
+  (``CodeTranslations``), not from the database, so no ``-u`` can
+  compensate for a stale build: the manifest version is the only handle
+  an audit has. Bumped so it is one.
+
 [19.0.1.4.0] - 2026-08-31
 -------------------------
 

--- a/deltatech_purchase_ubl/__manifest__.py
+++ b/deltatech_purchase_ubl/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "Deltatech Purchase UBL",
     "summary": "Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills",
-    "version": "19.0.1.4.0",
+    "version": "19.0.1.4.1",
     "category": "Purchases",
     "author": "Terrabit, Dorin Hongu",
     "license": "OPL-1",

--- a/deltatech_purchase_ubl/readme/HISTORY.md
+++ b/deltatech_purchase_ubl/readme/HISTORY.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [19.0.1.4.1] - 2026-09-02
+
+### Fixed
+- **Version bump so a build can be told apart by its translations.** The RO translation fix of
+  19.0.1.4.0 (regenerated `.pot`, resynced `ro.po`) landed *without* touching `__manifest__.py`,
+  so code from before and after it both report `19.0.1.4.0`. On a customer database
+  `ir.module.module.latest_version` therefore proved nothing about whether the translations were
+  actually on disk — a Romchim check had to fall back to reading `code_translations` in a shell.
+  Python code translations are read from `i18n/*.po` on disk at runtime (`CodeTranslations`), not
+  from the database, so no `-u` can compensate for a stale build: the manifest version is the only
+  handle an audit has. Bumped so it is one.
+
 ## [19.0.1.4.0] - 2026-08-31
 
 ### Added


### PR DESCRIPTION
Fix-ul traducerilor RO din `d2e84be0e` (regenerat `.pot`, resincronizat `ro.po`) a intrat **fără** să atingă `__manifest__.py`. Versiunea urcase pe 27.08 în `6e7e31f08`, deci codul de dinainte și cel de după fix raportează amândouă `19.0.1.4.0`.

## De ce contează

S-a văzut pe producția Romchim: `ir.module.module.latest_version` era `19.0.1.4.0`, dar asta nu dovedea nimic despre traduceri — verificarea a trebuit să cadă înapoi pe citirea `code_translations` din shell-ul bazei:

```python
from odoo.tools.translate import code_translations
code_translations.get_python_translations("deltatech_purchase_ubl", "ro_RO")
```

Traducerile de cod Python se citesc la runtime din `i18n/*.po` **de pe disc** (`CodeTranslations`), nu din bază, deci niciun `-u` nu compensează un build vechi. Versiunea din manifest e singurul indiciu pe care îl are un audit de la distanță.

## Conținut

- `__manifest__.py`: `19.0.1.4.0` → `19.0.1.4.1`
- `readme/HISTORY.md` + `README.rst` regenerat (doar modulul acesta)

Fără schimbări de comportament.

🤖 Generated with [Claude Code](https://claude.com/claude-code)