### PR TITLE
[FIX] tb_gen_index: text negru pe Apps Store (clasa text-body forța gri)

### DIFF
--- a/deltatech/static/description/index.html
+++ b/deltatech/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech</code> module is the foundational technical dependency for the entire Deltatech suite
 of Odoo addons. It provides shared base extensions and minor infrastructure improvements that
@@ -65,7 +65,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_account/static/description/index.html
+++ b/deltatech_account/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Deltatech Account extends Odoo's standard accounting module with enhanced invoice views,
 additional journal configuration options, and an extra setting for Anglo-Saxon accounting
@@ -39,7 +39,7 @@ workflows.</p>
   (e.g., "Incoming payments" label for the receivable payments menu).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Provides a foundation for further invoice view customisations inheriting from the
   standard account invoice form.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Anglo-Saxon Accounting</h2>
 <p>The module adds one setting under <strong>Accounting &gt; Configuration &gt; Settings</strong>, in the
@@ -102,7 +102,7 @@ disable it independently.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_average_payment_period" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_expenses" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -214,7 +214,7 @@ disable it independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_account_analytic/static/description/index.html
+++ b/deltatech_account_analytic/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The Deltatech Account Analytic module is a comprehensive extension for Odoo's analytic accounting system, designed to enhance the management and tracking of analytic information. Developed by Terrabit, this module provides advanced features for splitting analytic lines, especially in sales and purchase workflows, allowing for more detailed financial analysis and reporting.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -103,7 +103,7 @@
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Use Cases</h2>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Sales Margin Analysis</span><div class="mt-1">Track and analyze sales margins separately from cost of goods sold.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Team Performance Tracking</span><div class="mt-1">Associate specific analytic accounts with sales teams for performance analysis.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Cost Center Management</span><div class="mt-1">Better allocation of costs and revenues to appropriate cost centers.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Profitability Analysis</span><div class="mt-1">More accurate analysis of product and service profitability.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.0.6 (2026-07-31)</h2>
@@ -165,7 +165,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_average_payment_period" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -213,7 +213,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_expenses" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -229,7 +229,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -245,7 +245,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -261,7 +261,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -277,7 +277,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_account_edi_ubl_advice/static/description/index.html
+++ b/deltatech_account_edi_ubl_advice/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enriches outgoing UBL e-invoices (e-Factura) with a reference to the
 delivery documents behind each invoice.</p>
@@ -70,7 +70,7 @@ delivery notes (despatch advices) the invoice covers.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -86,7 +86,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_average_payment_period" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_expenses" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@ delivery notes (despatch advices) the invoice covers.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_account_edit_currency_rate/static/description/index.html
+++ b/deltatech_account_edit_currency_rate/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module allows users to edit the currency exchange rate directly on invoice documents.
@@ -61,7 +61,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -77,7 +77,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -93,7 +93,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_actions/static/description/index.html
+++ b/deltatech_actions/static/description/index.html
@@ -32,7 +32,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Provides a set of scheduled maintenance actions (cron jobs) to keep an Odoo database clean and performant.
 All jobs are <strong>disabled by default</strong> and run in <strong>dry mode</strong> (no data is changed until explicitly enabled by an administrator).</p>
@@ -40,7 +40,7 @@ All jobs are <strong>disabled by default</strong> and run in <strong>dry mode</s
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Delete duplicate XML (EDI/ANAF) attachments on invoices &#8212; cron: <em>Delete duplicate xml attachments</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Delete old generated PDF attachments on invoices &#8212; cron: <em>Delete pdf invoice attachments</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Delete old generated PDF attachments on sale orders &#8212; cron: <em>Delete pdf sale order attachments</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Delete old generated PDF attachments on stock pickings &#8212; cron: <em>Delete pdf pickings attachments</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Delete old chatter messages (with linked non-ANAF attachments) &#8212; cron: <em>Delete mail messages</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Create missing stock reordering rules for storable products &#8212; cron: <em>Create missing reordering rules (0/0)</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Merge duplicate contacts by e-mail address &#8212; cron: <em>Merge duplicate contacts by email</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Merge duplicate companies by VAT number &#8212; cron: <em>Merge duplicate companies by VAT</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Normalize company name suffixes (SRL &#8594; S.R.L., SA &#8594; S.A., etc.) &#8212; cron: <em>Normalize company names</em></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Force-cancel a sale order together with all its pickings, stock moves and account moves via a server action
   (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">force_cancel_order_and_moves</code>); the server action must be created manually for security reasons</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <p>All scheduled actions provided by this module are <strong>disabled by default</strong> (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">active=False</code> on the
 underlying <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ir.cron</code> record, set once at install and never reset on upgrade), and the ones that
@@ -133,7 +133,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
 <li>Add the action to the sale order's <em>Action</em> menu if needed.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.9.0</h2>
 <ul>
@@ -244,7 +244,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_category_group" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -260,7 +260,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -276,7 +276,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -292,7 +292,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -308,7 +308,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -324,7 +324,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -340,7 +340,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -356,7 +356,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_agreement_management/static/description/index.html
+++ b/deltatech_agreement_management/static/description/index.html
@@ -32,7 +32,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Manage commercial and service agreements with partners &#8212; track reference numbers,
 dates, statuses, and print agreement documents directly from Odoo.</p>
@@ -41,7 +41,7 @@ dates, statuses, and print agreement documents directly from Odoo.</p>
   when generating the agreement document.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Generate the agreement reference number automatically from the configured sequence
   (button <strong>Get number</strong> available while the agreement is still in Draft).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Print the agreement as a PDF using the report template attached to the agreement type.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Partners display an <strong>Agreements</strong> smart button showing the count of linked agreements.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Filter partners by the presence of agreements using the built-in search filter.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Full chatter/activity support on every agreement record.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Security groups</h2>
 <p>Two groups are provided. Assign users before they can access the Agreement menu:</p>
@@ -65,7 +65,7 @@ dates, statuses, and print agreement documents directly from Odoo.</p>
   <strong>Print</strong> is clicked on an agreement form. If not set, printing will raise an error.</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Creating an agreement</h2>
 <ol>
@@ -138,7 +138,7 @@ that is In Progress or Terminated will raise a validation error.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -218,7 +218,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -234,7 +234,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -250,7 +250,7 @@ that is In Progress or Terminated will raise a validation error.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_alternative/static/description/index.html
+++ b/deltatech_alternative/static/description/index.html
@@ -32,7 +32,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Manage multiple alternative codes per product and find any item by any of its codes.
 This module is useful when the same product is known under different references &#8212; supplier
@@ -48,7 +48,7 @@ team needs to locate it regardless of which code they have at hand.</p>
   <strong>Stock Move</strong> lines, keeping the code visible throughout the order-to-delivery flow.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Adds a free-text <strong>Used For</strong> field on the product to note what the item can be used for,
   aiding identification and cross-selling.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Alternative Search Settings</h2>
 <p>Navigate to <strong>Settings &gt; Inventory</strong> (the setting is injected after the <em>Units of Measure</em>
@@ -86,7 +86,7 @@ section) to configure the alternative-code search behaviour:</p>
 <p>These three values are stored as <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ir.config_parameter</code> system parameters and can also be
 set directly via <strong>Settings &gt; Technical &gt; Parameters &gt; System Parameters</strong> if needed.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Adding Alternative Codes to a Product</h2>
 <ol>
@@ -161,7 +161,7 @@ product.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -209,7 +209,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -225,7 +225,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -241,7 +241,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -257,7 +257,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -273,7 +273,7 @@ product.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_alternative_website/static/description/index.html
+++ b/deltatech_alternative_website/static/description/index.html
@@ -32,13 +32,13 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends the Odoo website shop to expose <strong>alternative product codes</strong> directly on the product page and in the website search engine. It is designed for businesses (spare parts distributors, industrial suppliers) where customers search by OEM codes, cross-reference numbers, or manufacturer codes rather than internal SKUs.</p>
 <p><strong>Key features:</strong></p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Displays the alternative code(s) stored on the product (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">alternative_ids</code>) as hidden <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">&lt;span&gt;</code> elements with <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">itemprop="alternateName"</code>, making them available to search engines and the internal site search.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Shows a dedicated <strong>"Alternative code"</strong> section on the product page (visible to logged-in users only) with the primary <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">alternative_code</code> value.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Shows a <strong>"Used For"</strong> section on the product page when the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">used_for</code> field is populated, indicating the vehicle / equipment the part fits.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Extends the website full-text search (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">_search_get_detail</code>) to include <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">alternative_ids.name</code> in the searchable fields, so customers can find products by any of their cross-reference codes.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Improves search query normalisation via <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">website.searchable.mixin</code>: strips leading/trailing whitespace and collapses multiple spaces before the search is executed, reducing false "0 results" responses.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Depends on <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_alternative</code> for the underlying <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">alternative_ids</code> and <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">used_for</code> fields on <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">product.template</code>.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Searching by alternative code</h2>
 <ol>
@@ -67,7 +67,7 @@
 <li>Add one or more alternative/cross-reference codes. These codes will immediately be searchable on the website.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.8 (2026-07-27)</h2>
 <ul>
@@ -119,7 +119,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -215,7 +215,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -231,7 +231,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_analytic_distribution/static/description/index.html
+++ b/deltatech_analytic_distribution/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enforces strict analytic distribution rules on vendor bills, ensuring every
 invoice line is fully allocated across the company's analytic dimensions before posting.</p>
@@ -37,7 +37,7 @@ invoice line is fully allocated across the company's analytic dimensions before 
   100%.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Enforces that each distribution entry covers exactly three analytic dimensions:
   Location, Department, and Line of Business.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Company-specific setting &#8212; can be enabled per company via Accounting configuration.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <p>To enable analytic distribution enforcement for a company:</p>
 <ol>
@@ -93,7 +93,7 @@ enabled or disabled independently.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -205,7 +205,7 @@ enabled or disabled independently.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_auto_reorder_rule/static/description/index.html
+++ b/deltatech_auto_reorder_rule/static/description/index.html
@@ -32,13 +32,13 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Automatically creates reorder rules (replenishment rules) for products in Odoo, reducing the manual overhead of setting up stock replenishment in warehouses that manage many SKUs.</p>
 <p><strong>Key features:</strong></p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Automatically creates a <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">stock.warehouse.orderpoint</code> entry for every new storable product, using the warehouse and route marked for auto-rules.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Provides a <strong>Create rule</strong> server action (available on the Products list) to generate rules in bulk for existing products that do not yet have one.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Provides an <strong>Open Rules Wizard</strong> server action (available on the product form) to create rules for specific locations, with configurable minimum/maximum quantities and trigger mode (automatic or manual).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>A system parameter allows disabling the automatic rule creation on product creation, without uninstalling the module.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Rules are only created for warehouses that have the <strong>Generate Reorder Rules</strong> option enabled, ensuring multi-warehouse setups can opt in or out per warehouse.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>A dedicated flag on stock routes (<strong>Use This for Auto Rules</strong>) controls which route is assigned to automatically created rules.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Warehouse configuration</h2>
 <p>Go to <strong>Inventory &gt; Configuration &gt; Warehouses</strong>, open the warehouse form, and look for the <strong>Generate Reorder Rules</strong> checkbox (added by this module in the replenishment section). Enable it on every warehouse for which rules should be created automatically. It is enabled by default on new warehouses.</p>
@@ -52,7 +52,7 @@
 </ul>
 <p>When this parameter is set, rules are no longer created on product creation but can still be generated manually via the server actions on the Products list or form.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Automatic rule creation</h2>
 <p>After the module is installed and configured (see CONFIGURE), every new storable product saved in the system will have a reorder rule created automatically for each warehouse that has <strong>Generate Reorder Rules</strong> enabled. No manual action is required.</p>
@@ -117,7 +117,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -213,7 +213,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -229,7 +229,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_average_payment_period/static/description/index.html
+++ b/deltatech_average_payment_period/static/description/index.html
@@ -27,14 +27,14 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Tracks how long customers and suppliers actually take to pay, giving finance teams a concrete measure of cash-collection and payment efficiency.</p>
 <p>For each reconciled journal entry the module records the exact payment date and computes the number of days elapsed since the invoice date. An aggregated pivot/graph report &#8212; <strong>Average Payment Period</strong> &#8212; is added directly to the Accounting Reports menu so managers can slice the data by partner, journal, or period at a glance.</p>
 <p><strong>Key features:</strong></p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Payment Date</span><div class="mt-1">&#8212; automatically derived from the reconciliation partner line and stored on each <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move.line</code>.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Payment Days</span><div class="mt-1">&#8212; difference (in days) between the invoice date and the payment date, weighted by the line amount for accurate averages across grouped data.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Plain Payment Days</span><div class="mt-1">&#8212; simplified variant limited to customer invoices (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">out_invoice</code>) and vendor bills (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">in_invoice</code>), excluding credit notes, for cleaner KPI reporting.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Average Payment Period report</span><div class="mt-1">&#8212; a dedicated pivot and graph view (menu: Accounting &gt; Reporting &gt; Average Payment Period) grouped by partner by default; filterable by date, partner, journal, and account.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Weighted average calculation</span><div class="mt-1">&#8212; when grouping rows, the average is computed as <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">sum(amount &#215; days) / sum(amount)</code> rather than a plain arithmetic mean, preventing distortion from small-amount outliers.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Viewing the Average Payment Period report</h2>
 <ol>
