### PR TITLE
[FIX] deltatech_ecr_fiscal: statut Mature, ca dependenții Mature să fie valizi

### DIFF
--- a/deltatech_ecr_fiscal/__manifest__.py
+++ b/deltatech_ecr_fiscal/__manifest__.py
@@ -16,7 +16,11 @@
     "price": 0.00,
     "currency": "EUR",
     "pre_init_hook": "pre_init_hook",
-    "development_status": "Production/Stable",
+    # Mature, nu Production/Stable: `deltatech_sale_store` este Mature, iar
+    # `manifestoo check-dev-status` interzice dependența pe un modul cu statut mai jos.
+    # Se justifică: modulul doar găzduiește definiții de câmpuri aflate în producție
+    # de ani, mutate aici neschimbate.
+    "development_status": "Mature",
     "installable": True,
     "application": False,
     "hidden": True,


### PR DESCRIPTION
Urmare la #2887. `manifestoo check-dev-status` interzice dependența pe un modul cu statut mai jos în scară (`Alpha < Beta < Production/Stable < Mature`), iar `deltatech_sale_store` este **Mature**. Cu modulul de bază pe `Production/Stable`, CI-ul suitei bitshop cădea la acel pas:

```
deltatech_sale_store (Mature) depends on deltatech_ecr_fiscal (Production/Stable)
```

Statutul se justifică pe fond: modulul doar găzduiește definiții de câmpuri aflate în producție de ani, mutate aici neschimbate.

Deblochează terrabit-solutions/bitshop#2792.

🤖 Generated with [Claude Code](https://claude.com/claude-code)