### PR TITLE
[FIX] deltatech_sale_add_extra_line_pos: linia extra nu se mai adăuga în POS pe 19.0

### DIFF
--- a/deltatech_sale_add_extra_line_pos/__manifest__.py
+++ b/deltatech_sale_add_extra_line_pos/__manifest__.py
@@ -4,7 +4,7 @@
 {
     "name": "POS Add Extra Line",
     "summary": "POS Add Extra Line",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.0.1",
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",

--- a/deltatech_sale_add_extra_line_pos/readme/HISTORY.md
+++ b/deltatech_sale_add_extra_line_pos/readme/HISTORY.md
@@ -1,0 +1,8 @@
+## 19.0.1.0.1
+
+- [FIX] the extra line is added again in the POS. Since 19.0 the point of sale
+  builds a line from `vals.product_tmpl_id` and no longer from `vals.product_id`,
+  so the patch read an undefined product and silently skipped the extra line -
+  the SGR deposit product was never added to the receipt. The template is now
+  read from either key, and the extra line is requested with the template as
+  well, which 19.0 requires

--- a/deltatech_sale_add_extra_line_pos/static/src/js/models.esm.js
+++ b/deltatech_sale_add_extra_line_pos/static/src/js/models.esm.js
@@ -5,24 +5,46 @@ import {PosOrderline} from "@point_of_sale/app/models/pos_order_line";
 import {PosStore} from "@point_of_sale/app/services/pos_store";
 import {patch} from "@web/core/utils/patch";
 
+/**
+ * Since 19.0 the POS builds a line from `vals.product_tmpl_id`, not from
+ * `vals.product_id` - the variant is derived from the template. Read the
+ * template from whichever of the two the caller provided.
+ */
+function getProductTemplate(store, vals) {
+    let template = vals.product_tmpl_id;
+    if (typeof template === "number") {
+        template = store.data.models["product.template"].get(template);
+    }
+    if (!template) {
+        let product = vals.product_id;
+        if (typeof product === "number") {
+            product = store.data.models["product.product"].get(product);
+        }
+        template = product?.product_tmpl_id;
+    }
+    return template;
+}
+
 patch(PosStore.prototype, {
     async addLineToCurrentOrder(vals, opt = {}, configure = true) {
         const line = await super.addLineToCurrentOrder(vals, opt, configure);
 
-        let product = vals.product_id;
-        if (typeof product === "number") {
-            product = this.data.models["product.product"].get(product);
-        }
+        const product_tmpl = getProductTemplate(this, vals);
+        const extra_product_id = product_tmpl?.extra_product_id;
 
-        const extra_product_id = product?.product_tmpl_id?.extra_product_id;
-
-        if (extra_product_id) {
+        // The extra product is only reachable when it is itself loaded in the
+        // POS - it has to be available in the point of sale.
+        if (extra_product_id?.product_tmpl_id) {
             const order = this.getOrder();
             const extra_line = order.add_extra_product(extra_product_id);
             if (!extra_line) {
                 let qty = vals.qty || 1;
-                qty *= product.product_tmpl_id.extra_qty;
-                this.addLineToCurrentOrder({product_id: extra_product_id, qty: qty});
+                qty *= product_tmpl.extra_qty || 1;
+                await this.addLineToCurrentOrder({
+                    product_tmpl_id: extra_product_id.product_tmpl_id,
+                    product_id: extra_product_id,
+                    qty: qty,
+                });
             }
         }
         return line;
@@ -35,13 +57,13 @@ patch(PosOrder.prototype, {
         let qty = 0;
 
         for (const line of this.lines) {
-            const line_extra_product = line.product_id.product_tmpl_id.extra_product_id;
+            const line_extra_product = line.product_id?.product_tmpl_id?.extra_product_id;
             if (line_extra_product) {
                 if (line_extra_product.id === extra_product_id.id) {
-                    qty += line.qty * line.product_id.product_tmpl_id.extra_qty;
+                    qty += line.qty * (line.product_id.product_tmpl_id.extra_qty || 1);
                 }
             }
-            if (line.product_id.id === extra_product_id.id) {
+            if (line.product_id?.id === extra_product_id.id) {
                 line.qty = 0;
                 extra_line = line;
             }
@@ -56,7 +78,7 @@ patch(PosOrder.prototype, {
 patch(PosOrderline.prototype, {
     setQuantity(quantity, keep_price) {
         const res = super.setQuantity(quantity, keep_price);
-        const extra_product_id = this.product_id.product_tmpl_id.extra_product_id;
+        const extra_product_id = this.product_id?.product_tmpl_id?.extra_product_id;
         if (extra_product_id) {
             const order = this.order_id;
             order.add_extra_product(extra_product_id);


### PR DESCRIPTION
## Simptom

La **Damira** nu se mai aduce în POS produsul pentru taxa SGR. Fără eroare, fără mesaj — linia pur și simplu lipsește de pe bon.

## Cauza

În Odoo 19 `PosStore.addLineToOrder` construiește linia din `vals.product_tmpl_id` (varianta se derivă din șablon), nu din `vals.product_id` ca în 18.0:

```js
const productTemplate = vals.product_tmpl_id;
const values = { ..., product_id: productTemplate.product_variant_ids[0], ...vals };
```

Migrarea 18→19 a modulului (1bfa4bf0c) a fost pur mecanică — doar redenumiri de metode (`get_order` → `getOrder`, `set_quantity` → `setQuantity`) — și a păstrat citirea `vals.product_id`. Pe 19 aceasta e mereu `undefined`, deci `product?.product_tmpl_id?.extra_product_id` e `undefined` și blocul care adaugă linia extra **nu se execută niciodată**. Eșec tăcut: optional chaining înghite totul.

În plus, chiar dacă produsul ar fi fost găsit, apelul intern `addLineToCurrentOrder({product_id: ...})` ar fi crăpat pe `productTemplate.taxes_id` — `vals` fără `product_tmpl_id`.

## Corecția

- șablonul se citește din oricare dintre cele două chei (`product_tmpl_id` sau `product_id`), cu helperul `getProductTemplate`;
- linia extra se cere cu `product_tmpl_id` (cerut de 19) **și** `product_id`;
- gard: produsul extra se adaugă doar dacă e el însuși încărcat în POS (`available_in_pos`), altfel relația e nerezolvată în frontend;
- optional chaining defensiv în `add_extra_product` / `setQuantity`;
- `extra_qty` cade pe 1 când e zero, ca în versiunea de vânzări.

Versiune 19.0.1.0.0 → 19.0.1.0.1, cu `readme/HISTORY.md`.

## Testare

Nerulat pe o instanță — analiza e statică pe contractul din `point_of_sale/static/src/app/services/pos_store.js`. De verificat pe Damira: produs cu `extra_product_id` = produsul SGR, ambele disponibile în POS, adăugare pe bon → apare linia SGR, iar modificarea cantității o recalculează.

🤖 Generated with [Claude Code](https://claude.com/claude-code)