@@ -96,7 +96,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_expenses" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -192,7 +192,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -208,7 +208,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_backup_attachment/static/description/index.html
+++ b/deltatech_backup_attachment/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module allows Odoo administrators to export a selective set of file attachments as a
 single ZIP archive. By providing a domain filter on the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ir.attachment</code> model, you can precisely
@@ -45,7 +45,7 @@ to specific records, or stored on a particular field.</p>
   &#8212; export attachments linked to fields (not products or the wizard itself).</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Export Attachments</h2>
 <ol>
@@ -102,7 +102,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_contact" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_credentials" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_gln" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_image_optimize" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -214,7 +214,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_batch_transfer/static/description/index.html
+++ b/deltatech_batch_transfer/static/description/index.html
@@ -32,7 +32,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Extends Odoo's batch transfer (batch picking) functionality to give warehouse operators
 better control over batches that contain partially-processed or empty transfers.
@@ -57,7 +57,7 @@ interface).</li>
   move lines with quantity &gt; 0 (bold) vs. zero-quantity lines (muted).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Deliveries batch report</span><div class="mt-1">&#8212; PDF report that prints all delivery documents in a
   batch in a single action.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">System parameter: deltatech_batch_keep_pickings</h2>
 <p>This parameter controls how empty pickings (all done quantities = 0) are handled when
@@ -97,7 +97,7 @@ a batch is validated.</p>
 <li>Save. The change takes effect immediately on the next batch validation.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Prepare a batch from purchase/sale orders</h2>
 <ol>
@@ -194,7 +194,7 @@ customer and sets mode to <em>Sale</em>.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -226,7 +226,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -242,7 +242,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -258,7 +258,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -274,7 +274,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -290,7 +290,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -306,7 +306,7 @@ customer and sets mode to <em>Sale</em>.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_business_process/static/description/index.html
+++ b/deltatech_business_process/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Business Process Management for Odoo</p>
 <p>This module helps you structure and execute business implementation projects in Odoo. It introduces Projects, Business Processes and their Steps, along with Testing and Issue tracking flows so teams can design, validate and deliver processes in a controlled way.</p>
@@ -86,7 +86,7 @@
 <li>OPL-1. See README.rst at the addons root for license details.</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.9.0</h2>
 <ul>
@@ -150,7 +150,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process_handover_document" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_record_type" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_delivery" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -214,7 +214,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -230,7 +230,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -246,7 +246,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -262,7 +262,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_business_process_handover_document/static/description/index.html
+++ b/deltatech_business_process_handover_document/static/description/index.html
@@ -27,13 +27,13 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Extends the <strong>deltatech_business_process</strong> module to generate a formal <strong>Handover Document</strong> (proces-verbal de predare-primire) in PDF format directly from a Business Project.</p>
 <p><strong>Key features:</strong></p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Adds provider and recipient company details (name, representative, testers) to the Business Project form.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Automatically collects all developments linked to the project.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Adds a <strong>Handover Checked</strong> checkbox on each Business Area for sign-off tracking.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Generates a QWeb PDF report (A4 format) accessible via the <strong>Print</strong> menu on the Business Project.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Report is available in both English and Romanian.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Generating a Handover Document</h2>
 <ol>
@@ -95,7 +95,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_record_type" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_delivery" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -191,7 +191,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -207,7 +207,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_cash_statement/static/description/index.html
+++ b/deltatech_cash_statement/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a utility for easily updating cash balances within
 Odoo's bank statement records. It is particularly useful for accounting
@@ -41,7 +41,7 @@ financial records are accurate.</p>
   menu.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Designed for accounting professionals to help resolve discrepancies in
   cash registers without manual account journal entries.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Updating Cash Statement Balances</h2>
 <ol>
@@ -97,7 +97,7 @@ so that the starting balance of the next statement stays consistent.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -209,7 +209,7 @@ so that the starting balance of the next statement stays consistent.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_category_group/static/description/index.html
+++ b/deltatech_category_group/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends Odoo's internal product categories with two additional
 grouping dimensions &#8212; <strong>Category type</strong> and <strong>Category class</strong> &#8212; enabling
@@ -41,7 +41,7 @@ at a finer level than the built-in category hierarchy.</p>
   dimensions.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Access to the configuration lists is controlled by the dedicated security
   group <strong>Manage category groups</strong> (assigned to Administrator by default).</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <p>Before using the grouping filters in reports, configure the available types
 and classes.</p>
@@ -106,7 +106,7 @@ category form you will find two new fields, <strong>Category type</strong> and
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -218,7 +218,7 @@ category form you will find two new fields, <strong>Category type</strong> and
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_competitors_price/static/description/index.html
+++ b/deltatech_competitors_price/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Track competitors' product prices directly on the product form and fetch current prices on demand (or via future automation).</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
@@ -109,7 +109,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_chatter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_unique_code" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_packaging" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -205,7 +205,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -221,7 +221,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_contact/static/description/index.html
+++ b/deltatech_contact/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Extends the standard Odoo Contacts module with additional personal data fields for individual contacts, including Romanian CNP (Personal Numeric Code) with checksum validation, identity card details, birthdate, gender, and means of transport.</p>
 <p><strong>Key features:</strong></p>
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_backup_attachment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_credentials" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_gln" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_image_optimize" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_credentials/static/description/index.html
+++ b/deltatech_credentials/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;"><strong>Deltatech Credentials</strong> provides a centralised store for external service credentials
 within Odoo. Instead of scattering API keys, tokens, and login pairs across system
