### PR TITLE
[FIX] deltatech_sale_purchase: declară dependența pe purchase_stock

### DIFF
--- a/deltatech_sale_purchase/__manifest__.py
+++ b/deltatech_sale_purchase/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Sales",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
-    "depends": ["sale_purchase", "sale_stock"],
+    "depends": ["sale_purchase", "sale_stock", "purchase_stock"],
     "license": "LGPL-3",
     "images": ["static/description/main_screenshot.png"],
     "development_status": "Beta",


### PR DESCRIPTION
Descoperit prin shard-ul `test (sale-2)` picat în #2900 (un PR de regenerare de README care nu atinge deloc acest modul — doar a declanșat shard-ul care îl rulează).

## Bug-ul

`deltatech_sale_purchase` folosește `purchase_stock` fără să-l declare:

```python
"depends": ["sale_purchase", "sale_stock"],
```

Nu e doar în teste — [models/sale_order.py:17](https://github.com/dhongu/deltatech/blob/19.0/deltatech_sale_purchase/models/sale_order.py#L17) folosește `move_ids.created_purchase_line_ids`, câmp definit exclusiv în `purchase_stock/models/stock_move.py`.

## De ce nu s-a văzut până acum

Golul era acoperit tăcut de **auto_install**: `purchase_stock` are `auto_install=True` și depinde de `stock_account` + `purchase`, ambele aduse de `sale_stock` și `sale_purchase`. Pe orice bază normală ajungea instalat oricum, deci modulul părea corect.

Pe Odoo 19, `oca_init_test_database` adaugă `--skip-auto-install`:

```
+ ((  ODOO_MAJOR >= 19  ))
+ params+=(--skip-auto-install)
```

iar lista de instalat e închiderea tranzitivă a `depends` **declarate** (`manifestoo list-depends`). `purchase_stock` nu apare în ea, rămâne neinstalat, și `setUpClass` crapă:

```
ValueError: External ID not found in the system: purchase_stock.route_warehouse0_buy
```

## Verificare

Reprodus și confirmat local, pe bază curată, cu exact flag-ul din CI:

| | `purchase_stock` | rezultat |
|---|---|---|
| fără fix, `--skip-auto-install` | `uninstalled` | `exit=1`, `External ID not found` — identic cu CI |
| cu fix, `--skip-auto-install` | `installed` | `exit=0`, `0 failed, 0 error(s) of 3 tests` |

Fără `--skip-auto-install` **trec ambele variante** — de aceea bug-ul nu se reproduce local prin rularea obișnuită.

## Audit pe restul suitei

Am verificat mecanic toate cele ~180 de module din `deltatech` pentru aceeași clasă de problemă:

- **xmlid-uri `alt_modul.xml_id`** (în `env.ref`, `ref=`, `inherit_id`) față de `depends` tranzitiv, ignorând comentariile XML și referințele cu `raise_if_not_found=False` — **zero constatări** în afara acesteia. Verificarea a fost validată: pe manifestul nereparat semnalează exact acest bug și nimic altceva.
- **`_inherit` pe modele** definite în module nedeclarate — zero constatări.
- **câmpuri** definite doar în module nedeclarate — 24 de candidați, toți cei din cod verificați manual și respinși: `hasattr()` deliberat, gardă explicită pe modul instalat, sau metodă locală cu nume coincident.

Ultima verificare e euristică, deci nu garantează acoperire completă pentru dependențe folosite doar prin câmpuri.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
