### PR TITLE
[IMP] deltatech_report_packaging: keep packaging quantities set by hand

### DIFF
--- a/deltatech_report_packaging/README.rst
+++ b/deltatech_report_packaging/README.rst
@@ -25,10 +25,37 @@ Report Packaging
 Calculates packaging materials from invoiced product quantities and
 provides an aggregate packaging-material report from the invoice list.
 
+The quantities are refreshed when the invoice is posted, as long as the
+invoice is under automatic update. Editing or deleting a quantity by
+hand takes the invoice out of automatic update, so that the correction
+survives the validation of the invoice; the Refresh button computes the
+quantities again and puts the invoice back under automatic update.
+
 **Table of contents**
 
 .. contents::
    :local:
+
+Usage
+=====
+
+Set the packaging materials and the quantity per unit on the product, in
+the **Packaging materials** section of the product form.
+
+On a customer or vendor invoice, the **Packaging materials** tab shows
+the quantity of each material, computed as the invoiced quantity
+multiplied by the quantity configured on the product. The quantities are
+computed again when the invoice is posted.
+
+To correct a quantity, edit it — or delete the line — directly in the
+tab. The **Auto-update packaging materials** switch in the tab is unset
+automatically, and the validation of the invoice no longer overwrites
+what you entered. Press **Refresh** to discard the corrections, compute
+the quantities from the invoice lines again and put the invoice back
+under automatic update.
+
+To obtain the aggregate report, select several invoices in the list view
+and run the packaging-material report action.
 
 Bug Tracker
 ===========

--- a/deltatech_report_packaging/__manifest__.py
+++ b/deltatech_report_packaging/__manifest__.py
@@ -2,7 +2,7 @@
     "images": ["static/description/main_screenshot.png"],
     "name": "Report Packaging",
     "summary": "Report packaging materials used for invoiced products",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "category": "Product",
     "author": "Terrabit",
     "website": "https://www.terrabit.ro",

--- a/deltatech_report_packaging/models/account_move.py
+++ b/deltatech_report_packaging/models/account_move.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 from ..constants import PACKAGING_MATERIAL_TYPES
 
@@ -12,6 +12,14 @@ class AccountMove(models.Model):
         "packaging.invoice.material",
         "invoice_id",
         string="Packaging materials",
+    )
+    packaging_material_auto = fields.Boolean(
+        string="Auto-update packaging materials",
+        default=True,
+        help="Keep the packaging material quantities computed from the invoice lines and "
+        "refreshed when the invoice is posted. Unset it to keep the quantities entered by "
+        "hand: editing or deleting a quantity unsets it automatically, and the Refresh "
+        "button computes them again and sets it back.",
     )
 
     def refresh_packaging_material(self):
@@ -26,8 +34,11 @@ class AccountMove(models.Model):
                 for material in product.product_tmpl_id.packaging_material_ids:
                     quantities_by_material[material.material_type] += quantity * material.qty
 