@@ -39,7 +39,7 @@ secure location &#8212; available directly under <strong>Settings &gt; Users &am
   API bridges) can reference <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">access.credentials</code> records to retrieve their credentials
   programmatically, keeping secrets out of module settings.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Managing Credentials</h2>
 <p>Only users with the <strong>Administrator</strong> role (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">base.group_system</code>) can access the
@@ -99,7 +99,7 @@ it as needed.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_backup_attachment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -115,7 +115,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_contact" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -131,7 +131,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -147,7 +147,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -163,7 +163,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_gln" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_image_optimize" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -195,7 +195,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -211,7 +211,7 @@ it as needed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_cron_monitor_webhook/static/description/index.html
+++ b/deltatech_cron_monitor_webhook/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a simple and secure solution to trigger Odoo cron jobs via webhooks using a global access token.</p>
 <h3 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:19px;letter-spacing:-0.3px;line-height:1.2;">Key Features:</h3>
@@ -38,7 +38,7 @@
 <h3 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:19px;letter-spacing:-0.3px;line-height:1.2;">Integration:</h3>
 <p>It is ideal for integration with external monitoring and scheduling platforms such as <strong>cron-job.org</strong>, <strong>healthchecks.io</strong>, or <strong>EasyCron</strong>, allowing better control over when jobs run, independent of the internal Odoo scheduler.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <p>To use this module with an external service like <strong>cron-job.org</strong>, follow these steps:</p>
 <h3 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:19px;letter-spacing:-0.3px;line-height:1.2;">1. Global Configuration</h3>
@@ -133,7 +133,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_rpc_audit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_tc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transport_change" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -213,7 +213,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -229,7 +229,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -245,7 +245,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_data_sheet/static/description/index.html
+++ b/deltatech_data_sheet/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Attach product documentation &#8212; technical data sheets and safety data sheets &#8212; directly to product records in Odoo, making the PDFs accessible from the product form for sales and logistics teams.</p>
 <p><strong>Key features:</strong></p>
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_backup_attachment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_contact" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_credentials" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_gln" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_image_optimize" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_data_sheet_website/static/description/index.html
+++ b/deltatech_data_sheet_website/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends the Odoo eCommerce product page to surface product documentation
 directly to website visitors. When a product has an associated data sheet or safety data
@@ -40,7 +40,7 @@ automatically displayed on the public product page &#8212; no extra configuratio
   in their browser.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Requires the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_data_sheet</code> module to manage and attach data sheets to
   products.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Prerequisites</h2>
 <p>Before using this module, attach a data sheet or safety data sheet to a product
@@ -98,7 +98,7 @@ template. Products without attached documents show no buttons.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_backup_attachment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_contact" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_credentials" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_gln" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_image_optimize" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ template. Products without attached documents show no buttons.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_dc/static/description/index.html
+++ b/deltatech_dc/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -39,7 +39,7 @@
 </li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.12 (2026-08-15)</h2>
@@ -88,7 +88,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process_handover_document" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_record_type" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_delivery" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -184,7 +184,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -200,7 +200,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_delivery_status/static/description/index.html
+++ b/deltatech_delivery_status/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends the functionality of the delivery system in Odoo to provide enhanced tracking and status management for shipments.</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h2>
@@ -73,7 +73,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_discount_policy/static/description/index.html
+++ b/deltatech_discount_policy/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module restores the Odoo 17 discount policy functionality in Odoo 18, allowing users to choose how discounts are displayed on sales orders.</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h2>
@@ -61,7 +61,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -77,7 +77,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -93,7 +93,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_download/static/description/index.html
+++ b/deltatech_download/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_dropshipping/static/description/index.html
+++ b/deltatech_dropshipping/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the dropshipping workflow by providing better visibility and price control.</p>
 <p>Features:</p>
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_ecr_fiscal/static/description/index.html
+++ b/deltatech_ecr_fiscal/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Defines, in a single place, the fields that record the result of printing on a fiscal
 cash register (ECR/AMEF):</p>
@@ -59,7 +59,7 @@ c&#226;mpuri.</p>
 module donoare, ca actualizarea lor s&#259; nu duc&#259; la &#537;tergerea coloanelor &#537;i a numerelor de
 bon fiscal deja &#238;nregistrate.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <p>Modulul nu adaug&#259; interfa&#539;&#259; proprie: el doar pune c&#226;mpurile la dispozi&#539;ie.</p>
 <p><strong>Ca s&#259; scrii &#238;n ele</strong> (driver de cas&#259; de marcat), mo&#537;tene&#537;te mixinul pe modelul t&#259;u:</p>
@@ -108,7 +108,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -188,7 +188,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -204,7 +204,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -220,7 +220,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_expenses/static/description/index.html
+++ b/deltatech_expenses/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -247,7 +247,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -263,7 +263,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -279,7 +279,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -295,7 +295,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_average_payment_period" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -311,7 +311,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -327,7 +327,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -343,7 +343,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -359,7 +359,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_fast_purchase/static/description/index.html
+++ b/deltatech_fast_purchase/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_create_bill_button" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_mail" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_refund" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_ubl" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_fast_sale/static/description/index.html
+++ b/deltatech_fast_sale/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Streamline your sales workflow by collapsing confirmation, delivery, and invoicing into a
 single button click directly on the sale order. Designed for businesses that need to
@@ -43,7 +43,7 @@ steps required.</p>
   picking view after delivery is done.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Stock availability is verified before delivery: if any product is not fully available,
   the action is blocked with a clear error message.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Invoice date is automatically set to today's date.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Fast confirmation and invoicing from a sale order</h2>
 <ol>
@@ -118,7 +118,7 @@ displayed.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -214,7 +214,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -230,7 +230,7 @@ displayed.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_followup/static/description/index.html
+++ b/deltatech_followup/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -110,7 +110,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -190,7 +190,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -206,7 +206,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -222,7 +222,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_generic_partner_restriction/static/description/index.html
+++ b/deltatech_generic_partner_restriction/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module has been merged into <strong>Deltatech Generic Partner</strong>
 (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_partner_generic</code>) and is now empty: it only keeps the dependency,
@@ -63,7 +63,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_gln/static/description/index.html
+++ b/deltatech_gln/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Partner GLN (Obsolete)</h1>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Status: Obsolete</h1>
@@ -81,7 +81,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_backup_attachment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_contact" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_credentials" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_image_optimize" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_image_optimize/static/description/index.html
+++ b/deltatech_image_optimize/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Two related jobs on the same images: <strong>recompress</strong> them to reclaim filestore
 space, and <strong>remove the ones stored twice</strong>.</p>
@@ -246,7 +246,7 @@ enable it.</p>
     env.cr.commit()
 </code></pre>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.9.0 (2026-08-27)</h2>
@@ -414,7 +414,7 @@ uncompressed. No change for opaque images.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_backup_attachment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -430,7 +430,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_contact" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -446,7 +446,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_credentials" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -462,7 +462,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -478,7 +478,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_data_sheet_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -494,7 +494,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_gln" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -510,7 +510,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -526,7 +526,7 @@ uncompressed. No change for opaque images.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_number/static/description/index.html
+++ b/deltatech_invoice_number/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -72,7 +72,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -184,7 +184,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_picking/static/description/index.html
+++ b/deltatech_invoice_picking/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -73,7 +73,7 @@ linked pickings.</strong></li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@ linked pickings.</strong></li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_picking_automatically/static/description/index.html
+++ b/deltatech_invoice_picking_automatically/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>Features:<ul>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_product_filter/static/description/index.html
+++ b/deltatech_invoice_product_filter/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_receipt/static/description/index.html
+++ b/deltatech_invoice_receipt/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_report/static/description/index.html
+++ b/deltatech_invoice_report/static/description/index.html
@@ -37,7 +37,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Extends the standard Odoo invoice analysis report and the product form with
 purchase/sales history data, making it easy to see how much of each product
@@ -69,7 +69,7 @@ that are useful for distribution and manufacturing companies.</p>
 &#8212; it is rebuilt in full by the daily cron, or on demand per product via the
 Refresh button. The source of truth remains the posted <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">account.move</code> records.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Cron job</h2>
 <p>After installation a scheduled action named <strong>Update Product Invoice History by
@@ -91,7 +91,7 @@ available immediately after installation, trigger the cron manually:</p>
 <li>Click <strong>Run Manually</strong>.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Viewing invoice history on a product</h2>
 <ol>
@@ -123,7 +123,7 @@ available immediately after installation, trigger the cron manually:</p>
 recomputes the history table for all products. No manual action is required for
 routine updates.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.8</h2>
 <ul>
@@ -174,7 +174,7 @@ routine updates.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -190,7 +190,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -206,7 +206,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -222,7 +222,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -238,7 +238,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -254,7 +254,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -270,7 +270,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -286,7 +286,7 @@ routine updates.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_to_draft/static/description/index.html
+++ b/deltatech_invoice_to_draft/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -60,7 +60,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_weight" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_invoice_weight/static/description/index.html
+++ b/deltatech_invoice_weight/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Invoice Weight and Mass Tracking</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds logistical weight tracking capabilities directly to Odoo's invoicing and order management systems. It's designed to help businesses monitor and report on the total net and gross weight of items being invoiced, purchased, or sold.</p>
@@ -84,7 +84,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -100,7 +100,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_kit_price/static/description/index.html
+++ b/deltatech_kit_price/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Deltatech Kit Price Calculation</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides specialized logic for calculating the cost price of kit products directly within sales order lines. It's designed for businesses that sell products composed of multiple components and need to track accurate margins based on the individual costs of those components.</p>
@@ -63,7 +63,7 @@
 <li>View the resulting margin to ensure profitability.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.0.2 (2026-08-15)</h2>
@@ -116,7 +116,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -212,7 +212,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -228,7 +228,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_ledger/static/description/index.html
+++ b/deltatech_ledger/static/description/index.html
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a comprehensive "Ledger" management system for tracking and organizing documents within Odoo.</p>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_line_counter/static/description/index.html
+++ b/deltatech_line_counter/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Module Line Counter</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds a wizard to count lines of code in selected Odoo modules.
@@ -58,7 +58,7 @@ Tests are excluded from the count.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sms" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ Tests are excluded from the count.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_list_view/static/description/index.html
+++ b/deltatech_list_view/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Function:</p>
 <ul>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_logistic_docs/static/description/index.html
+++ b/deltatech_logistic_docs/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Logistic Documents Centralizer</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a centralized repository for logistical and shipping-related documentation within Odoo. It's designed to streamline the management of physical documents (like CMRs, certificates of origin, or delivery notes) across different stages of the supply chain.</p>
@@ -86,7 +86,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_lot/static/description/index.html
+++ b/deltatech_lot/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mail/static/description/index.html
+++ b/deltatech_mail/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -68,7 +68,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -84,7 +84,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -100,7 +100,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_markdown_field/static/description/index.html
+++ b/deltatech_markdown_field/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;"><strong>Markdown Field Widget</strong> adds a new OWL field widget &#8212; <strong><code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">markdown</code></strong> &#8212; for any
 <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">Text</code> field in the Odoo backend.</p>
@@ -51,7 +51,7 @@ needs no external CDN.</p>
 &lt;field name=&quot;notes&quot; widget=&quot;markdown&quot; options=&quot;{'min_height': 300}&quot;/&gt;
 </code></pre>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <p>Declare the field as <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">Text</code> on your model:</p>
 <pre class="border rounded-3 p-3 my-3" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;overflow-x:auto;"><code class="language-python">notes = fields.Text(string=&quot;Notes&quot;)
@@ -106,7 +106,7 @@ without the toolbar.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -218,7 +218,7 @@ without the toolbar.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_move_negative_stock/static/description/index.html
+++ b/deltatech_move_negative_stock/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a convenient way to identify and resolve negative inventory levels at specific stock locations by automatically populating transfers with required quantities from other source locations.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -69,7 +69,7 @@
 <li>Optionally, set a <strong>Manager</strong> on the location to receive the daily negative stock email.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <ul>
 <li>
@@ -157,7 +157,7 @@ with negative stock in the location, summed over its sub-locations.</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_price_categ" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_promissory_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_purchase_requisition" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -205,7 +205,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_qty_available" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -221,7 +221,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_negative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -237,7 +237,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -253,7 +253,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -269,7 +269,7 @@ with negative stock in the location, summed over its sub-locations.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp/static/description/index.html
+++ b/deltatech_mrp/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Ajustari:</p>
 <p>mrp.bom EN: - field value_overhead was added - it is a percent for indirect expenses - rouding quantity at BOM explosion
@@ -75,7 +75,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_concentration" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -91,7 +91,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -107,7 +107,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -123,7 +123,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -139,7 +139,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -155,7 +155,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -171,7 +171,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -187,7 +187,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_bom/static/description/index.html
+++ b/deltatech_mrp_bom/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the management of Bills of Materials (BoM) in Odoo by introducing a template-based approach for product variants. It streamlines the creation and maintenance of complex BoMs by allowing users to define a "Base" structure that automatically propagates to specific variants, ensuring consistency and reducing manual configuration.</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>
@@ -72,7 +72,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -184,7 +184,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_bom_formula/static/description/index.html
+++ b/deltatech_mrp_bom_formula/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module lets a bill of material compute the quantity of a component from the attribute
 values of the manufactured variant, instead of repeating the same component on one line per
@@ -80,7 +80,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -192,7 +192,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_concentration/static/description/index.html
+++ b/deltatech_mrp_concentration/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">MRP Concentration Management</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces a specialized concentration management feature for manufacturing processes in Odoo. It's designed for industries (such as chemical, food, or pharmaceuticals) where the actual concentration of an active ingredient in a component can vary, requiring adjustments in the production quantities to maintain final product quality.</p>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_cost/static/description/index.html
+++ b/deltatech_mrp_cost/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_simple/static/description/index.html
+++ b/deltatech_mrp_simple/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -71,7 +71,7 @@ components</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -87,7 +87,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@ components</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_simple_barcode/static/description/index.html
+++ b/deltatech_mrp_simple_barcode/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -65,7 +65,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_mrp_validation_date/static/description/index.html
+++ b/deltatech_mrp_validation_date/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Tracks the exact date when a manufacturing order is validated (marked as done),
 giving production managers a reliable audit trail of order completion times.</p>
@@ -37,7 +37,7 @@ giving production managers a reliable audit trail of order completion times.</p>
   ensuring data integrity.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Works alongside the standard MRP scheduling fields (scheduled date, date finished)
   to provide a complete production timeline.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Using the Validation Date</h2>
 <ol>
@@ -88,7 +88,7 @@ giving production managers a reliable audit trail of order completion times.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -184,7 +184,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -200,7 +200,7 @@ giving production managers a reliable audit trail of order completion times.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_no_quick_create/static/description/index.html
+++ b/deltatech_no_quick_create/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_notification_sound/static/description/index.html
+++ b/deltatech_notification_sound/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Overview:
 Adds audible feedback to Odoo backend notifications so operators are alerted instantly without watching the screen.</p>
@@ -86,7 +86,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_partner_generic/static/description/index.html
+++ b/deltatech_partner_generic/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides an efficient way to manage transactions for generic or anonymous partners by allowing the definition of a specific "Generic Partner" in the Odoo configuration.</p>
@@ -91,7 +91,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -107,7 +107,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -123,7 +123,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -139,7 +139,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -155,7 +155,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -171,7 +171,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -187,7 +187,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -203,7 +203,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_partner_merge/static/description/index.html
+++ b/deltatech_partner_merge/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Merges partner records that share the same VAT number, in bulk.</p>
 <p>Odoo's own merge wizard walks the foreign keys <strong>group by group</strong>: for every pair it goes through all
@@ -51,7 +51,7 @@ import, with the names of the absorbed records alongside for correction.</p>
 <p>The same procedure is available as plain SQL scripts in <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech/scripts/partner_merge/</code>, for when
 it has to be run outside Odoo.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-08-18)</h2>
 <ul>
@@ -100,7 +100,7 @@ it has to be run outside Odoo.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -212,7 +212,7 @@ it has to be run outside Odoo.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_payment_forecast/static/description/index.html
+++ b/deltatech_payment_forecast/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module generates a report which shows what payments should be
 expected until a certain date A cron job can be scheduled to
@@ -57,7 +57,7 @@ automatically generate the report</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@ automatically generate the report</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_payment_term/static/description/index.html
+++ b/deltatech_payment_term/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module helps finance and sales teams quickly generate structured installment
 payment terms in Odoo, eliminating the need to manually create each payment line.
@@ -47,7 +47,7 @@ installments, and due dates automatically.</p>
   the action menu of sale orders and invoices, so terms can be regenerated without
   leaving the document.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Generating a payment term from the Payment Terms form</h2>
 <ol>
