### PR TITLE
[FIX] deltatech_purchase_ubl: read EAN from Item/Description fallback (#9287)

### DIFF
--- a/deltatech_purchase_ubl/tests/test_ubl_import.py
+++ b/deltatech_purchase_ubl/tests/test_ubl_import.py
@@ -67,6 +67,7 @@ def _xml_invoice(
                     <cbc:PriceAmount currencyID=\"{currency}\">{l.get("price", "0")}</cbc:PriceAmount>
                 </cac:Price>
                 <cac:Item>
+                    <cbc:Description>{l.get("description", "")}</cbc:Description>
                     <cac:SellersItemIdentification><cbc:ID>{l.get("code", "")}</cbc:ID></cac:SellersItemIdentification>
                     {std_id}
                     <cbc:Name>{l.get("name", "")}</cbc:Name>
@@ -1058,6 +1059,54 @@ class TestPurchaseUblImport(TransactionCase):
         Wiz = self.env["purchase.ubl.import.wizard"]
         wiz = Wiz.new({})
         self.assertEqual(wiz._uom_from_code("NOT-A-REAL-UNIT-CODE"), self.env.ref("uom.product_uom_unit"))
+
+    def test_barcode_from_description_accepts_valid_ean13(self):
+        """Tichet #9287: PPG puts the EAN in Item/Description instead of
+        StandardItemIdentification. Real barcode from Damira production."""
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        wiz = Wiz.new({})
+        self.assertEqual(wiz._barcode_from_description("5946062025948"), "5946062025948")
+        # Padding/whitespace from the XML must not break the check-digit match.
+        self.assertEqual(wiz._barcode_from_description(" 5946062025948 "), "5946062025948")
+
+    def test_barcode_from_description_rejects_non_barcode_text(self):
+        """Must not misread a supplier's genuine free-text description, a wrong-length
+        numeric string, or a numeric string with an invalid check digit as a barcode -
+        each would silently mismatch the product on an unrelated line."""
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        wiz = Wiz.new({})
+        self.assertIsNone(wiz._barcode_from_description("Vopsea alba mata 2.5L"))
+        self.assertIsNone(wiz._barcode_from_description("12345"))
+        self.assertIsNone(wiz._barcode_from_description("5946062025949"))  # bad check digit
+        self.assertIsNone(wiz._barcode_from_description(""))
+        self.assertIsNone(wiz._barcode_from_description(False))
+
+    def test_parse_xml_uses_description_as_barcode_fallback(self):
+        """Integration: a line with no SellersItemIdentification/StandardItemIdentification
+        but a valid EAN in Description must come out matched via that barcode."""
+        product = self.env["product.product"].create({"name": "PPG Paint", "type": "consu", "barcode": "5946062025948"})
+        xml = _xml_invoice(
+            lines=[
+                {
+                    "code": "",
+                    "name": "00471016 DANKE EMAIL USCARE RAP ALB MAT 2.5L",
+                    "description": "5946062025948",
+                    "qty": "2",
+                    "price": "57.75",
+                    "line_total": "115.50",
+                    "unit_code": "H87",
+                    "tax": "21",
+                }
+            ]
+        )
+        Wiz = self.env["purchase.ubl.import.wizard"]
+        wiz = Wiz.new({})
+        parsed = wiz._parse_xml(xml)
+        self.assertEqual(parsed["lines"][0]["barcode"], "5946062025948")
+
+        matched, match_type = wiz._match_product_detailed(self.vendor, "", parsed["lines"][0]["name"], "5946062025948")
+        self.assertEqual(matched, product)
+        self.assertEqual(match_type, "barcode")
 
     def test_find_supplier_partner_matches_vat_ignoring_spaces(self):
         partner = self.env["res.partner"].create(

--- a/deltatech_purchase_ubl/wizard/ubl_import_wizard.py
+++ b/deltatech_purchase_ubl/wizard/ubl_import_wizard.py
@@ -47,6 +47,22 @@ class PurchaseUblImportWizard(models.TransientModel):
     def _uom_from_ubl(self, unit_code):
         return self._uom_from_code(unit_code)
 
+    def _barcode_from_description(self, description):
+        """Fallback for suppliers (e.g. PPG, tichet #9287) that put the EAN in the
+        free-text Item/Description instead of StandardItemIdentification. Accepts ONLY
+        a digit string of EAN-8/12/13/14 length WITH a valid check digit - anything
+        looser would misread a supplier's genuine free-text description (lot number,
+        internal note, ...) as a barcode and silently mismatch the product.
+        """
+        candidate = (description or "").strip()
+        if not candidate.isdigit() or len(candidate) not in (8, 12, 13, 14):
+            return None
+        digits = [int(d) for d in candidate]
+        check_digit = digits[-1]
+        body = digits[:-1][::-1]
+        total = sum(d * (3 if i % 2 == 0 else 1) for i, d in enumerate(body))
+        return candidate if (10 - total % 10) % 10 == check_digit else None
+
     def _is_ubl_invoice(self, content: bytes) -> bool:
         """Quickly check if provided XML bytes look like an UBL Invoice.
         We validate the root namespace equals the UBL Invoice namespace or that
@@ -151,6 +167,14 @@ class PurchaseUblImportWizard(models.TransientModel):
                 # Prefer when schemeID is 0160, but accept any value present in this tag if scheme missing
                 if not scheme_id or scheme_id == "0160":
                     barcode_val = std_id_el.text
+            if not barcode_val:
+                # Some suppliers (e.g. PPG, tichet #9287) put the EAN in the free-text
+                # Description instead of StandardItemIdentification. Only accept it when
+                # it's a checksum-valid EAN, so a supplier that puts real free text there
+                # doesn't get misread as a barcode.
+                barcode_val = self._barcode_from_description(
+                    inv_line.findtext("cac:Item/cbc:Description", namespaces=NS)
+                )
 
             name = inv_line.findtext("cac:Item/cbc:Name", namespaces=NS) or inv_line.findtext(
                 "cac:Item/cbc:Description", namespaces=NS


### PR DESCRIPTION
## Summary
- Continuare tichet helpdesk #9287 (Damira): clientul a semnalat că facturile de la PPG nu se potrivesc automat cu catalogul, deși codul de bare "e implementat".
- Am descărcat și verificat direct XML-ul real (mesaj SPV #2441): codul de bare (`5946062025948`, se potrivește exact cu produsul din catalogul Damira) e prezent în factură, dar PPG îl pune în elementul de text liber `cac:Item/cbc:Description`, nu în elementul standard UBL `StandardItemIdentification`. Parser-ul nostru citea doar elementul standard, deci informația — deși prezentă și corectă — era complet ignorată.
- `_barcode_from_description()`: fallback nou, folosit **doar** când `StandardItemIdentification` lipsește, și care acceptă **doar** un șir numeric de lungime EAN-8/12/13/14 **cu cifră de control validă**. Validarea strictă e intenționată: fără ea, orice furnizor care pune text liber real în `Description` (număr de lot, notă internă) ar fi interpretat greșit ca având cod de bare și potrivit tăcut cu produsul greșit.
- 3 teste noi: validare checksum (acceptă/respinge) direct pe helper, plus un test de integrare prin `_parse_xml` + `_match_product_detailed`, folosind exact codul de bare real din cazul Damira.

## Test plan
- [x] `deltatech_purchase_ubl` — `TestPurchaseUblImport`: 33 teste, 0 failed, 0 error (inclusiv cele 3 noi)
- [x] pre-commit (ruff, ruff-format, pylint_odoo) — toate trec

🤖 Generated with [Claude Code](https://claude.com/claude-code)