-            invoice.packaging_material_ids.unlink()
-            self.env["packaging.invoice.material"].create(
+            # `packaging_material_sync` tells the lines that this write comes from the
+            # computation itself, so that it is not mistaken for a manual edit
+            # (which would unset `packaging_material_auto`, ticket #9413).
+            invoice.packaging_material_ids.with_context(packaging_material_sync=True).unlink()
+            self.env["packaging.invoice.material"].with_context(packaging_material_sync=True).create(
                 [
                     {
                         "invoice_id": invoice.id,
@@ -37,11 +48,24 @@ class AccountMove(models.Model):
                     for material_type, quantity in quantities_by_material.items()
                 ]
             )
+            # an explicit refresh takes the invoice back under automatic update
+            if not invoice.packaging_material_auto:
+                invoice.packaging_material_auto = True
         return True
+
+    def _packaging_material_mark_manual_on_invoice(self):
+        """Unset the automatic update, the packaging quantities being set by hand."""
+        if self.env.context.get("packaging_material_sync"):
+            return
+        # a line can be unlinked together with its invoice, which is then already gone
+        manual = self.exists().filtered("packaging_material_auto")
+        if manual:
+            manual.packaging_material_auto = False
 
     def action_post(self):
         result = super().action_post()
-        self.filtered(lambda move: move.move_type != "entry").refresh_packaging_material()
+        auto = self.filtered(lambda move: move.move_type != "entry" and move.packaging_material_auto)
+        auto.refresh_packaging_material()
         return result
 
 
@@ -58,3 +82,25 @@ class InvoicePackagingMaterial(models.Model):
     )
     material_type = fields.Selection(PACKAGING_MATERIAL_TYPES, required=True)
     qty = fields.Float(string="Quantity", required=True)
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        lines = super().create(vals_list)
+        lines._packaging_material_mark_manual()
+        return lines
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._packaging_material_mark_manual()
+        return res
+
+    def unlink(self):
+        # the invoices have to be read before the lines are gone
+        invoices = self.invoice_id
+        res = super().unlink()
+        invoices._packaging_material_mark_manual_on_invoice()
+        return res
+
+    def _packaging_material_mark_manual(self):
+        """Take the invoice out of automatic update, the quantities being set by hand."""
+        self.invoice_id._packaging_material_mark_manual_on_invoice()

--- a/deltatech_report_packaging/readme/DESCRIPTION.md
+++ b/deltatech_report_packaging/readme/DESCRIPTION.md
@@ -1,2 +1,8 @@
 Calculates packaging materials from invoiced product quantities and provides an
 aggregate packaging-material report from the invoice list.
+
+The quantities are refreshed when the invoice is posted, as long as the invoice is
+under automatic update. Editing or deleting a quantity by hand takes the invoice out
+of automatic update, so that the correction survives the validation of the invoice;
+the Refresh button computes the quantities again and puts the invoice back under
+automatic update.

--- a/deltatech_report_packaging/readme/NOUTATI_19.md
+++ b/deltatech_report_packaging/readme/NOUTATI_19.md
@@ -2,3 +2,4 @@
 
 ## Ce e nou față de 18.0
 - **Evidența materialelor de ambalare consumate pentru produsele facturate**: configurare pe produs, urmărire pe liniile de factură și asistent de completare în masă — baza pentru raportările de ambalaje.
+- **Corecții manuale păstrate la validare**: cantitățile de materiale de ambalare editate sau șterse pe factură nu mai sunt rescrise la validarea acesteia — comutatorul „Actualizare automată” din tab se dezactivează singur la prima editare, iar butonul „Refresh” recalculează și readuce factura sub actualizare automată.

--- a/deltatech_report_packaging/readme/USAGE.md
+++ b/deltatech_report_packaging/readme/USAGE.md
@@ -1,0 +1,15 @@
+Set the packaging materials and the quantity per unit on the product, in the
+**Packaging materials** section of the product form.
+
+On a customer or vendor invoice, the **Packaging materials** tab shows the quantity of
+each material, computed as the invoiced quantity multiplied by the quantity configured
+on the product. The quantities are computed again when the invoice is posted.
+
+To correct a quantity, edit it — or delete the line — directly in the tab. The
+**Auto-update packaging materials** switch in the tab is unset automatically, and the
+validation of the invoice no longer overwrites what you entered. Press **Refresh** to
+discard the corrections, compute the quantities from the invoice lines again and put
+the invoice back under automatic update.
+
+To obtain the aggregate report, select several invoices in the list view and run the
+packaging-material report action.

--- a/deltatech_report_packaging/tests/test_report_packaging.py
+++ b/deltatech_report_packaging/tests/test_report_packaging.py
@@ -86,3 +86,57 @@ class TestPackagingMaterial(AccountTestInvoicingCommon):
         )
         self.assertEqual(report.state, "get")
         self.assertEqual(action["res_id"], report.id)