@@ -130,7 +130,7 @@ linked to installment payment terms for that partner.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -226,7 +226,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -242,7 +242,7 @@ linked to installment payment terms for that partner.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_picking_restrict/static/description/index.html
+++ b/deltatech_picking_restrict/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>A security group can be attached to a Operation Type. Only users in this group can validate pickings of this type</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>If left empty, no security group is required</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Adds another option, "Restrict done quantities to reserved", on move type, if the option is checked you can't validate
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_picking_restrict_entry_exit/static/description/index.html
+++ b/deltatech_picking_restrict_entry_exit/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>You will not be able to create a picking for receipt/delivery if there is no origin</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>You can't receive/deliver more than the demanded quantity</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>There is an implicit group on all users to restrict the access to the picking creation without origin</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>To remove someone from this group, you need go to the group "Picking create permission" and remove the user, be
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_picking_services/static/description/index.html
+++ b/deltatech_picking_services/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_picking_split/static/description/index.html
+++ b/deltatech_picking_split/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_picking_transit/static/description/index.html
+++ b/deltatech_picking_transit/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>On the stock picking type form you can add "next operation"</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>when you make an internal transfer with a picking type that has the "next operation" set, the system gives you the
@@ -65,7 +65,7 @@ based on the partner of the transfer (use the contact associated to the second w
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@ based on the partner of the transfer (use the contact associated to the second w
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_pos_fix/static/description/index.html
+++ b/deltatech_pos_fix/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Fix POS total calculation when using tax-included fiscal position mapping.</p>
 <p>When a product has a tax-included tax and a fiscal position maps it to a non-included tax (like 0% reverse charge), the POS should reduce the total price to the tax-excluded amount. This module patches the POS to handle this recalculation correctly, matching the backend Sales behavior.</p>
@@ -46,7 +46,7 @@ alongside the rest of the Terrabit POS suite and the official Romanian fiscal co
 without any overlap:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos</span><div class="mt-1">/ <strong>deltatech_pos_base</strong> &#8212; print fiscal receipts and drive cash management on a certified cash register</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_ecr_connect</span><div class="mt-1">&#8212; shared fiscal document model, ECR format converter and Terrabit Connect sender</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_stock</span><div class="mt-1">&#8212; shows available stock directly in the POS interface</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_price_sync</span><div class="mt-1">&#8212; pushes live product price changes to already open POS sessions</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_fiscal_compliance</span><div class="mt-1">&#8212; AMEF fiscal receipt tracking, Z report reconciliation and session blocking</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_anaf_d394_pos</span><div class="mt-1">&#8212; reports POS fiscal receipts in the D394 (op. 2) declaration to ANAF</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_returns</span><div class="mt-1">&#8212; dedicated return invoice and cash register line for every POS return</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-08-14)</h2>
 <ul>
@@ -98,7 +98,7 @@ without any overlap:</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pos_price_sync" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pos_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_pos_price_sync/static/description/index.html
+++ b/deltatech_pos_price_sync/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module pushes live product price changes to Point of Sale sessions that are already open.</p>
 <p>Key features:</p>
@@ -38,7 +38,7 @@ alongside the rest of the Terrabit POS suite and the official Romanian fiscal co
 without any overlap:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos</span><div class="mt-1">/ <strong>deltatech_pos_base</strong> &#8212; print fiscal receipts and drive cash management on a certified cash register</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_ecr_connect</span><div class="mt-1">&#8212; shared fiscal document model, ECR format converter and Terrabit Connect sender</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_stock</span><div class="mt-1">&#8212; shows available stock directly in the POS interface, using the same live-bus channel as this module</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_fix</span><div class="mt-1">&#8212; corrects POS total calculation for tax-included fiscal position mapping</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_fiscal_compliance</span><div class="mt-1">&#8212; AMEF fiscal receipt tracking, Z report reconciliation and session blocking</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_anaf_d394_pos</span><div class="mt-1">&#8212; reports POS fiscal receipts in the D394 (op. 2) declaration to ANAF</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_returns</span><div class="mt-1">&#8212; dedicated return invoice and cash register line for every POS return</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-08-20)</h2>
 <ul>
@@ -90,7 +90,7 @@ without any overlap:</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pos_fix" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pos_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_pos_product_filter/static/description/index.html
+++ b/deltatech_pos_product_filter/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -67,7 +67,7 @@ without any overlap:</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_analytic_distribution" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -83,7 +83,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cash_statement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -99,7 +99,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_followup" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -115,7 +115,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_number" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -131,7 +131,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_product_filter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -147,7 +147,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_receipt" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -163,7 +163,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_to_draft" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_pos_stock/static/description/index.html
+++ b/deltatech_pos_stock/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends the Point of Sale functionality to display the available stock quantity directly on the product cards.</p>
 <p>Key features:</p>
@@ -38,7 +38,7 @@ alongside the rest of the Terrabit POS suite and the official Romanian fiscal co
 without any overlap:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos</span><div class="mt-1">/ <strong>deltatech_pos_base</strong> &#8212; print fiscal receipts and drive cash management on a certified cash register</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_ecr_connect</span><div class="mt-1">&#8212; shared fiscal document model, ECR format converter and Terrabit Connect sender</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_price_sync</span><div class="mt-1">&#8212; pushes live product price changes to already open POS sessions, using the same live-bus channel as this module</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_fix</span><div class="mt-1">&#8212; corrects POS total calculation for tax-included fiscal position mapping</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_fiscal_compliance</span><div class="mt-1">&#8212; AMEF fiscal receipt tracking, Z report reconciliation and session blocking</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_anaf_d394_pos</span><div class="mt-1">&#8212; reports POS fiscal receipts in the D394 (op. 2) declaration to ANAF</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_returns</span><div class="mt-1">&#8212; dedicated return invoice and cash register line for every POS return</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.1.0 (2026-08-19)</h2>
 <ul>
@@ -105,7 +105,7 @@ without any overlap:</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pos_fix" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pos_price_sync" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -201,7 +201,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -217,7 +217,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_price_categ/static/description/index.html
+++ b/deltatech_price_categ/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces a tiered pricing system for products in Odoo, allowing businesses to define multiple price levels (Bronze, Copper, Silver, and Gold) based on configurable percentage markups from a base price.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -93,7 +93,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_move_negative_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_promissory_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_purchase_requisition" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_qty_available" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_negative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -205,7 +205,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_pricelist/static/description/index.html
+++ b/deltatech_pricelist/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:  </p>
 <ul>
@@ -60,7 +60,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_pricelist_line_viewer/static/description/index.html
+++ b/deltatech_pricelist_line_viewer/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances Odoo's pricelist management by providing a dedicated list view for pricelist items (lines). This makes it significantly easier to search, filter, and manage complex pricing rules across multiple products and categories.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_category_color" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_catalog/static/description/index.html
+++ b/deltatech_product_catalog/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_reordering_limit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenishment_explain" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_orderpoint_multiple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_picking_activity_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transfer_product_to_product" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_category_color/static/description/index.html
+++ b/deltatech_product_category_color/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_category_group/static/description/index.html
+++ b/deltatech_product_category_group/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -59,7 +59,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -75,7 +75,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -91,7 +91,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -107,7 +107,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -123,7 +123,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -139,7 +139,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -155,7 +155,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -171,7 +171,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_chatter/static/description/index.html
+++ b/deltatech_product_chatter/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Restrict deletion (and emptying) of chatter messages on Product Template and Product Variant unless the user belongs to a dedicated security group.</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">What it does</h2>
@@ -68,7 +68,7 @@
 <li>No data is modified beyond preventing unauthorized deletions/edits of product chatter messages.</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0</h2>
 <ul>
@@ -115,7 +115,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_competitors_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -131,7 +131,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_unique_code" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -147,7 +147,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_packaging" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -163,7 +163,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -195,7 +195,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -211,7 +211,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -227,7 +227,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_code/static/description/index.html
+++ b/deltatech_product_code/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Product Codification</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances Odoo's product management by providing advanced tools for automated internal reference generation, barcode management, and data consistency.
@@ -61,7 +61,7 @@ It is designed for businesses that require strict and structured product codific
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -77,7 +77,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -93,7 +93,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@ It is designed for businesses that require strict and structured product codific
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_dimension/static/description/index.html
+++ b/deltatech_product_dimension/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -38,7 +38,7 @@
 </li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">[19.0.1.0.0] - 2026-06-15</h2>
@@ -85,7 +85,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -101,7 +101,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_extension/static/description/index.html
+++ b/deltatech_product_extension/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Deltatech Product Extension</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module expands the standard Odoo product model by introducing essential technical and logistical fields. It's designed for businesses that require detailed tracking of product attributes like shelf life, manufacturer details, and physical dimensions.</p>
@@ -94,7 +94,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -190,7 +190,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -206,7 +206,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_labels/static/description/index.html
+++ b/deltatech_product_labels/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>prints labels from products, sale orders, pickings</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>if only lot option is selected and printing is started from a product, all lots in stock will be printed</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>by default overrides the print label button in products. To revert to standard print function, system parameter
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_list/static/description/index.html
+++ b/deltatech_product_list/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_saleorder_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_mpn/static/description/index.html
+++ b/deltatech_product_mpn/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds a field for Manufacturer Part Number (MPN) to the product template.
 The field is also added to the search bar for easier product identification.</p>
@@ -56,7 +56,7 @@ The field is also added to the search bar for easier product identification.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -72,7 +72,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@ The field is also added to the search bar for easier product identification.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_reordering_limit/static/description/index.html
+++ b/deltatech_product_reordering_limit/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Product Reordering Limits and Inventory Status</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces a simplified way to manage inventory replenishment levels directly on the product template in Odoo. It's designed for inventory managers who need to maintain specific minimum and maximum stock levels globally for a product, without the complexity of individual reordering rules for every warehouse location.</p>
@@ -63,7 +63,7 @@
 <li>Use this information to trigger new purchase or manufacturing orders.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.2 (2026-08-14)</h2>
 <ul>
@@ -119,7 +119,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_catalog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenishment_explain" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_orderpoint_multiple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_picking_activity_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transfer_product_to_product" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -215,7 +215,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -231,7 +231,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_trade_markup/static/description/index.html
+++ b/deltatech_product_trade_markup/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Product Trade Markup and Pricing</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces an automated pricing mechanism for Odoo products based on a trade markup percentage. It's designed to help businesses maintain consistent profit margins by automatically calculating the selling price from a base cost or purchase price.</p>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_unique_code/static/description/index.html
+++ b/deltatech_product_unique_code/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Restricts the use of duplicate Internal Reference (default_code) and Barcode in products.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>The uniqueness check includes archived products to prevent reusing codes from old records.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Validation is performed on both product templates and product variants.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Only values that actually change are validated ("no new duplicates" policy): products that
@@ -35,7 +35,7 @@
    at a time, code cleared or renamed) by regular users &#8212; but any new or changed value must be
    unique.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Includes a security group "Product Duplicate Code" to allow specific users to bypass these restrictions if necessary.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0</h2>
 <ul>
@@ -83,7 +83,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_competitors_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -99,7 +99,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_chatter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -115,7 +115,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_packaging" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -131,7 +131,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -147,7 +147,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -163,7 +163,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -195,7 +195,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_product_visibility/static/description/index.html
+++ b/deltatech_product_visibility/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Give every product a <strong>0&#8211;100 website visibility score</strong> shown as a colored
 traffic-light indicator, so you can tell at a glance how findable and complete a
@@ -150,7 +150,7 @@ new edits recompute on the fly.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -214,7 +214,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -230,7 +230,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -246,7 +246,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -262,7 +262,7 @@ new edits recompute on the fly.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_project_price_list/static/description/index.html
+++ b/deltatech_project_price_list/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Project-level pricelist used when creating Sales Orders from a project or a task. Built for Odoo 19.</p>
 <h4 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:17px;letter-spacing:-0.3px;line-height:1.2;">Purpose</h4>
@@ -89,7 +89,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -201,7 +201,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_promissory_note/static/description/index.html
+++ b/deltatech_promissory_note/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_move_negative_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_price_categ" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_purchase_requisition" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_qty_available" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_negative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_add_extra_line/static/description/index.html
+++ b/deltatech_purchase_add_extra_line/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Purchase Add Extra Line Extension</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces an automated process for adding extra lines (e.g., service fees, handling charges, or supplementary products) to Purchase Orders in Odoo. It's designed to help procurement teams consistently apply additional costs or items based on the primary products being purchased.</p>
@@ -84,7 +84,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -100,7 +100,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_create_bill_button/static/description/index.html
+++ b/deltatech_purchase_create_bill_button/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">In Odoo 19, the "Create Bill" button on the purchase order form was replaced by an
 "Upload Bill" widget that requires selecting a file before a bill can be created.</p>
@@ -63,7 +63,7 @@ Odoo 18 behavior.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_purchase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_mail" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_refund" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_ubl" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@ Odoo 18 behavior.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_mail/static/description/index.html
+++ b/deltatech_purchase_mail/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Multi-Purchase Order Email with XLSX Summary</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces an advanced email dispatch feature for the Odoo Purchase module. It allows procurement teams to select multiple purchase orders and send them simultaneously to their respective vendors or internal stakeholders, complete with an aggregated XLSX summary and individual PDF attachments.</p>
@@ -93,7 +93,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_purchase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_create_bill_button" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_refund" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_ubl" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -205,7 +205,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_phase/static/description/index.html
+++ b/deltatech_purchase_phase/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Overview</p>
 <p>This module adds a lightweight phase/stage tracking on purchase orders. It introduces
@@ -121,7 +121,7 @@ on the current order(s).</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_picking_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_xls" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenish" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -201,7 +201,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -217,7 +217,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -233,7 +233,7 @@ on the current order(s).</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_picking_status/static/description/index.html
+++ b/deltatech_purchase_picking_status/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -70,7 +70,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_phase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -86,7 +86,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_xls" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenish" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_price/static/description/index.html
+++ b/deltatech_purchase_price/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -102,7 +102,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_phase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_picking_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_xls" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenish" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -214,7 +214,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_refund/static/description/index.html
+++ b/deltatech_purchase_refund/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -65,7 +65,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_purchase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_create_bill_button" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_mail" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_ubl" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_stock/static/description/index.html
+++ b/deltatech_purchase_stock/static/description/index.html
@@ -27,14 +27,14 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
 <li>Separate manual purchase orders from replenishment purchase orders</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.1 (2026-07-29)</h2>
 <ul>
@@ -92,7 +92,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_phase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_picking_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_xls" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenish" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -188,7 +188,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -204,7 +204,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_ubl/static/description/index.html
+++ b/deltatech_purchase_ubl/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module imports vendor invoices in UBL XML format and uses them to update purchase workflows in Odoo.</p>
 <p>Key features:</p>
@@ -38,7 +38,7 @@
 </ul></div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Price management</span><div class="mt-1">updates vendor prices in <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">product.supplierinfo</code> directly from the XML data.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Discount support</span><div class="mt-1">extracts line discounts from <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">AllowanceCharge</code> (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">ChargeIndicator=false</code>) and applies them as percentage discounts on purchase order lines.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Total check</span><div class="mt-1">compares the purchase order total with the XML total (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">PayableAmount</code> / <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">TaxInclusiveAmount</code>, with untaxed fallback) and shows a warning when there is a difference.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Stock automation</span><div class="mt-1">optionally validates the associated stock receipt by matching quantities from the XML.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Accounting</span><div class="mt-1">optionally creates and links a vendor bill from the purchase order when an order is resolved.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Missing products</span><div class="mt-1">option to automatically create missing products using data from the UBL file. Automated callers can pass <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">purchase_ubl_no_new_products</code> in context to leave unmatched lines unmatched instead of silently creating duplicates.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Mapping preview</span><div class="mt-1">the interactive flow previews one row per invoice line with the product the matcher found and how it found it (green = supplier code or barcode, yellow = name only, red = no match); any row can be reassigned to a different product before confirming.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Unattended runs surface themselves</span><div class="mt-1">a headless import whose total does not add up, or that leaves lines unmatched, posts a color-coded log and schedules a "SPV import needs review" to-do activity on the purchase order, assigned to its buyer.</div></div></li></ul>
 <p>The module supports standard UBL Invoice namespaces and common unit code mappings (C62, KGM, LTR, etc.).</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">[19.0.1.4.1] - 2026-09-02</h2>
@@ -248,7 +248,7 @@ creating an empty bill.</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_purchase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -264,7 +264,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_create_bill_button" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -280,7 +280,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_mail" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -296,7 +296,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_refund" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -312,7 +312,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -328,7 +328,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -344,7 +344,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -360,7 +360,7 @@ creating an empty bill.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_purchase_xls/static/description/index.html
+++ b/deltatech_purchase_xls/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides an easy way to manage purchase order lines by allowing for import and export via Excel files.</p>
@@ -66,7 +66,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_phase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -82,7 +82,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_picking_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -98,7 +98,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenish" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_putaway_strategy/static/description/index.html
+++ b/deltatech_putaway_strategy/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends Odoo Inventory locations with simple capacity tracking and enhances the putaway decision logic.</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key features</h2>
@@ -97,7 +97,7 @@ instead of the warehouse root.</li>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Screenshots</h2>
 <p>The app store gallery uses the images from <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">static/description/</code>.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.7 (2026-08-04)</h2>
@@ -194,7 +194,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -226,7 +226,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -242,7 +242,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -258,7 +258,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -274,7 +274,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -290,7 +290,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -306,7 +306,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_queue_job/static/description/index.html
+++ b/deltatech_queue_job/static/description/index.html
@@ -32,7 +32,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The module provides specific enhancements to the job queue functionality in Odoo, focusing on performance, reliability, and flexibility in job execution. Here's a detailed breakdown of the features: <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_queue_job</code></p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -70,7 +70,7 @@
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Performance Benefits</h1>
 <p>This module is essential for high-volume Odoo environments. By decoupling the job runner from the standard Odoo cron schedule and providing optimized database locking, it ensures that your background tasks are processed as fast as possible with minimal overhead and maximum reliability.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <p><strong>External Job Processor Configuration</strong></p>
 <p>To process jobs every minute using an external service like <a href="https://cron-job.org">cron-job.org</a>:</p>
@@ -118,7 +118,7 @@
 <p><strong>Manual Processing</strong>
 You can manually trigger job processing from the Queue Job list view using the <strong>Process</strong> button (internal cron trigger) or <strong>Process (Thread)</strong> (API-style runner in a new thread), or trigger a background execution using <strong>Cron Trigger</strong>.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.4.0</h2>
@@ -201,7 +201,7 @@ You can manually trigger job processing from the Queue Job list view using the <
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -217,7 +217,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -233,7 +233,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -249,7 +249,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -265,7 +265,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -281,7 +281,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -297,7 +297,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -313,7 +313,7 @@ You can manually trigger job processing from the Queue Job list view using the <
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_ral/static/description/index.html
+++ b/deltatech_ral/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Allows the selection of a pigment (RAL) in production order.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>The pigment is a material which have code that starts with RAL.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>If in BOM it is used the pigment RAL 0000 it will be replaced with the pigment from production order.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>The batch will be created automatically upon order confirmation and will have the pigment from production order.</div></div></li></ul>
@@ -60,7 +60,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_layout" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_reception_note/static/description/index.html
+++ b/deltatech_reception_note/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Batch Reception Note Management</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a specialized tool for managing batch reception notes within Odoo's stock and purchase modules. It is designed to streamline the process of receiving multiple items or handling bulk reception documentation.</p>
@@ -63,7 +63,7 @@
 <li>View and print the resulting reception note for logistical or accounting purposes.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.1.2 (2026-07-29)</h2>
 <ul>
@@ -115,7 +115,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -131,7 +131,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -147,7 +147,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -163,7 +163,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -195,7 +195,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -211,7 +211,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -227,7 +227,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_record_type/static/description/index.html
+++ b/deltatech_record_type/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Deltatech Record Type</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
@@ -76,7 +76,7 @@ available for Odoo 17.0.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process_handover_document" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_delivery" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -188,7 +188,7 @@ available for Odoo 17.0.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_replenish/static/description/index.html
+++ b/deltatech_replenish/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Starting with Odoo 19.0 the vendor selection in the replenishment wizard is
@@ -48,7 +48,7 @@ model, view or data of its own.</p>
 <li>Select the desired supplier and proceed with the replenishment.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0</h2>
 <ul>
@@ -97,7 +97,7 @@ model, view or data of its own.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_phase" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_picking_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_purchase_xls" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -209,7 +209,7 @@ model, view or data of its own.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_replenishment_explain/static/description/index.html
+++ b/deltatech_replenishment_explain/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Explains, in a read-only dialog, how a reordering rule (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">stock.warehouse.orderpoint</code>)
 reached its <strong>forecast</strong> and <strong>to-order</strong> quantity, and flags where it may under- or
@@ -42,7 +42,7 @@ with the to-order gap) and a <strong>horizon timeline</strong> (today &#8594; le
 forecast), <strong>no vendor found</strong> (silent +365 days), a <strong>potential stockout</strong> even when nothing is
 ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <p><strong>19.0.1.1.1</strong></p>
 <ul>
@@ -100,7 +100,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_catalog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_reordering_limit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_orderpoint_multiple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_picking_activity_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transfer_product_to_product" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -212,7 +212,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_report_layout/static/description/index.html
+++ b/deltatech_report_layout/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Customized Report Layouts and Styles</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides specialized report layout styles for Odoo, allowing businesses to customize the appearance of their printed documents (Invoices, Quotations, Purchase Orders, etc.) with more modern and professional designs.</p>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_bom_formula" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_cost" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_simple_barcode" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_mrp_validation_date" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ral" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_report_packaging/static/description/index.html
+++ b/deltatech_report_packaging/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Calculates packaging materials from invoiced product quantities and provides an
 aggregate packaging-material report from the invoice list.</p>
@@ -37,7 +37,7 @@ of automatic update, so that the correction survives the validation of the invoi
 the Refresh button computes the quantities again and puts the invoice back under
 automatic update.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <p>Set the packaging materials and the quantity per unit on the product, in the
 <strong>Packaging materials</strong> section of the product form.</p>
@@ -90,7 +90,7 @@ packaging-material report action.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_competitors_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_chatter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_unique_code" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@ packaging-material report action.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_report_prn/static/description/index.html
+++ b/deltatech_report_prn/static/description/index.html
@@ -27,14 +27,14 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
 <li>It allows the printing of files with the .prn extension. These are files that have syntax for Zebra label printers.</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.1.0</h2>
 <ul>
@@ -85,7 +85,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -101,7 +101,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_restrict_reports/static/description/index.html
+++ b/deltatech_restrict_reports/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Restricts who can see the <strong>Sales Analysis</strong> (Sales &gt; Reporting) and
 <strong>Invoice Analysis</strong> (Accounting/Invoicing &gt; Reporting) screens,
@@ -45,7 +45,7 @@ reports, and the corresponding menu entries are hidden for him. Nobody
 is granted either group automatically - assignment is manual, from
 Settings &gt; Users.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">History</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0</h2>
@@ -95,7 +95,7 @@ Settings &gt; Users.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -191,7 +191,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -207,7 +207,7 @@ Settings &gt; Users.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_rpc_audit/static/description/index.html
+++ b/deltatech_rpc_audit/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module logs external RPC calls, so you can audit which integration calls
 which model and method, and from where. It covers both the legacy endpoints &#8212;
@@ -60,7 +60,7 @@ logger is muted above INFO, the module does no work at all.</p>
 <p>It is meant as a lightweight diagnostic / audit tool; the web client UI is not
 affected, since it uses a different endpoint.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">History</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.2.1 (2026-08-25)</h2>
@@ -163,7 +163,7 @@ cached 60s alongside the ignore list.
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cron_monitor_webhook" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_tc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -195,7 +195,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transport_change" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -211,7 +211,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -227,7 +227,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -243,7 +243,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -259,7 +259,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -275,7 +275,7 @@ cached 60s alongside the ignore list.
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_activity_report/static/description/index.html
+++ b/deltatech_sale_activity_report/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>whenever a user changes something on a sale order , a record is created in the activity report</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>in the report menu of the sales app you can see the activity records and the pivot view so you can see the activity
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_activity_search/static/description/index.html
+++ b/deltatech_sale_activity_search/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Sale Order Activity Search Extension</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the search and filtering capabilities of the Sales module in Odoo by providing more visibility into active activities associated with sales orders. It's designed to help sales teams and managers quickly identify and track orders that require immediate attention or have specific types of pending tasks.</p>
@@ -86,7 +86,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_add_extra_line/static/description/index.html
+++ b/deltatech_sale_add_extra_line/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Sale Add Extra Line Module</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The <strong>deltatech_sale_add_extra_line</strong> module is an Odoo addon that provides automated functionality for adding extra product lines to sale orders based on the products being sold.</p>
@@ -79,7 +79,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -191,7 +191,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_add_extra_line_pos/static/description/index.html
+++ b/deltatech_sale_add_extra_line_pos/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Sale Add Extra Line - Point of Sale Extension</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The <strong>deltatech_sale_add_extra_line_pos</strong> module is an Odoo addon that extends the Point of Sale (POS) functionality to automatically add extra product lines to POS orders based on configured products. This module is a specialized extension of the <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">deltatech_sale_add_extra_line</code> module, specifically designed for the Point of Sale system.</p>
@@ -78,7 +78,7 @@ alongside the rest of the Terrabit POS suite and the official Romanian fiscal co
 without any overlap:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos</span><div class="mt-1">/ <strong>deltatech_pos_base</strong> &#8212; print fiscal receipts and drive cash management on a certified cash register</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_ecr_connect</span><div class="mt-1">&#8212; shared fiscal document model, ECR format converter and Terrabit Connect sender</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_stock</span><div class="mt-1">&#8212; shows available stock directly in the POS interface</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_price_sync</span><div class="mt-1">&#8212; pushes live product price changes to already open POS sessions</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">deltatech_pos_fix</span><div class="mt-1">&#8212; corrects POS total calculation for tax-included fiscal position mapping</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_fiscal_compliance</span><div class="mt-1">&#8212; AMEF fiscal receipt tracking, Z report reconciliation and session blocking</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_anaf_d394_pos</span><div class="mt-1">&#8212; reports POS fiscal receipts in the D394 (op. 2) declaration to ANAF</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">l10n_ro_pos_returns</span><div class="mt-1">&#8212; dedicated return invoice and cash register line for every POS return</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.1</h2>
 <ul>
@@ -128,7 +128,7 @@ without any overlap:</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -192,7 +192,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -208,7 +208,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -224,7 +224,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -240,7 +240,7 @@ without any overlap:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_analysis_vat/static/description/index.html
+++ b/deltatech_sale_analysis_vat/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Adds a VAT dimension to the standard sales analysis reports, so the turnover of a
 period can be broken down by VAT rate without leaving the pivot views.</p>
@@ -50,7 +50,7 @@ duplicated in the reports.</p>
 <p>Turnover of a period, without duplication, is the Point of Sale Analysis filtered on
 "Receipts without Invoice" plus the whole Invoice Analysis for customer invoices.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.1 (2026-08-10)</h2>
 <ul>
@@ -106,7 +106,7 @@ duplicated in the reports.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -218,7 +218,7 @@ duplicated in the reports.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_catalog_website/static/description/index.html
+++ b/deltatech_sale_catalog_website/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module improves the <strong>product catalog opened from a Sales Order</strong> (the
 "Catalog" button on a quotation / sales order). The changes apply <strong>only to the
@@ -77,7 +77,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -93,7 +93,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_commission/static/description/index.html
+++ b/deltatech_sale_commission/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -47,7 +47,7 @@ and if the difference between the date of the last payment and the due date is l
 </li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.5.0 (2026-08-20)</h2>
@@ -98,7 +98,7 @@ and if the difference between the date of the last payment and the due date is l
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ and if the difference between the date of the last payment and the due date is l
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_contact/static/description/index.html
+++ b/deltatech_sale_contact/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_cost_product/static/description/index.html
+++ b/deltatech_sale_cost_product/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides specialized tools for monitoring and analyzing the costs and margins of sales orders in Odoo. It's designed for sales managers and controllers who need more visibility into the profitability of their deals at the order and order-line level.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -55,7 +55,7 @@
 </li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <ol>
 <li>Navigate to <strong>Sales &gt; Orders</strong>.</li>
@@ -103,7 +103,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -215,7 +215,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_currency/static/description/index.html
+++ b/deltatech_sale_currency/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Sale Currency Extension</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides specialized handling for currency conversion between sales orders and their generated invoices. It's particularly useful for businesses that maintain pricelists in one currency (e.g., EUR) but wish to issue invoices in another (e.g., the journal's currency or company's functional currency like RON).</p>
@@ -83,7 +83,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -99,7 +99,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -115,7 +115,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -131,7 +131,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -147,7 +147,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -163,7 +163,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -179,7 +179,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -195,7 +195,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_feedback/static/description/index.html
+++ b/deltatech_sale_feedback/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Sends an automated e-mail to clients based on out invoices</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>A cron job (default not active) is used to send the e-mails at 3 days after the invoice date. Another interval can be
@@ -60,7 +60,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_invoice_status/static/description/index.html
+++ b/deltatech_sale_invoice_status/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_margin/static/description/index.html
+++ b/deltatech_sale_margin/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -56,7 +56,7 @@ to that percentage, a positive value also reports thin but positive margins.</p>
 sale.margin_limit_check_validate - system parameter - if set, the verificaion is made at order confirmation (users with
 no rights to sell below margin/purchase price can still create draft sale orders)</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.2.0 (2026-08-20)</h2>
@@ -181,7 +181,7 @@ note in the chatter;</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -213,7 +213,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -229,7 +229,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -245,7 +245,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -261,7 +261,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -277,7 +277,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -293,7 +293,7 @@ note in the chatter;</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_multiple/static/description/index.html
+++ b/deltatech_sale_multiple/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>You can set a minimum quantity and a multiple quantity on the product.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Rules are configured in the product's default unit of measure and converted to the sale line unit.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>If you try to sell less than the minimum, the quantity is raised to the first valid multiple at or above that minimum.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>A multiple of 0 or 1 disables the multiple restriction; a minimum of 0 disables the minimum restriction.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Rules are enforced consistently in form onchanges, imports, ORM creates, and single or batch writes.</div></div></li></ul>
@@ -56,7 +56,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -72,7 +72,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_multiple_website/static/description/index.html
+++ b/deltatech_sale_multiple_website/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Extends sale quantity multiples to eCommerce. Product minimum and multiple
 quantities can be enforced only for website carts or globally, and the active
@@ -60,7 +60,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_pallet/static/description/index.html
+++ b/deltatech_sale_pallet/static/description/index.html
@@ -27,13 +27,13 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>create a product category with the "Pallet" option enabled</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>select the pallet product and put in the the above category</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>select a min quantity for a pallet</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>when creating a sale order with a product that requires pallets, if you reach the min qty for a pallet, the system
   will automatically add a pallet product to the order</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>the system will increase the quantity of required pallets when you reach the next multiple of the min qty for a pallet</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.9 (2026-08-15)</h2>
@@ -81,7 +81,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_pallet_website/static/description/index.html
+++ b/deltatech_sale_pallet_website/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends pallet sales functionality to the Odoo eCommerce platform, allowing for better management and display of products sold by pallets on the website.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -82,7 +82,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -98,7 +98,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_payment/static/description/index.html
+++ b/deltatech_sale_payment/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_phone/static/description/index.html
+++ b/deltatech_sale_phone/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_picking_status/static/description/index.html
+++ b/deltatech_sale_picking_status/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -70,7 +70,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -86,7 +86,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_purchase/static/description/index.html
+++ b/deltatech_sale_purchase/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module optimizes the link between sales and purchases by adding advanced management features for procurement.</p>
@@ -39,7 +39,7 @@
 <li>It also handles decreases in ordered quantities, updating the purchase order lines accordingly.</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-07-29)</h2>
 <ul>
@@ -97,7 +97,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -209,7 +209,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_purchase_requisition/static/description/index.html
+++ b/deltatech_sale_purchase_requisition/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds a button on the Sales Quotation to create Purchase RFQ(s)
 from the quotation lines and links those RFQs back to the quote.</p>
@@ -68,7 +68,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_move_negative_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -84,7 +84,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_price_categ" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -100,7 +100,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_promissory_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_qty_available" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_negative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_qty_available/static/description/index.html
+++ b/deltatech_sale_qty_available/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <blockquote>
@@ -60,7 +60,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_move_negative_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_price_categ" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_promissory_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_purchase_requisition" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_negative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_report/static/description/index.html
+++ b/deltatech_sale_report/static/description/index.html
@@ -13,7 +13,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features: This module will add new fields to the sale order report:</p>
 <ul>
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_ledger" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_return_cause/static/description/index.html
+++ b/deltatech_sale_return_cause/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The <strong>Sale Order Return Cause</strong> module enhances Odoo's sales management by providing a systematic way to track and analyze the reasons behind sales returns. It allows businesses to categorize returns, monitor return values, and generate insightful reports to identify and address common issues in the sales or fulfillment process.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h1>
@@ -60,7 +60,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -76,7 +76,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -92,7 +92,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_stage/static/description/index.html
+++ b/deltatech_sale_stage/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module helps your sales team stay on top of every order by introducing a <strong>customizable phase system</strong> for sale orders.</p>
 <p>Instead of relying only on Odoo's standard statuses (Draft, Confirmed, Done), your team can define their own internal phases &#8212; such as <em>Confirmed</em>, <em>Prepared</em>, <em>Shipped</em>, <em>Delivered</em> &#8212; and track exactly where each order stands in your fulfillment process.</p>
@@ -81,7 +81,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_team/static/description/index.html
+++ b/deltatech_sale_team/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_transfer/static/description/index.html
+++ b/deltatech_sale_transfer/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@ available</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@ available</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sale_xls/static/description/index.html
+++ b/deltatech_sale_xls/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h1>
 <ul>
@@ -37,7 +37,7 @@
   Effortlessly import purchase order lines directly from Excel files using Odoo's standard import tool, allowing quick bulk uploads and updates for each specific sale order.</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.1</h2>
 <ul>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_saleorder_pickup_list/static/description/index.html
+++ b/deltatech_saleorder_pickup_list/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Sale Order Pickup List Report</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a specialized <strong>Pickup List</strong> report for Sales Orders in Odoo. It's designed to streamline the warehouse operation process by providing a clear and efficient list of items to be picked from inventory for specific sales orders.</p>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_saleorder_search/static/description/index.html
+++ b/deltatech_saleorder_search/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the search capabilities in Odoo Sales by allowing users to find sales orders based on multiple partner-related fields.</p>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_list" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_secondary_uom/static/description/index.html
+++ b/deltatech_secondary_uom/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds <strong>product specific conversion factors</strong> between units of
 measure, following the SAP material master (MARM) pattern.</p>
@@ -50,7 +50,7 @@ valuation.</p>
 global UoM table clean and does not affect standard reports, stock valuation
 or any code reading <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">uom.factor</code> directly in SQL.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.1.0 (2026-08-06)</h2>
 <ul>
@@ -104,7 +104,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_map" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -184,7 +184,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -200,7 +200,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -216,7 +216,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sms/static/description/index.html
+++ b/deltatech_sms/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -69,7 +69,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_line_counter" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -85,7 +85,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -101,7 +101,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_sms_sale/static/description/index.html
+++ b/deltatech_sms_sale/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -59,7 +59,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -75,7 +75,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -91,7 +91,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -107,7 +107,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -123,7 +123,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -139,7 +139,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -155,7 +155,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -171,7 +171,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_account/static/description/index.html
+++ b/deltatech_stock_account/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -59,7 +59,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -75,7 +75,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -91,7 +91,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -107,7 +107,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -123,7 +123,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -139,7 +139,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -155,7 +155,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -171,7 +171,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_analytic/static/description/index.html
+++ b/deltatech_stock_analytic/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module automates the generation of analytic account entries directly from stock movements in Odoo. It's designed for organizations that need precise tracking of costs and revenues associated with inventory transfers and adjustments.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
@@ -92,7 +92,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -108,7 +108,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -124,7 +124,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -140,7 +140,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -156,7 +156,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -172,7 +172,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -188,7 +188,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -204,7 +204,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_close/static/description/index.html
+++ b/deltatech_stock_close/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Stock Closing Operations</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides tools for managing stock closing operations at a specific date.
@@ -37,7 +37,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Go to Inventory &gt; Reporting &gt; Romanian Stock Storage Sheet.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Enable the "Only active" option to exclude closed valuations from the report.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Mark stock move valuations as closed (unset "Valuation Active") according to your business needs.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0</h2>
@@ -85,7 +85,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -101,7 +101,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_count_zero/static/description/index.html
+++ b/deltatech_stock_count_zero/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds an option to automatically set the inventoried quantity to zero when a count is requested.
@@ -61,7 +61,7 @@ This is useful during physical inventory, where items not found must be explicit
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -77,7 +77,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -93,7 +93,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -109,7 +109,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_warehouse_arrangement" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@ This is useful during physical inventory, where items not found must be explicit
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_delivery/static/description/index.html
+++ b/deltatech_stock_delivery/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the integration between Odoo Accounting and Inventory by providing quick access to related warehouse operations directly from an invoice.</p>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_business_process_handover_document" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_record_type" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_inventory/static/description/index.html
+++ b/deltatech_stock_inventory/static/description/index.html
@@ -32,7 +32,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Deltatech Stock Inventory</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
@@ -76,7 +76,7 @@ is updated with the price from the inventory lines.</li>
 <p>The module implements:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Complete reimplementation of the stock.inventory model.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Integration with stock valuation layers (SVL) for proper accounting.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Custom views for enhanced inventory operations.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Barcode scanning capabilities for mobile inventory.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Compatibility with Odoo 19 and Romanian accounting modules.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <ol>
 <li>Create a new inventory document from the <strong>Inventory</strong> menu.</li>
@@ -90,7 +90,7 @@ is updated with the price from the inventory lines.</li>
 <li>Use barcode scanning for faster operation.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.2.7.4 (2026-08-22)</h2>
 <ul>
@@ -171,7 +171,7 @@ is updated with the price from the inventory lines.</li>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -187,7 +187,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -203,7 +203,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -219,7 +219,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -235,7 +235,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -251,7 +251,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -267,7 +267,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -283,7 +283,7 @@ is updated with the price from the inventory lines.</li>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory_product_display" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_inventory_product_display/static/description/index.html
+++ b/deltatech_stock_inventory_product_display/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds a button on Sales Orders and Invoices to quickly view the products included in the lines.</p>
 <h3 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:19px;letter-spacing:-0.3px;line-height:1.2;">Features:</h3>
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_negative/static/description/index.html
+++ b/deltatech_stock_negative/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -39,7 +39,7 @@
 </li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <ul>
 <li>Inventory -&gt; Configuration -&gt; Settings</li>
@@ -89,7 +89,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_move_negative_stock" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_price_categ" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_promissory_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_purchase_requisition" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_sale_qty_available" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -201,7 +201,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_orderpoint_multiple/static/description/index.html
+++ b/deltatech_stock_orderpoint_multiple/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Odoo a eliminat c&#226;mpul <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">qty_multiple</code> de pe <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">stock.warehouse.orderpoint</code> la trecerea
 la versiunea 19.0 (commit <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">09d6c79f0e4</code>, "replace <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">qty_multiple</code> by replenishment
@@ -42,7 +42,7 @@ de rotunjire, f&#259;r&#259; nicio dependen&#539;&#259; de unit&#259;&#539;i de 
 rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul nativ
 (<code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">replenishment_uom_id</code>) r&#259;m&#226;ne neschimbat.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-08-21)</h2>
 <ul>
@@ -87,7 +87,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_catalog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_reordering_limit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenishment_explain" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_picking_activity_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transfer_product_to_product" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_picking_activity_report/static/description/index.html
+++ b/deltatech_stock_picking_activity_report/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Logs detailed modifications on stock pickings, including field changes and line updates.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Captures messages posted in the chatter for a comprehensive activity history.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Automatically tracks validation events and categorizes the number of products processed (Incoming, Outgoing, or Internal).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Provides an Activity Report accessible via Inventory -&gt; Reporting -&gt; Activity Report for statistical analysis.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Automatically deletes activity records older than 2 months using the Data Recycle mechanism.</div></div></li></ul>
@@ -56,7 +56,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_catalog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -72,7 +72,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_reordering_limit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenishment_explain" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_orderpoint_multiple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transfer_product_to_product" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_removal_priority/static/description/index.html
+++ b/deltatech_stock_removal_priority/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module introduces a priority-based stock removal strategy for Odoo warehouse locations. It gives inventory managers granular control over the order in which items are picked from different storage areas, ensuring optimal logistical flows and storage utilization.</p>
 <p>Designed to work together with <strong>deltatech_putaway_strategy</strong>: putaway rules direct products to specific sub-locations at receipt, and this module uses those same rules to determine the removal order at picking time.</p>
@@ -103,7 +103,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -215,7 +215,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_report/static/description/index.html
+++ b/deltatech_stock_report/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_stock_reseller/static/description/index.html
+++ b/deltatech_stock_reseller/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:  </p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Report with positions from stock location, with pricelist</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Choose stock location</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Choose partner or pricelist for price computation</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Two thresholds can be set for "text" quantities (i.e. Low stock,
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_disable_fuzzy_search" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_tc/static/description/index.html
+++ b/deltatech_tc/static/description/index.html
@@ -37,7 +37,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Base module for <strong>Terrabit Connect</strong> &#8212; the lightweight native agent that runs on
 a workstation and bridges Odoo with local hardware and services it cannot reach
@@ -75,7 +75,7 @@ name is stored in the database, so without that rule a modified record could cal
 any ORM method. The prefix also makes "reachable from a job" a property you can
 grep for.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-configure" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-configure" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Configuration</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Security groups</h2>
 <p>Assign users to the appropriate group under <strong>Settings &#8594; Users &amp; Companies &#8594; Users</strong>
@@ -174,7 +174,7 @@ as narrow as the job actually needs.</p>
 load when many stations are polling frequently; online detection remains accurate
 within the throttle window.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Registering a station</h2>
 <ol>
@@ -250,7 +250,7 @@ Terrabit Connect feature module (e.g. ANAF messages, fiscal printer, Zebra label
 DUKIntegrator) to activate additional job types. They appear automatically in the
 <strong>Type</strong> column of the job list once the feature module is installed.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.1.1 (2026-08-15)</h2>
 <ul>
@@ -314,7 +314,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cron_monitor_webhook" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -330,7 +330,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_rpc_audit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -346,7 +346,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_transport_change" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -362,7 +362,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -378,7 +378,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -394,7 +394,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -410,7 +410,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -426,7 +426,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_team_logo/static/description/index.html
+++ b/deltatech_team_logo/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Permite afi&#537;area unui logo diferit &#238;n rapoartele PDF (factur&#259;, ofert&#259;/comand&#259;,
 aviz de livrare) &#238;n func&#539;ie de <strong>echipa de v&#226;nzare</strong> a documentului.</p>
@@ -71,7 +71,7 @@ standard (logo-ul firmei).</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -87,7 +87,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@ standard (logo-ul firmei).</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_test_system/static/description/index.html
+++ b/deltatech_test_system/static/description/index.html
@@ -27,14 +27,14 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
 <li>can neutralizes the DB in settings and adds a permanent banner up top to know the DB is a test DB</li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Changelog</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.0.9 (2026-08-15)</h2>
@@ -82,7 +82,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -98,7 +98,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_watermark" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_transfer_product_to_product/static/description/index.html
+++ b/deltatech_transfer_product_to_product/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <blockquote>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_catalog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_reordering_limit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_replenishment_explain" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_orderpoint_multiple" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_picking_activity_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_transport_change/static/description/index.html
+++ b/deltatech_transport_change/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">DeltaTech Transport Change</p>
 <p>DeltaTech Transport Change is an Odoo technical module designed to manage the export of configuration changes and transport them between environments (Development &#8594; Staging &#8594; Production) in a structured and version-controlled manner. The module provides a functionality similar to SAP transport requests, allowing system administrators and consultants to track, export, and migrate configuration data safely.</p>
@@ -65,7 +65,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_cron_monitor_webhook" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_rpc_audit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_tc" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_vendor_stock/static/description/index.html
+++ b/deltatech_vendor_stock/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Update available quantity at supplier in product base data</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Display available quantity at supplier in sale order</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Display icon with yellow if current quantity is zero but will come</div></div></li></ul>
@@ -56,7 +56,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -72,7 +72,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_warehouse_access/static/description/index.html
+++ b/deltatech_warehouse_access/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides more granular control over warehouse operations by restricting access to specific users.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h1>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_delivery_status" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_dropshipping" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_restrict_entry_exit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_split" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_transit" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_close" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_inventory" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_warehouse_arrangement/static/description/index.html
+++ b/deltatech_warehouse_arrangement/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_auto_reorder_rule" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_batch_transfer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_picking_services" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_product_labels" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_reception_note" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_report_prn" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_count_zero" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_warehouse_map/static/description/index.html
+++ b/deltatech_warehouse_map/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
@@ -97,7 +97,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_secondary_uom" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -209,7 +209,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_warranty/static/description/index.html
+++ b/deltatech_warranty/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_discount_policy" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_fast_sale" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_invoice_picking_automatically" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_pricelist_line_viewer" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_watermark/static/description/index.html
+++ b/deltatech_watermark/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Watermark Field Base</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides a base field for watermark images or text within Odoo. It's designed to act as a centralized storage and configuration point for watermarking functionalities used across different areas of the system, particularly in reports and on the website.</p>
@@ -64,7 +64,7 @@
 <p>WARNING:</p>
 <p>This module provides the necessary fields and configuration but does not apply the watermark by itself. It requires additional extension modules to perform the actual watermarking on specific documents or images.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-usage" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-usage" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Usage</h2>
 <ul>
 <li>Go to: Setting -&gt; General Settings - Business Documents</li>
@@ -109,7 +109,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -125,7 +125,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_markdown_field" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -141,7 +141,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_no_quick_create" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -157,7 +157,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_notification_sound" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -173,7 +173,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_merge" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -189,7 +189,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_restrict_reports" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -205,7 +205,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_test_system" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -221,7 +221,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_blog/static/description/index.html
+++ b/deltatech_website_blog/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Sorts blog posts by publication date in descending order. Posts with the same
 publication date are ordered by descending record ID.</p>
@@ -56,7 +56,7 @@ publication date are ordered by descending record ID.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -72,7 +72,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@ publication date are ordered by descending record ID.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_breadcrumb/static/description/index.html
+++ b/deltatech_website_breadcrumb/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_city" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_sale_cost_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_category/static/description/index.html
+++ b/deltatech_website_category/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the management of eCommerce public categories on the Odoo website.</p>
@@ -41,7 +41,7 @@
 <li>Archived categories will not appear in the shop menu or as filter options on the product list page.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.1.1 (2026-07-30)</h2>
 <ul>
@@ -116,7 +116,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -212,7 +212,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -228,7 +228,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_checkout_confirm/static/description/index.html
+++ b/deltatech_website_checkout_confirm/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">eCommerce Checkout Confirmation Enhancement</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module adds an extra layer of order confirmation to Odoo's eCommerce checkout process. It's designed for businesses that want to ensure customers have a final chance to review their purchase before the order is finalized and sent for processing.</p>
@@ -87,7 +87,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -103,7 +103,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -119,7 +119,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -135,7 +135,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -151,7 +151,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -167,7 +167,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_city/static/description/index.html
+++ b/deltatech_website_city/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">City Extension for Website</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the address management system in the Odoo eCommerce and Portal areas by providing structured city selection. It's particularly useful for regions where city names need to be validated or selected from a predefined list rather than being entered as free text.</p>
@@ -63,7 +63,7 @@
 <li>Users will now be able to select cities from the predefined list, and the system will assist with the corresponding address details.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.2.1 (2026-08-13)</h2>
 <ul>
@@ -113,7 +113,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_breadcrumb" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_sale_cost_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -193,7 +193,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -209,7 +209,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -225,7 +225,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_country/static/description/index.html
+++ b/deltatech_website_country/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">eCommerce Country and Address Enhancements</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module provides country-related extensions for Odoo's eCommerce platform. It ensures that the checkout address form always has a default country pre-selected, based on the website's company country, improving the address entry experience for customers.</p>
@@ -61,7 +61,7 @@
 <li>Go to <strong>Website &gt; Configuration &gt; Countries</strong> to ensure your target markets are active and correctly configured with their respective states.</li>
 </ol>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">18.0.1.0.2 (2026-06-10)</h2>
 <ul>
@@ -106,7 +106,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -202,7 +202,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -218,7 +218,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_delivery_address/static/description/index.html
+++ b/deltatech_website_delivery_address/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the Odoo website's delivery management by providing users with more control over their default delivery addresses.</p>
@@ -65,7 +65,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_delivery_and_payment/static/description/index.html
+++ b/deltatech_website_delivery_and_payment/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>restrict payment selection by delivery method</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>restrict payment acquirers for partners (linked with logged in user) with certain label</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>restrict delivery methods for partners (linked with logged in user) with certain label</div></div></li></ul>
@@ -57,7 +57,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -73,7 +73,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -89,7 +89,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_disable_fuzzy_search/static/description/index.html
+++ b/deltatech_website_disable_fuzzy_search/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_fixed_price/static/description/index.html
+++ b/deltatech_website_fixed_price/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_floating_widgets" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_floating_widgets/static/description/index.html
+++ b/deltatech_website_floating_widgets/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Add customizable floating widgets to the right side of your website.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Choose from a variety of icons (Phone, Email, WhatsApp, Facebook, Instagram, TikTok, etc.).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Live icon preview in the backend for easy configuration.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Support for different link types: URL, Phone (tel:), and Email (mailto:).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Option to open links in a new tab.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Note: For external links, ensure you include the protocol (e.g., <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">https://</code>). Otherwise, they will be treated as relative links within the Odoo website.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Control visibility per device (Display on Mobile / Display on Desktop).</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Customizable button shapes: Circle, Square, or Rounded.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Fully customizable colors for background and text.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Manage the order of icons using sequence.</div></div></li></ul>
@@ -56,7 +56,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -72,7 +72,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -88,7 +88,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_pager_guard/static/description/index.html
+++ b/deltatech_website_pager_guard/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Makes the shop return <strong>404</strong> for listing pages that do not exist.</p>
 <p>Odoo's <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">pager()</code> helper clamps an out-of-range page number to the last real
@@ -48,7 +48,7 @@ why the check runs after <code class="border rounded px-2" style="font-family:ui
 <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">request.render</code> is lazy in Odoo, so raising there means the QWeb template is
 never rendered.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">History</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-07-30)</h2>
@@ -98,7 +98,7 @@ never rendered.</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -114,7 +114,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -130,7 +130,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -146,7 +146,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -162,7 +162,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -178,7 +178,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -194,7 +194,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -210,7 +210,7 @@ never rendered.</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_phone_validation/static/description/index.html
+++ b/deltatech_website_phone_validation/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -39,7 +39,7 @@
 </li>
 </ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.1 (2026-08-13)</h2>
 <ul>
@@ -84,7 +84,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -100,7 +100,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -116,7 +116,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -132,7 +132,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -148,7 +148,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -164,7 +164,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -180,7 +180,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -196,7 +196,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_price_without_tax/static/description/index.html
+++ b/deltatech_website_price_without_tax/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_product_code/static/description/index.html
+++ b/deltatech_website_product_code/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
@@ -73,7 +73,7 @@ Set to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-
 </ul>
 </div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.3.1 (2026-07-28)</h2>
 <ul>
@@ -167,7 +167,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -183,7 +183,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -199,7 +199,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -215,7 +215,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -231,7 +231,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -247,7 +247,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -263,7 +263,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -279,7 +279,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_product_placeholder/static/description/index.html
+++ b/deltatech_website_product_placeholder/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module allows you to configure a custom placeholder image for products that do not have an image set.
 Optimizes website performance by serving a single static or configurable URL for all products without images, which improves browser and CDN caching.</p>
@@ -58,7 +58,7 @@ Optimizes website performance by serving a single static or configurable URL for
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@ Optimizes website performance by serving a single static or configurable URL for
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_product_url_image/static/description/index.html
+++ b/deltatech_website_product_url_image/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -62,7 +62,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -78,7 +78,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -94,7 +94,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_attribute_filter/static/description/index.html
+++ b/deltatech_website_sale_attribute_filter/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Dynamically filters product attribute values on the website shop page based on the products currently displayed.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Ensures that only relevant attribute values (those belonging to the visible products) are shown in the filter sidebar and off-canvas menu.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Supports all standard Odoo attribute display types:<ul class="ps-3 mt-2">
@@ -39,7 +39,7 @@
 </ul>
 </div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Automatically updates filters when searching or navigating categories.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Preserves the filter UI state (expanded attribute accordions, open mobile off-canvas panel, scroll position) across the page reload triggered on each selection, so the customer does not have to reopen the filters every time.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Optimized for performance by efficiently identifying active attribute values from the product template attribute lines.</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Compatible with Odoo's standard eCommerce layout and responsive off-canvas filters.</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.1.0</h2>
 <ul>
@@ -88,7 +88,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -104,7 +104,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -120,7 +120,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -136,7 +136,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -152,7 +152,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -168,7 +168,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -184,7 +184,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -200,7 +200,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_attributes/static/description/index.html
+++ b/deltatech_website_sale_attributes/static/description/index.html
@@ -27,14 +27,14 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Website Sale Attributes</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the product attribute display in the e-commerce website by:</p>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Displaying attribute values based on determined products</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Filtering attribute values to show only those that are relevant to the currently available products</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Optimizing the attribute selection experience for customers</div></div></li></ul>
 <p>The module modifies the default Odoo behavior by filtering attribute values in the website_sale.products_attributes template to show only relevant options.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">History</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.3 (2026-07-30)</h2>
@@ -86,7 +86,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -102,7 +102,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -118,7 +118,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -134,7 +134,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -150,7 +150,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -166,7 +166,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -182,7 +182,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -198,7 +198,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_cost_price/static/description/index.html
+++ b/deltatech_website_sale_cost_price/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends the standard Odoo "Prevent Sale of Zero Priced Product" functionality to also prevent sales when the product price is lower than its cost price (standard price).</p>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Key Features:</h2>
@@ -74,7 +74,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_breadcrumb" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_city" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -186,7 +186,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_portal/static/description/index.html
+++ b/deltatech_website_sale_portal/static/description/index.html
@@ -27,12 +27,12 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <p>-</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.1 (2026-07-30)</h2>
 <ul>
@@ -79,7 +79,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -191,7 +191,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_sort/static/description/index.html
+++ b/deltatech_website_sale_sort/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -64,7 +64,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -80,7 +80,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -96,7 +96,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -112,7 +112,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -128,7 +128,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -144,7 +144,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -160,7 +160,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -176,7 +176,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_status/static/description/index.html
+++ b/deltatech_website_sale_status/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -42,7 +42,7 @@
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Plasat&#259;</span><div class="mt-1">- comanda este plasat&#259; pe website de client</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">&#206;n procesare</span><div class="mt-1">&#8211; comanda introdus&#259; de operator</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">A&#537;teapt&#259; disponibilitate</span><div class="mt-1">- nu sunt disponibile toate produsele</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Am&#226;nat&#259;</span><div class="mt-1">- livrarea a fost am&#226;nat&#259;</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">De livrat</span><div class="mt-1">- produsele sunt disponibile &#537;i se poate face livrarea</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">&#206;n livrare</span><div class="mt-1">&#8211; produsele au fost predate la curier</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Livrat&#259;</span><div class="mt-1">- produsele au ajuns la client</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Anulat&#259;</span><div class="mt-1">- comanda de v&#226;nzare a fost anulat&#259;</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100"><span class="fw-bold">Returnat&#259;</span><div class="mt-1">- comanda a fost returnat&#259; de c&#259;tre client</div></div></li></ul>
 </blockquote>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.2.0.5 (2026-07-23)</h2>
 <ul>
@@ -94,7 +94,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -110,7 +110,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -126,7 +126,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -142,7 +142,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -158,7 +158,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -174,7 +174,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -190,7 +190,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -206,7 +206,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_sale_wishlist/static/description/index.html
+++ b/deltatech_website_sale_wishlist/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">eCommerce Wishlist Extension</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module extends the standard Odoo eCommerce wishlist functionality by providing backend management and actionable insights into products that customers are interested in but have not yet purchased.</p>
@@ -85,7 +85,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -101,7 +101,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_searchbar/static/description/index.html
+++ b/deltatech_website_searchbar/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module reduces the number of autocomplete requests sent to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">/website/snippet/autocomplete</code>
 by applying two complementary optimizations to the website search bar widget.</p>
@@ -56,7 +56,7 @@ by applying two complementary optimizations to the website search bar widget.</p
 No configuration is required. The constants <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">MIN_SEARCH_TERM_LENGTH</code> (4) and <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">DEBOUNCE_DELAY</code> (800ms)
 can be adjusted directly in <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">static/src/js/searchbar.esm.js</code> if different values are needed.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.0 (2026-08-14)</h2>
 <ul>
@@ -101,7 +101,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -213,7 +213,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_short_description/static/description/index.html
+++ b/deltatech_website_short_description/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <ul>
 <li>
@@ -63,7 +63,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -79,7 +79,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -95,7 +95,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -111,7 +111,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -127,7 +127,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -143,7 +143,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -159,7 +159,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -175,7 +175,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_stock_availability/static/description/index.html
+++ b/deltatech_website_stock_availability/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">The module allows the display of stock on the website below a certain threshold, with the possibility of ordering even
 if the stock is not sufficient. The module also calculates the number of days for delivery, taking into account the
@@ -37,7 +37,7 @@ products that are not in stock.</p>
 suficient. Modulul calculeaz&#259; &#537;i num&#259;rul de zile de &#238;n care se va face livrare &#539;in&#226;nd cont de timpul de livrare din
 produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile de livrare de la furnizor pentru produsele care nu sunt pe stoc.</p>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">History</h1>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.1.0.9 (2026-07-30)</h2>
@@ -89,7 +89,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -105,7 +105,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -121,7 +121,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -137,7 +137,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -153,7 +153,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -169,7 +169,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -185,7 +185,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -201,7 +201,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_vat_validation/static/description/index.html
+++ b/deltatech_website_vat_validation/static/description/index.html
@@ -27,7 +27,7 @@
   </li>
 </ul>
 <div class="tab-content">
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Deltatech Website VAT Validation</h1>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the VAT (Value Added Tax) validation functionality on Odoo website checkout and customer portal, ensuring VAT numbers are properly validated.</p>
@@ -36,7 +36,7 @@
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Benefits</h2>
 <ul class="list-unstyled row row-cols-1 row-cols-md-2 g-3 mt-1 mb-4"><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Improved data quality by preventing duplicate VAT registrations</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Enhanced compliance with tax regulations</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Better customer experience with immediate feedback on VAT number validity</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Reduced manual verification by administrators</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Streamlined checkout process with proper validation</div></div></li><li class="col"><div class="border rounded-3 p-3 h-100 d-flex gap-2"><span class="flex-shrink-0 text-center fw-bold rounded d-inline-block" style="background-color:#57B952;color:#04331f;width:22px;height:22px;line-height:22px;font-size:13px;">&#10003;</span><div>Prevention of potential billing and accounting issues related to incorrect VAT information</div></div></li></ul>
 </div>
-<div class="tab-pane fade py-2 text-body" id="tb-panel-versions" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade py-2" id="tb-panel-versions" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Versions</h2>
 <h2 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">19.0.0.0.2 (2026-08-21)</h2>
 <ul>
@@ -85,7 +85,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -101,7 +101,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -117,7 +117,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -133,7 +133,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -149,7 +149,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -165,7 +165,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -181,7 +181,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -197,7 +197,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_website_warehouse_stock/static/description/index.html
+++ b/deltatech_website_warehouse_stock/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">This module enhances the eCommerce experience by providing real-time stock availability for each warehouse directly on the product page. Customers can see if a product is in stock, low on stock, or unavailable at specific locations, helping them make informed purchasing decisions based on warehouse proximity or availability.</p>
 <p>While Odoo 18/19 introduced a standard "Click &amp; Collect" feature with a map-based store selector, this module provides a complementary, high-visibility approach:</p>
@@ -65,7 +65,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative_website" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -81,7 +81,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_blog" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -97,7 +97,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_category" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -113,7 +113,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_checkout_confirm" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -129,7 +129,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_country" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -145,7 +145,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_address" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -161,7 +161,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_delivery_and_payment" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -177,7 +177,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_website_fixed_price" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_widget_fontawesome/static/description/index.html
+++ b/deltatech_widget_fontawesome/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">Features:</p>
 <ul>
@@ -58,7 +58,7 @@
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_generic_partner_restriction" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -74,7 +74,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_list_view" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -90,7 +90,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_logistic_docs" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -106,7 +106,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_lot" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -122,7 +122,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_partner_generic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -138,7 +138,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -154,7 +154,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_report" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -170,7 +170,7 @@
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_stock_reseller" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/deltatech_widget_many2one_badge/static/description/index.html
+++ b/deltatech_widget_many2one_badge/static/description/index.html
@@ -14,7 +14,7 @@
   </div>
 </div>
 
-<div class="tab-pane fade show active py-2 text-body" id="tb-panel-overview" style="font-size:16px;line-height:1.65;">
+<div class="tab-pane fade show active py-2" id="tb-panel-overview" style="font-size:16px;line-height:1.65;color:#212529;font-weight:400;">
 <h2 class="fw-bold mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Overview</h2>
 <p class="mb-4" style="font-size:19px;line-height:1.6;max-width:780px;">A custom widget  that displays Many2one fields as colored badges, similar to <code class="border rounded px-2" style="font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;font-size:13px;">many2many_tags</code>.</p>
 <h1 class="fw-bold mt-4 mb-3" style="border:none;border-left:4px solid #57B952;padding-left:16px;font-size:24px;letter-spacing:-0.3px;line-height:1.2;">Features</h1>
@@ -238,7 +238,7 @@ class Priority(models.Model):
   <div class="row g-3">
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -254,7 +254,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -270,7 +270,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_analytic" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -286,7 +286,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edi_ubl_advice" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -302,7 +302,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_account_edit_currency_rate" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -318,7 +318,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_actions" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -334,7 +334,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_agreement_management" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -350,7 +350,7 @@ class Priority(models.Model):
     </div>
     <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/19.0/deltatech_alternative" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:#212529;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"

--- a/scripts/tb_gen_index.py
+++ b/scripts/tb_gen_index.py
@@ -148,8 +148,12 @@ NAV_ITEM = """  <li class="nav-item mx-1 mb-2">
   </li>"""
 NAV_CLOSE = "</ul>"
 
-# Panou: `text-body` (theme-aware) dă culoarea corpului pe orice temă gazdă.
-PANEL = """<div class="tab-pane fade%(active)s py-2 text-body" id="tb-panel-%(key)s" style="font-size:16px;line-height:1.65;">
+# Panou: NU folosi clasa `text-body` — pe apps.odoo.com ea e definită ca
+# `color: rgba(var(--body-color-rgb), 1) !important`, iar `--body-color` al store-ului
+# e gri (#374151); fiind `!important`, bate și `color` inline de pe wrapper, deci
+# textul iese gri, nu negru. Punem culoarea și greutatea inline pe panou
+# (store-ul moștenește `--body-font-weight: 300`, care subțiază textul).
+PANEL = """<div class="tab-pane fade%(active)s py-2" id="tb-panel-%(key)s" style="font-size:16px;line-height:1.65;color:%(body_color)s;font-weight:400;">
 %(heading)s
 %(body)s
 </div>"""
@@ -194,7 +198,7 @@ CROSS_SELL_OPEN = """
 """
 CROSS_SELL_CARD = """    <div class="col-md-3 col-sm-6">
       <a href="https://apps.odoo.com/apps/modules/%(series)s/%(tech)s" target="_blank" rel="noopener"
-         class="card h-100 text-decoration-none border text-body">
+         class="card h-100 text-decoration-none border" style="color:%(body)s;">
         <div class="card-body p-3">
           <div class="d-flex align-items-center mb-2">
             <span class="d-inline-block text-center text-white fw-bold rounded me-2 flex-shrink-0"
@@ -505,6 +509,7 @@ def build_tabs(tabs):
                 "active": " show active" if i == 0 else "",
                 "key": key,
                 "heading": heading,
+                "body_color": BODY,
                 "body": build_panel_body(key, md_text),
             }
         )


### PR DESCRIPTION
## Problema

Pe apps.odoo.com, tema store-ului definește:

```css
.text-body { color: rgba(var(--body-color-rgb), 1) !important; }
:root { --800: #374151; }   /* --body-color al store-ului */
```

Panourile de tab din `static/description/index.html` purtau clasa `text-body` (pusă intenționat, ca „theme-aware"). Fiind `!important`, regula store-ului bate și `color:#212529` pe care generatorul îl pune inline pe wrapper — deci textul descrierii ieșea **gri**, nu negru. Culoarea calculată pe pagina publicată: `rgb(55, 65, 81)`.

Al doilea factor: store-ul moștenește `--body-font-weight: 300`, care subțiază textul și accentuează senzația de „decolorat".

## Soluția

Scoate clasa `text-body` din `PANEL` și din `CROSS_SELL_CARD`, punând `color` (și `font-weight:400` pe panou) inline. Fără `!important` pe element, stilul inline câștigă.

Verificat pe pagina publicată a `deltatech_calendar_caldav`: culoarea calculată trece din `rgb(55,65,81)` în `rgb(33,37,41)`, greutatea din 300 în 400.

## Conținut

- `scripts/tb_gen_index.py` — fixul în generator
- toate `index.html`-urile regenerate (fără `--force`, deci nicio pagină scrisă manual nu e atinsă)

`ruff format --check` și `ruff check` trec pe generator. Același fix e propagat în toate cele 10 suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