+
+    def test_manual_quantity_unsets_the_automatic_update(self):
+        invoice = self._create_invoice()
+        invoice.refresh_packaging_material()
+        self.assertTrue(invoice.packaging_material_auto)
+
+        invoice.packaging_material_ids.filtered(lambda line: line.material_type == "plastic").qty = 7.0
+
+        self.assertFalse(invoice.packaging_material_auto)
+
+    def test_deleting_a_quantity_unsets_the_automatic_update(self):
+        invoice = self._create_invoice()
+        invoice.refresh_packaging_material()
+
+        invoice.packaging_material_ids.filtered(lambda line: line.material_type == "wood").unlink()
+
+        self.assertFalse(invoice.packaging_material_auto)
+
+    def test_post_keeps_manual_quantities(self):
+        invoice = self._create_invoice()
+        invoice.refresh_packaging_material()
+        invoice.packaging_material_ids.filtered(lambda line: line.material_type == "glass").unlink()
+        invoice.packaging_material_ids.filtered(lambda line: line.material_type == "plastic").qty = 7.0
+
+        invoice.action_post()
+
+        quantities = {line.material_type: line.qty for line in invoice.packaging_material_ids}
+        self.assertEqual(
+            quantities,
+            {"plastic": 7.0, "wood": 1.0},
+            "the quantities set by hand survive the validation of the invoice",
+        )
+        self.assertFalse(invoice.packaging_material_auto)
+
+    def test_refresh_takes_the_invoice_back_under_automatic_update(self):
+        invoice = self._create_invoice()
+        invoice.refresh_packaging_material()
+        invoice.packaging_material_ids.filtered(lambda line: line.material_type == "plastic").qty = 7.0
+
+        invoice.refresh_packaging_material()
+
+        quantities = {line.material_type: line.qty for line in invoice.packaging_material_ids}
+        self.assertEqual(quantities, {"plastic": 2.0, "wood": 1.0, "glass": 0.5})
+        self.assertTrue(invoice.packaging_material_auto)
+
+    def test_refresh_does_not_unset_the_automatic_update(self):
+        invoice = self._create_invoice()
+
+        invoice.refresh_packaging_material()
+
+        self.assertTrue(
+            invoice.packaging_material_auto,
+            "the computation itself is not a manual edit",
+        )

--- a/deltatech_report_packaging/views/account_move_view.xml
+++ b/deltatech_report_packaging/views/account_move_view.xml
@@ -9,6 +9,7 @@
                 <page name="packaging_material" string="Packaging materials" invisible="move_type == 'entry'">
                     <header>
                         <button name="refresh_packaging_material" string="Refresh" type="object"/>
+                        <field name="packaging_material_auto" widget="boolean_toggle"/>
                     </header>
                     <field name="packaging_material_ids" nolabel="1">
                         <list editable="bottom">


### PR DESCRIPTION
Tichet #9413 (PTC ONLINE) — „pentru anumite SKU-uri, să șterg cantitatea de ambalaje din factura de achiziție".

## Problema

Tabul **Packaging materials** de pe factură oferă linii editabile (`editable="bottom"`), dar `action_post` apela necondiționat `refresh_packaging_material`, care face `unlink()` pe **toate** liniile și le recreează din liniile facturii. Corecția manuală era deci anulată exact în momentul validării — editarea îi era oferită utilizatorului în interfață și îi era luată la validare, fără niciun mesaj.

## Soluția

Factura primește `packaging_material_auto` (bifat implicit, afișat ca comutator în header-ul tabului):

- **bifat** — cantitățile se recalculează la validare, ca până acum;
- **editare sau ștergere manuală a unei cantități** — se debifează singur, deci validarea nu mai rescrie corecția;
- **butonul Refresh** — recalculează din liniile facturii și readuce factura sub actualizare automată;
- scrierile venite din calculul propriu purtă `packaging_material_sync` în context, ca să nu fie luate drept editare manuală.

Bifa implicită reproduce comportamentul de azi pe toate facturile existente, deci **nu e nevoie de migrare**.

## Teste

Cinci teste noi în `tests/test_report_packaging.py`: editarea debifează, ștergerea debifează, validarea păstrează cantitățile manuale, Refresh readuce sub automat, iar calculul propriu nu se auto-debifează.

Rulat local: `11 tests, 0 failed, 0 error(s)`.

## Rămâne în afara acestui PR

Al doilea punct al tichetului — atenționarea la validarea facturii de intrare când ambalajele nu sunt setate — e funcționalitate nouă (nu există azi niciun warning pe ambalaje în cod) și așteaptă specificația clientului.

🤖 Generated with [Claude Code](https://claude.com/claude-code)