### PR TITLE
[FIX] apps store: text lizibil in descrierea modulului

### DIFF
--- a/deltatech/static/description/index.html
+++ b/deltatech/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@ for Odoo developers and system administrators maintaining the Deltatech addon su
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_account/static/description/index.html
+++ b/deltatech_account/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -70,13 +70,13 @@ disable it independently.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -96,7 +96,7 @@ disable it independently.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -109,10 +109,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Average Payment Period</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Computes average duration of cash accounting</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Computes average duration of cash accounting</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Expenses Deduction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Expenses Deduction &amp; Disposition of Cashing</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Expenses Deduction &amp; Disposition of Cashing</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -221,10 +221,10 @@ disable it independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_account_analytic/static/description/index.html
+++ b/deltatech_account_analytic/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -133,13 +133,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -159,7 +159,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Average Payment Period</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Computes average duration of cash accounting</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Computes average duration of cash accounting</p>
         </div>
       </a>
     </div>
@@ -220,10 +220,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Expenses Deduction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Expenses Deduction &amp; Disposition of Cashing</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Expenses Deduction &amp; Disposition of Cashing</p>
         </div>
       </a>
     </div>
@@ -236,10 +236,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -252,10 +252,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -268,10 +268,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -284,10 +284,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_account_edi_ubl_advice/static/description/index.html
+++ b/deltatech_account_edi_ubl_advice/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -38,13 +38,13 @@ delivery notes (despatch advices) the invoice covers.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -64,7 +64,7 @@ delivery notes (despatch advices) the invoice covers.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -77,10 +77,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -93,10 +93,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Average Payment Period</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Computes average duration of cash accounting</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Computes average duration of cash accounting</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Expenses Deduction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Expenses Deduction &amp; Disposition of Cashing</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Expenses Deduction &amp; Disposition of Cashing</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@ delivery notes (despatch advices) the invoice covers.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_account_edit_currency_rate/static/description/index.html
+++ b/deltatech_account_edit_currency_rate/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -29,13 +29,13 @@ It provides more flexibility when dealing with foreign currency invoices that ma
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -55,7 +55,7 @@ It provides more flexibility when dealing with foreign currency invoices that ma
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -68,10 +68,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -84,10 +84,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -100,10 +100,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@ It provides more flexibility when dealing with foreign currency invoices that ma
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_actions/static/description/index.html
+++ b/deltatech_actions/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -212,13 +212,13 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -238,7 +238,7 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -251,10 +251,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Category Group</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Groups for internal categories</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Groups for internal categories</p>
         </div>
       </a>
     </div>
@@ -267,10 +267,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -283,10 +283,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -299,10 +299,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -315,10 +315,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -331,10 +331,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -347,10 +347,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -363,10 +363,10 @@ state directly to <code class="border rounded px-2" style="font-family:ui-monosp
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_agreement_management/static/description/index.html
+++ b/deltatech_agreement_management/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -106,13 +106,13 @@ that is In Progress or Terminated will raise a validation error.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -132,7 +132,7 @@ that is In Progress or Terminated will raise a validation error.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -145,10 +145,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -225,10 +225,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -241,10 +241,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -257,10 +257,10 @@ that is In Progress or Terminated will raise a validation error.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>

--- a/deltatech_alternative/static/description/index.html
+++ b/deltatech_alternative/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -129,13 +129,13 @@ product.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -155,7 +155,7 @@ product.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -168,10 +168,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -216,10 +216,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -232,10 +232,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -248,10 +248,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -264,10 +264,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -280,10 +280,10 @@ product.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_alternative_website/static/description/index.html
+++ b/deltatech_alternative_website/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -87,13 +87,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -113,7 +113,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -222,10 +222,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -238,10 +238,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_analytic_distribution/static/description/index.html
+++ b/deltatech_analytic_distribution/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -61,13 +61,13 @@ enabled or disabled independently.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -87,7 +87,7 @@ enabled or disabled independently.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -100,10 +100,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -212,10 +212,10 @@ enabled or disabled independently.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_auto_reorder_rule/static/description/index.html
+++ b/deltatech_auto_reorder_rule/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -85,13 +85,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -111,7 +111,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -124,10 +124,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -220,10 +220,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -236,10 +236,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_average_payment_period/static/description/index.html
+++ b/deltatech_average_payment_period/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -64,13 +64,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -90,7 +90,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Expenses Deduction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Expenses Deduction &amp; Disposition of Cashing</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Expenses Deduction &amp; Disposition of Cashing</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -199,10 +199,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -215,10 +215,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_backup_attachment/static/description/index.html
+++ b/deltatech_backup_attachment/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -70,13 +70,13 @@ attachments (binary stored in the column, not the filestore) are silently skippe
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -96,7 +96,7 @@ attachments (binary stored in the column, not the filestore) are silently skippe
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -109,10 +109,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Contacts</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">New fields in partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">New fields in partner</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Credentials</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage credentials for external services</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage credentials for external services</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet Website</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Partner GLN </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Partner Global Location Number</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Partner Global Location Number</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Image Optimizer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Recompress oversized image attachments and remove duplicated product images</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Recompress oversized image attachments and remove duplicated product images</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -221,10 +221,10 @@ attachments (binary stored in the column, not the filestore) are silently skippe
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_batch_transfer/static/description/index.html
+++ b/deltatech_batch_transfer/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -162,13 +162,13 @@ customer and sets mode to <em>Sale</em>.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -188,7 +188,7 @@ customer and sets mode to <em>Sale</em>.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -201,10 +201,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -233,10 +233,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -249,10 +249,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -265,10 +265,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -281,10 +281,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -297,10 +297,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -313,10 +313,10 @@ customer and sets mode to <em>Sale</em>.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_business_process/static/description/index.html
+++ b/deltatech_business_process/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -118,13 +118,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -144,7 +144,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process handover document</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process handover document</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process handover document</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Declaration of Conformity</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Declaration of Conformity</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Declaration of Conformity</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit - Record Type</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage multiple record types</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage multiple record types</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ID</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Delivery / Reception</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adding button in invoice for display reception or delivery</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adding button in invoice for display reception or delivery</p>
         </div>
       </a>
     </div>
@@ -221,10 +221,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -237,10 +237,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -253,10 +253,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -269,10 +269,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_business_process_handover_document/static/description/index.html
+++ b/deltatech_business_process_handover_document/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -63,13 +63,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -89,7 +89,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Declaration of Conformity</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Declaration of Conformity</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Declaration of Conformity</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit - Record Type</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage multiple record types</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage multiple record types</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ID</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Delivery / Reception</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adding button in invoice for display reception or delivery</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adding button in invoice for display reception or delivery</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -198,10 +198,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -214,10 +214,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_cash_statement/static/description/index.html
+++ b/deltatech_cash_statement/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -65,13 +65,13 @@ so that the starting balance of the next statement stays consistent.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -91,7 +91,7 @@ so that the starting balance of the next statement stays consistent.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -104,10 +104,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -216,10 +216,10 @@ so that the starting balance of the next statement stays consistent.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_category_group/static/description/index.html
+++ b/deltatech_category_group/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -74,13 +74,13 @@ category form you will find two new fields, <strong>Category type</strong> and
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -100,7 +100,7 @@ category form you will find two new fields, <strong>Category type</strong> and
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -113,10 +113,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -225,10 +225,10 @@ category form you will find two new fields, <strong>Category type</strong> and
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_competitors_price/static/description/index.html
+++ b/deltatech_competitors_price/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -77,13 +77,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -103,7 +103,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -116,10 +116,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Product Chatter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict deletion of chatter messages on products unless user belongs to a special group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict deletion of chatter messages on products unless user belongs to a special group</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Unique Code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict duplicate default_code and barcode including archived products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict duplicate default_code and barcode including archived products</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Packaging</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report packaging materials used for invoiced products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report packaging materials used for invoiced products</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -212,10 +212,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -228,10 +228,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_contact/static/description/index.html
+++ b/deltatech_contact/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Backup Attachments</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Backup attachments for selected file type</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Backup attachments for selected file type</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Credentials</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage credentials for external services</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage credentials for external services</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet Website</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Partner GLN </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Partner Global Location Number</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Partner Global Location Number</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Image Optimizer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Recompress oversized image attachments and remove duplicated product images</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Recompress oversized image attachments and remove duplicated product images</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_credentials/static/description/index.html
+++ b/deltatech_credentials/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -67,13 +67,13 @@ it as needed.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -93,7 +93,7 @@ it as needed.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -106,10 +106,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Backup Attachments</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Backup attachments for selected file type</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Backup attachments for selected file type</p>
         </div>
       </a>
     </div>
@@ -122,10 +122,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Contacts</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">New fields in partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">New fields in partner</p>
         </div>
       </a>
     </div>
@@ -138,10 +138,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -154,10 +154,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet Website</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -170,10 +170,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Partner GLN </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Partner Global Location Number</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Partner Global Location Number</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Image Optimizer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Recompress oversized image attachments and remove duplicated product images</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Recompress oversized image attachments and remove duplicated product images</p>
         </div>
       </a>
     </div>
@@ -202,10 +202,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -218,10 +218,10 @@ it as needed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_cron_monitor_webhook/static/description/index.html
+++ b/deltatech_cron_monitor_webhook/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -101,13 +101,13 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -127,7 +127,7 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -140,10 +140,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RPC Audit Log</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Log XML-RPC / JSON-RPC calls with the real client IP</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Log XML-RPC / JSON-RPC calls with the real client IP</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit Connect - Base</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the&#8230;</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">DeltaTech Transport Change</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Export configuration changes to CSV and manage transport through Git</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Export configuration changes to CSV and manage transport through Git</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -220,10 +220,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -236,10 +236,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -252,10 +252,10 @@ Odoo will return a JSON response. In case of success, the HTTP status is <code c
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_data_sheet/static/description/index.html
+++ b/deltatech_data_sheet/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Backup Attachments</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Backup attachments for selected file type</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Backup attachments for selected file type</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Contacts</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">New fields in partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">New fields in partner</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Credentials</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage credentials for external services</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage credentials for external services</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet Website</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Partner GLN </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Partner Global Location Number</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Partner Global Location Number</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Image Optimizer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Recompress oversized image attachments and remove duplicated product images</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Recompress oversized image attachments and remove duplicated product images</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_data_sheet_website/static/description/index.html
+++ b/deltatech_data_sheet_website/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -66,13 +66,13 @@ template. Products without attached documents show no buttons.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -92,7 +92,7 @@ template. Products without attached documents show no buttons.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -105,10 +105,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Backup Attachments</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Backup attachments for selected file type</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Backup attachments for selected file type</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Contacts</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">New fields in partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">New fields in partner</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Credentials</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage credentials for external services</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage credentials for external services</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Partner GLN </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Partner Global Location Number</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Partner Global Location Number</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Image Optimizer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Recompress oversized image attachments and remove duplicated product images</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Recompress oversized image attachments and remove duplicated product images</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ template. Products without attached documents show no buttons.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_dc/static/description/index.html
+++ b/deltatech_dc/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -56,13 +56,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -82,7 +82,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process handover document</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process handover document</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process handover document</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit - Record Type</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage multiple record types</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage multiple record types</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ID</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Delivery / Reception</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adding button in invoice for display reception or delivery</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adding button in invoice for display reception or delivery</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -191,10 +191,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -207,10 +207,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_delivery_status/static/description/index.html
+++ b/deltatech_delivery_status/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -41,13 +41,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -67,7 +67,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_discount_policy/static/description/index.html
+++ b/deltatech_discount_policy/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -29,13 +29,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -55,7 +55,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -68,10 +68,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -84,10 +84,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -100,10 +100,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_download/static/description/index.html
+++ b/deltatech_download/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_dropshipping/static/description/index.html
+++ b/deltatech_dropshipping/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_ecr_fiscal/static/description/index.html
+++ b/deltatech_ecr_fiscal/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -76,13 +76,13 @@ nevoie de modulele de cas&#259; de marcat.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -102,7 +102,7 @@ nevoie de modulele de cas&#259; de marcat.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -115,10 +115,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -195,10 +195,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -211,10 +211,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -227,10 +227,10 @@ nevoie de modulele de cas&#259; de marcat.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_expenses/static/description/index.html
+++ b/deltatech_expenses/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -215,13 +215,13 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -241,7 +241,7 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -254,10 +254,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -270,10 +270,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -286,10 +286,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -302,10 +302,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Average Payment Period</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Computes average duration of cash accounting</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Computes average duration of cash accounting</p>
         </div>
       </a>
     </div>
@@ -318,10 +318,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -334,10 +334,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -350,10 +350,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -366,10 +366,10 @@ care este specific modulului <code class="border rounded px-2" style="font-famil
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_fast_purchase/static/description/index.html
+++ b/deltatech_fast_purchase/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Create Bill Button</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase: Send Multi Orders by Email with XLSX</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Refund Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vendor credit notes for negative quantities</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vendor credit notes for negative quantities</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase UBL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_fast_sale/static/description/index.html
+++ b/deltatech_fast_sale/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -86,13 +86,13 @@ displayed.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -112,7 +112,7 @@ displayed.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -125,10 +125,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -221,10 +221,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -237,10 +237,10 @@ displayed.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_followup/static/description/index.html
+++ b/deltatech_followup/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -78,13 +78,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -104,7 +104,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -197,10 +197,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -213,10 +213,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -229,10 +229,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_generic_partner_restriction/static/description/index.html
+++ b/deltatech_generic_partner_restriction/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@ ticked as restricted are preserved by the migration script of that module.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@ ticked as restricted are preserved by the migration script of that module.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@ ticked as restricted are preserved by the migration script of that module.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_gln/static/description/index.html
+++ b/deltatech_gln/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -49,13 +49,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -75,7 +75,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Backup Attachments</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Backup attachments for selected file type</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Backup attachments for selected file type</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Contacts</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">New fields in partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">New fields in partner</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Credentials</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage credentials for external services</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage credentials for external services</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet Website</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Image Optimizer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Recompress oversized image attachments and remove duplicated product images</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Recompress oversized image attachments and remove duplicated product images</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_image_optimize/static/description/index.html
+++ b/deltatech_image_optimize/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -382,13 +382,13 @@ uncompressed. No change for opaque images.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -408,7 +408,7 @@ uncompressed. No change for opaque images.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -421,10 +421,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Backup Attachments</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Backup attachments for selected file type</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Backup attachments for selected file type</p>
         </div>
       </a>
     </div>
@@ -437,10 +437,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Contacts</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">New fields in partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">New fields in partner</p>
         </div>
       </a>
     </div>
@@ -453,10 +453,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Credentials</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage credentials for external services</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage credentials for external services</p>
         </div>
       </a>
     </div>
@@ -469,10 +469,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -485,10 +485,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Data Sheet Website</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Data Sheet</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Data Sheet</p>
         </div>
       </a>
     </div>
@@ -501,10 +501,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PG</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Partner GLN </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Administration</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Administration</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Partner Global Location Number</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Partner Global Location Number</p>
         </div>
       </a>
     </div>
@@ -517,10 +517,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -533,10 +533,10 @@ uncompressed. No change for opaque images.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_number/static/description/index.html
+++ b/deltatech_invoice_number/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -40,13 +40,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -66,7 +66,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -79,10 +79,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -191,10 +191,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_picking/static/description/index.html
+++ b/deltatech_invoice_picking/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -41,13 +41,13 @@ linked pickings.</strong></li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -67,7 +67,7 @@ linked pickings.</strong></li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -80,10 +80,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@ linked pickings.</strong></li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_picking_automatically/static/description/index.html
+++ b/deltatech_invoice_picking_automatically/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_product_filter/static/description/index.html
+++ b/deltatech_invoice_product_filter/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_receipt/static/description/index.html
+++ b/deltatech_invoice_receipt/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_report/static/description/index.html
+++ b/deltatech_invoice_report/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -142,13 +142,13 @@ routine updates.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -168,7 +168,7 @@ routine updates.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -181,10 +181,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -197,10 +197,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -213,10 +213,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -229,10 +229,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -245,10 +245,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -261,10 +261,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -277,10 +277,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>
@@ -293,10 +293,10 @@ routine updates.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_to_draft/static/description/index.html
+++ b/deltatech_invoice_to_draft/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IW</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Weight</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Weight</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Weight</p>
         </div>
       </a>
     </div>

--- a/deltatech_invoice_weight/static/description/index.html
+++ b/deltatech_invoice_weight/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -52,13 +52,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -78,7 +78,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -91,10 +91,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -107,10 +107,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>

--- a/deltatech_kit_price/static/description/index.html
+++ b/deltatech_kit_price/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -84,13 +84,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -110,7 +110,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -123,10 +123,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -219,10 +219,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -235,10 +235,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_ledger/static/description/index.html
+++ b/deltatech_ledger/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale Report Additional Info</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;"></span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;"></span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sale Report Additional Info</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sale Report Additional Info</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_line_counter/static/description/index.html
+++ b/deltatech_line_counter/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@ Tests are excluded from the count.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@ Tests are excluded from the count.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech SMS</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Extra Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Extra Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Send SMS to custom endpoint</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Send SMS to custom endpoint</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ Tests are excluded from the count.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_list_view/static/description/index.html
+++ b/deltatech_list_view/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_logistic_docs/static/description/index.html
+++ b/deltatech_logistic_docs/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -54,13 +54,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -80,7 +80,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -93,10 +93,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_lot/static/description/index.html
+++ b/deltatech_lot/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_mail/static/description/index.html
+++ b/deltatech_mail/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -36,13 +36,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -62,7 +62,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -75,10 +75,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -91,10 +91,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -107,10 +107,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_markdown_field/static/description/index.html
+++ b/deltatech_markdown_field/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -74,13 +74,13 @@ without the toolbar.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -100,7 +100,7 @@ without the toolbar.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -113,10 +113,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -225,10 +225,10 @@ without the toolbar.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_move_negative_stock/static/description/index.html
+++ b/deltatech_move_negative_stock/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -125,13 +125,13 @@ with negative stock in the location, summed over its sub-locations.</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -151,7 +151,7 @@ with negative stock in the location, summed over its sub-locations.</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -164,10 +164,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price Category </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price List: Bronze Silver and Gold in product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price List: Bronze Silver and Gold in product</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Promissory Note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage Promissory Note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage Promissory Note</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale &#8594; Purchase RFQ (Alternative Purchase Orders)</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
         </div>
       </a>
     </div>
@@ -212,10 +212,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale Qty Available</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Quantity Available</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Quantity Available</p>
         </div>
       </a>
     </div>
@@ -228,10 +228,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No Negative Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Negative stocks are not allowed</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Negative stocks are not allowed</p>
         </div>
       </a>
     </div>
@@ -244,10 +244,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -260,10 +260,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -276,10 +276,10 @@ with negative stock in the location, summed over its sub-locations.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp/static/description/index.html
+++ b/deltatech_mrp/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -43,13 +43,13 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -69,7 +69,7 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -82,10 +82,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Concentration</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Production</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Production</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Concentration</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Concentration</p>
         </div>
       </a>
     </div>
@@ -98,10 +98,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -114,10 +114,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -130,10 +130,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -146,10 +146,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -162,10 +162,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -178,10 +178,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -194,10 +194,10 @@ adaugat camp cantitate disponibila - adaugat metoda onchange_product_id</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_bom/static/description/index.html
+++ b/deltatech_mrp_bom/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -40,13 +40,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -66,7 +66,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -79,10 +79,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -191,10 +191,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_bom_formula/static/description/index.html
+++ b/deltatech_mrp_bom_formula/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -48,13 +48,13 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -74,7 +74,7 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -87,10 +87,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -199,10 +199,10 @@ usual mathematical builtins. A line without a formula keeps its quantity unchang
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_concentration/static/description/index.html
+++ b/deltatech_mrp_concentration/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ME</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Production</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Production</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Extension</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_cost/static/description/index.html
+++ b/deltatech_mrp_cost/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_simple/static/description/index.html
+++ b/deltatech_mrp_simple/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -39,13 +39,13 @@ components</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -65,7 +65,7 @@ components</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -78,10 +78,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -94,10 +94,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@ components</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_simple_barcode/static/description/index.html
+++ b/deltatech_mrp_simple_barcode/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_mrp_validation_date/static/description/index.html
+++ b/deltatech_mrp_validation_date/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -56,13 +56,13 @@ giving production managers a reliable audit trail of order completion times.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -82,7 +82,7 @@ giving production managers a reliable audit trail of order completion times.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -95,10 +95,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -191,10 +191,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -207,10 +207,10 @@ giving production managers a reliable audit trail of order completion times.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_no_quick_create/static/description/index.html
+++ b/deltatech_no_quick_create/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_notification_sound/static/description/index.html
+++ b/deltatech_notification_sound/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -54,13 +54,13 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -80,7 +80,7 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -93,10 +93,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@ Adds audible feedback to Odoo backend notifications so operators are alerted ins
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_partner_generic/static/description/index.html
+++ b/deltatech_partner_generic/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -59,13 +59,13 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -85,7 +85,7 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -98,10 +98,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -114,10 +114,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -130,10 +130,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -146,10 +146,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -162,10 +162,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -178,10 +178,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -194,10 +194,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -210,10 +210,10 @@ geolocation &#8212; stay allowed, as do automated flows running with elevated ri
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_partner_merge/static/description/index.html
+++ b/deltatech_partner_merge/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -68,13 +68,13 @@ it has to be run outside Odoo.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -94,7 +94,7 @@ it has to be run outside Odoo.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -107,10 +107,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -219,10 +219,10 @@ it has to be run outside Odoo.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_payment_forecast/static/description/index.html
+++ b/deltatech_payment_forecast/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@ automatically generate the report</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@ automatically generate the report</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@ automatically generate the report</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>

--- a/deltatech_payment_term/static/description/index.html
+++ b/deltatech_payment_term/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -98,13 +98,13 @@ linked to installment payment terms for that partner.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -124,7 +124,7 @@ linked to installment payment terms for that partner.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -137,10 +137,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -233,10 +233,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -249,10 +249,10 @@ linked to installment payment terms for that partner.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_picking_restrict/static/description/index.html
+++ b/deltatech_picking_restrict/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_picking_restrict_entry_exit/static/description/index.html
+++ b/deltatech_picking_restrict_entry_exit/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_picking_services/static/description/index.html
+++ b/deltatech_picking_services/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_picking_split/static/description/index.html
+++ b/deltatech_picking_split/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_picking_transit/static/description/index.html
+++ b/deltatech_picking_transit/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@ based on the partner of the transfer (use the contact associated to the second w
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@ based on the partner of the transfer (use the contact associated to the second w
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@ based on the partner of the transfer (use the contact associated to the second w
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_pos_fix/static/description/index.html
+++ b/deltatech_pos_fix/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -66,13 +66,13 @@ without any overlap:</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -92,7 +92,7 @@ without any overlap:</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -105,10 +105,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech POS Price Sync</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Point of Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Point of Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Push live product price changes to already open POS sessions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Push live product price changes to already open POS sessions</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech POS Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Point of Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Point of Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display stock in POS</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display stock in POS</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>

--- a/deltatech_pos_price_sync/static/description/index.html
+++ b/deltatech_pos_price_sync/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -58,13 +58,13 @@ without any overlap:</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -84,7 +84,7 @@ without any overlap:</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -97,10 +97,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech POS Fix</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Point of Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Point of Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Fix POS total calculation when using tax-included fiscal position mapping</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Fix POS total calculation when using tax-included fiscal position mapping</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech POS Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Point of Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Point of Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display stock in POS</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display stock in POS</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>

--- a/deltatech_pos_product_filter/static/description/index.html
+++ b/deltatech_pos_product_filter/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -35,13 +35,13 @@ without any overlap:</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -61,7 +61,7 @@ without any overlap:</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -74,10 +74,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Analytic distribution enforcer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic distribution</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic distribution</p>
         </div>
       </a>
     </div>
@@ -90,10 +90,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cash Statement Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update cash balance</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update cash balance</p>
         </div>
       </a>
     </div>
@@ -106,10 +106,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Followup</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple invoice followup, with automatic e-mails</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple invoice followup, with automatic e-mails</p>
         </div>
       </a>
     </div>
@@ -122,10 +122,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Number</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Renumbering invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Renumbering invoice</p>
         </div>
       </a>
     </div>
@@ -138,10 +138,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Product Filter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Searching invoice using product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Searching invoice using product</p>
         </div>
       </a>
     </div>
@@ -154,10 +154,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice Receipt</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create receipt form invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create receipt form invoice</p>
         </div>
       </a>
     </div>
@@ -170,10 +170,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Invoice Report</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Invoice Report</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Invoice to Draft</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restricted access to reset account move to draft</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restricted access to reset account move to draft</p>
         </div>
       </a>
     </div>

--- a/deltatech_pos_stock/static/description/index.html
+++ b/deltatech_pos_stock/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -73,13 +73,13 @@ without any overlap:</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -99,7 +99,7 @@ without any overlap:</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -112,10 +112,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech POS Fix</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Point of Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Point of Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Fix POS total calculation when using tax-included fiscal position mapping</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Fix POS total calculation when using tax-included fiscal position mapping</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech POS Price Sync</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Point of Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Point of Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Push live product price changes to already open POS sessions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Push live product price changes to already open POS sessions</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -208,10 +208,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -224,10 +224,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>

--- a/deltatech_price_categ/static/description/index.html
+++ b/deltatech_price_categ/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -61,13 +61,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -87,7 +87,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -100,10 +100,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Replenish negative stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Replenish negative stock from other location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Replenish negative stock from other location</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Promissory Note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage Promissory Note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage Promissory Note</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale &#8594; Purchase RFQ (Alternative Purchase Orders)</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale Qty Available</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Quantity Available</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Quantity Available</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No Negative Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Negative stocks are not allowed</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Negative stocks are not allowed</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -212,10 +212,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_pricelist/static/description/index.html
+++ b/deltatech_pricelist/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_pricelist_line_viewer/static/description/index.html
+++ b/deltatech_pricelist_line_viewer/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Category Color</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Products Category Color</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Products Category Color</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_catalog/static/description/index.html
+++ b/deltatech_product_catalog/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Reordering Limit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Custom reordering limits for products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Custom reordering limits for products</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenishment Explain</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Orderpoint Qty Multiple</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Picking Activity Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Tracks activities and changes on stock pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Tracks activities and changes on stock pickings</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Transfer Product to Product</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Helps to transfer x quantity of product A and replace it with product B</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Helps to transfer x quantity of product A and replace it with product B</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_category_color/static/description/index.html
+++ b/deltatech_product_category_color/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_category_group/static/description/index.html
+++ b/deltatech_product_category_group/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -27,13 +27,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -53,7 +53,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -66,10 +66,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -82,10 +82,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -98,10 +98,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -114,10 +114,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -130,10 +130,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -146,10 +146,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -162,10 +162,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -178,10 +178,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_chatter/static/description/index.html
+++ b/deltatech_product_chatter/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -83,13 +83,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -109,7 +109,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -122,10 +122,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Competitors Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Track competitors&#x27; product prices and fetch on demand</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Track competitors&#x27; product prices and fetch on demand</p>
         </div>
       </a>
     </div>
@@ -138,10 +138,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Unique Code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict duplicate default_code and barcode including archived products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict duplicate default_code and barcode including archived products</p>
         </div>
       </a>
     </div>
@@ -154,10 +154,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Packaging</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report packaging materials used for invoiced products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report packaging materials used for invoiced products</p>
         </div>
       </a>
     </div>
@@ -170,10 +170,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -202,10 +202,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -218,10 +218,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -234,10 +234,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_code/static/description/index.html
+++ b/deltatech_product_code/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -29,13 +29,13 @@ It is designed for businesses that require strict and structured product codific
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -55,7 +55,7 @@ It is designed for businesses that require strict and structured product codific
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -68,10 +68,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -84,10 +84,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -100,10 +100,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@ It is designed for businesses that require strict and structured product codific
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_dimension/static/description/index.html
+++ b/deltatech_product_dimension/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -53,13 +53,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -79,7 +79,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -92,10 +92,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -108,10 +108,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_extension/static/description/index.html
+++ b/deltatech_product_extension/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -62,13 +62,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -88,7 +88,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -197,10 +197,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -213,10 +213,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_labels/static/description/index.html
+++ b/deltatech_product_labels/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_list/static/description/index.html
+++ b/deltatech_product_list/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Sale Order Search by Partner Fields</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Search sale order by partner e-mail, phone</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Search sale order by partner e-mail, phone</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_mpn/static/description/index.html
+++ b/deltatech_product_mpn/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -24,13 +24,13 @@ The field is also added to the search bar for easier product identification.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -50,7 +50,7 @@ The field is also added to the search bar for easier product identification.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -63,10 +63,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -79,10 +79,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@ The field is also added to the search bar for easier product identification.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_reordering_limit/static/description/index.html
+++ b/deltatech_product_reordering_limit/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -87,13 +87,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -113,7 +113,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Catalog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">This module helps to print the catalog of the multi products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">This module helps to print the catalog of the multi products</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenishment Explain</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Orderpoint Qty Multiple</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Picking Activity Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Tracks activities and changes on stock pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Tracks activities and changes on stock pickings</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Transfer Product to Product</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Helps to transfer x quantity of product A and replace it with product B</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Helps to transfer x quantity of product A and replace it with product B</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -222,10 +222,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -238,10 +238,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_trade_markup/static/description/index.html
+++ b/deltatech_product_trade_markup/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_unique_code/static/description/index.html
+++ b/deltatech_product_unique_code/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -51,13 +51,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -77,7 +77,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -90,10 +90,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Competitors Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Track competitors&#x27; product prices and fetch on demand</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Track competitors&#x27; product prices and fetch on demand</p>
         </div>
       </a>
     </div>
@@ -106,10 +106,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Product Chatter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict deletion of chatter messages on products unless user belongs to a special group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict deletion of chatter messages on products unless user belongs to a special group</p>
         </div>
       </a>
     </div>
@@ -122,10 +122,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Packaging</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report packaging materials used for invoiced products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report packaging materials used for invoiced products</p>
         </div>
       </a>
     </div>
@@ -138,10 +138,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -154,10 +154,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -170,10 +170,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -202,10 +202,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_product_visibility/static/description/index.html
+++ b/deltatech_product_visibility/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -118,13 +118,13 @@ new edits recompute on the fly.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -144,7 +144,7 @@ new edits recompute on the fly.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -157,10 +157,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -221,10 +221,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -237,10 +237,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -253,10 +253,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -269,10 +269,10 @@ new edits recompute on the fly.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_project_price_list/static/description/index.html
+++ b/deltatech_project_price_list/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -57,13 +57,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -83,7 +83,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -208,10 +208,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_promissory_note/static/description/index.html
+++ b/deltatech_promissory_note/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Replenish negative stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Replenish negative stock from other location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Replenish negative stock from other location</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price Category </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price List: Bronze Silver and Gold in product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price List: Bronze Silver and Gold in product</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale &#8594; Purchase RFQ (Alternative Purchase Orders)</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale Qty Available</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Quantity Available</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Quantity Available</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No Negative Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Negative stocks are not allowed</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Negative stocks are not allowed</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_add_extra_line/static/description/index.html
+++ b/deltatech_purchase_add_extra_line/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -52,13 +52,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -78,7 +78,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -91,10 +91,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -107,10 +107,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_create_bill_button/static/description/index.html
+++ b/deltatech_purchase_create_bill_button/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@ Odoo 18 behavior.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@ Odoo 18 behavior.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Achizitie rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Achizitie rapida</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase: Send Multi Orders by Email with XLSX</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Refund Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vendor credit notes for negative quantities</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vendor credit notes for negative quantities</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase UBL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@ Odoo 18 behavior.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_mail/static/description/index.html
+++ b/deltatech_purchase_mail/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -61,13 +61,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -87,7 +87,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -100,10 +100,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Achizitie rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Achizitie rapida</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Create Bill Button</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Refund Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vendor credit notes for negative quantities</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vendor credit notes for negative quantities</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase UBL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -212,10 +212,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_phase/static/description/index.html
+++ b/deltatech_purchase_phase/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -89,13 +89,13 @@ on the current order(s).</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -115,7 +115,7 @@ on the current order(s).</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -128,10 +128,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase picking status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Get purchase status from pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Get purchase status from pickings</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update vendor price after reception</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update vendor price after reception</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Stock</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Stock</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PX</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase XLS</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import/export purchase line from/to Excel</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import/export purchase line from/to Excel</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenish</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Replenish</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Replenish</p>
         </div>
       </a>
     </div>
@@ -208,10 +208,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -224,10 +224,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -240,10 +240,10 @@ on the current order(s).</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_picking_status/static/description/index.html
+++ b/deltatech_purchase_picking_status/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -38,13 +38,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -64,7 +64,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -77,10 +77,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase Order Stage</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Order Stage</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Order Stage</p>
         </div>
       </a>
     </div>
@@ -93,10 +93,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update vendor price after reception</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update vendor price after reception</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Stock</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Stock</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PX</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase XLS</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import/export purchase line from/to Excel</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import/export purchase line from/to Excel</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenish</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Replenish</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Replenish</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_price/static/description/index.html
+++ b/deltatech_purchase_price/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -70,13 +70,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -96,7 +96,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -109,10 +109,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase Order Stage</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Order Stage</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Order Stage</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase picking status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Get purchase status from pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Get purchase status from pickings</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Stock</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Stock</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PX</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase XLS</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import/export purchase line from/to Excel</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import/export purchase line from/to Excel</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenish</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Replenish</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Replenish</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -221,10 +221,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_refund/static/description/index.html
+++ b/deltatech_purchase_refund/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Achizitie rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Achizitie rapida</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Create Bill Button</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase: Send Multi Orders by Email with XLSX</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase UBL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import UBL XML vendor invoices to update prices, validate receipts, and create vendor bills</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_stock/static/description/index.html
+++ b/deltatech_purchase_stock/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -60,13 +60,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -86,7 +86,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase Order Stage</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Order Stage</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Order Stage</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase picking status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Get purchase status from pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Get purchase status from pickings</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update vendor price after reception</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update vendor price after reception</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PX</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase XLS</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import/export purchase line from/to Excel</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import/export purchase line from/to Excel</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenish</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Replenish</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Replenish</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -195,10 +195,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -211,10 +211,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_ubl/static/description/index.html
+++ b/deltatech_purchase_ubl/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -216,13 +216,13 @@ creating an empty bill.</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -242,7 +242,7 @@ creating an empty bill.</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -255,10 +255,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Achizitie rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Achizitie rapida</p>
         </div>
       </a>
     </div>
@@ -271,10 +271,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Create Bill Button</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restores the one-click Create Bill button and vendor reference copy on the purchase order form</p>
         </div>
       </a>
     </div>
@@ -287,10 +287,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase: Send Multi Orders by Email with XLSX</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Select multiple purchase orders and send an email with XLSX summary and attached PDFs</p>
         </div>
       </a>
     </div>
@@ -303,10 +303,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Refund Purchase</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchases</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchases</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vendor credit notes for negative quantities</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vendor credit notes for negative quantities</p>
         </div>
       </a>
     </div>
@@ -319,10 +319,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -335,10 +335,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -351,10 +351,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -367,10 +367,10 @@ creating an empty bill.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_purchase_xls/static/description/index.html
+++ b/deltatech_purchase_xls/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -34,13 +34,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -60,7 +60,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -73,10 +73,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase Order Stage</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Order Stage</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Order Stage</p>
         </div>
       </a>
     </div>
@@ -89,10 +89,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase picking status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Get purchase status from pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Get purchase status from pickings</p>
         </div>
       </a>
     </div>
@@ -105,10 +105,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update vendor price after reception</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update vendor price after reception</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Stock</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Stock</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenish</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Replenish</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Replenish</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_putaway_strategy/static/description/index.html
+++ b/deltatech_putaway_strategy/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -162,13 +162,13 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -188,7 +188,7 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -201,10 +201,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -233,10 +233,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -249,10 +249,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -265,10 +265,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -281,10 +281,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -297,10 +297,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -313,10 +313,10 @@ The option also requires <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_queue_job/static/description/index.html
+++ b/deltatech_queue_job/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -169,13 +169,13 @@ You can manually trigger job processing from the Queue Job list view using the <
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -195,7 +195,7 @@ You can manually trigger job processing from the Queue Job list view using the <
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -208,10 +208,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -224,10 +224,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -240,10 +240,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -256,10 +256,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -272,10 +272,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -288,10 +288,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -304,10 +304,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -320,10 +320,10 @@ You can manually trigger job processing from the Queue Job list view using the <
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_ral/static/description/index.html
+++ b/deltatech_ral/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Report Layout</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Customized report layouts</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Customized report layouts</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_reception_note/static/description/index.html
+++ b/deltatech_reception_note/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -83,13 +83,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -109,7 +109,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -122,10 +122,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -138,10 +138,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -154,10 +154,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -170,10 +170,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -202,10 +202,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -218,10 +218,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -234,10 +234,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_record_type/static/description/index.html
+++ b/deltatech_record_type/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -44,13 +44,13 @@ available for Odoo 17.0.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -70,7 +70,7 @@ available for Odoo 17.0.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -83,10 +83,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process handover document</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process handover document</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process handover document</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Declaration of Conformity</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Declaration of Conformity</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Declaration of Conformity</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ID</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Delivery / Reception</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adding button in invoice for display reception or delivery</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adding button in invoice for display reception or delivery</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -195,10 +195,10 @@ available for Odoo 17.0.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_replenish/static/description/index.html
+++ b/deltatech_replenish/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -65,13 +65,13 @@ model, view or data of its own.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -91,7 +91,7 @@ model, view or data of its own.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -104,10 +104,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase Order Stage</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Order Stage</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Order Stage</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase picking status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Get purchase status from pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Get purchase status from pickings</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Update vendor price after reception</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Update vendor price after reception</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Purchase Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Purchase Stock</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Purchase Stock</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PX</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Purchase XLS</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Purchase</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Purchase</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Import/export purchase line from/to Excel</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Import/export purchase line from/to Excel</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -216,10 +216,10 @@ model, view or data of its own.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_replenishment_explain/static/description/index.html
+++ b/deltatech_replenishment_explain/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -68,13 +68,13 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -94,7 +94,7 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -107,10 +107,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Catalog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">This module helps to print the catalog of the multi products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">This module helps to print the catalog of the multi products</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Reordering Limit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Custom reordering limits for products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Custom reordering limits for products</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Orderpoint Qty Multiple</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Picking Activity Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Tracks activities and changes on stock pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Tracks activities and changes on stock pickings</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Transfer Product to Product</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Helps to transfer x quantity of product A and replace it with product B</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Helps to transfer x quantity of product A and replace it with product B</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -219,10 +219,10 @@ ordered (deadline set), rounding inflation, manual overrides and snoozes.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_report_layout/static/description/index.html
+++ b/deltatech_report_layout/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Bom</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Bom</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Bom</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP BoM Formula</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Compute BoM component quantities from product attribute values</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Compute BoM component quantities from product attribute values</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Cost</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">MRP Cost</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">MRP Cost</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Simple MRP barcode</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Simple production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Simple production</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">MRP Validation Date</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Validation date on production order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Validation date on production order</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RAL</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Manufacturing</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Manufacturing</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">RAL</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">RAL</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_report_packaging/static/description/index.html
+++ b/deltatech_report_packaging/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -58,13 +58,13 @@ packaging-material report action.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -84,7 +84,7 @@ packaging-material report action.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -97,10 +97,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Competitors Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Track competitors&#x27; product prices and fetch on demand</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Track competitors&#x27; product prices and fetch on demand</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Product Chatter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict deletion of chatter messages on products unless user belongs to a special group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict deletion of chatter messages on products unless user belongs to a special group</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PU</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Unique Code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Product</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Product</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict duplicate default_code and barcode including archived products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict duplicate default_code and barcode including archived products</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@ packaging-material report action.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_report_prn/static/description/index.html
+++ b/deltatech_report_prn/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -53,13 +53,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -79,7 +79,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -92,10 +92,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -108,10 +108,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_restrict_reports/static/description/index.html
+++ b/deltatech_restrict_reports/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -63,13 +63,13 @@ Settings &gt; Users.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -89,7 +89,7 @@ Settings &gt; Users.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -102,10 +102,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -198,10 +198,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -214,10 +214,10 @@ Settings &gt; Users.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_rpc_audit/static/description/index.html
+++ b/deltatech_rpc_audit/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -131,13 +131,13 @@ cached 60s alongside the ignore list.
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -157,7 +157,7 @@ cached 60s alongside the ignore list.
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -170,10 +170,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cron Monitor Webhook</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Run cron jobs from webhook</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Run cron jobs from webhook</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit Connect - Base</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the&#8230;</p>
         </div>
       </a>
     </div>
@@ -202,10 +202,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">DeltaTech Transport Change</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Export configuration changes to CSV and manage transport through Git</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Export configuration changes to CSV and manage transport through Git</p>
         </div>
       </a>
     </div>
@@ -218,10 +218,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -234,10 +234,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -250,10 +250,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -266,10 +266,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -282,10 +282,10 @@ cached 60s alongside the ignore list.
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_activity_report/static/description/index.html
+++ b/deltatech_sale_activity_report/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_activity_search/static/description/index.html
+++ b/deltatech_sale_activity_search/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -54,13 +54,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -80,7 +80,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -93,10 +93,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_add_extra_line/static/description/index.html
+++ b/deltatech_sale_add_extra_line/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -47,13 +47,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -73,7 +73,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -198,10 +198,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_add_extra_line_pos/static/description/index.html
+++ b/deltatech_sale_add_extra_line_pos/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -96,13 +96,13 @@ without any overlap:</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -122,7 +122,7 @@ without any overlap:</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -135,10 +135,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -199,10 +199,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -215,10 +215,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -231,10 +231,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -247,10 +247,10 @@ without any overlap:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_analysis_vat/static/description/index.html
+++ b/deltatech_sale_analysis_vat/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -74,13 +74,13 @@ duplicated in the reports.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -100,7 +100,7 @@ duplicated in the reports.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -113,10 +113,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -225,10 +225,10 @@ duplicated in the reports.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_catalog_website/static/description/index.html
+++ b/deltatech_sale_catalog_website/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -45,13 +45,13 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -71,7 +71,7 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -84,10 +84,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -100,10 +100,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@ Sales catalog</strong> &#8212; the Purchase catalog keeps the standard behaviour
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_commission/static/description/index.html
+++ b/deltatech_sale_commission/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -66,13 +66,13 @@ and if the difference between the date of the last payment and the due date is l
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -92,7 +92,7 @@ and if the difference between the date of the last payment and the due date is l
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -105,10 +105,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ and if the difference between the date of the last payment and the due date is l
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_contact/static/description/index.html
+++ b/deltatech_sale_contact/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_cost_product/static/description/index.html
+++ b/deltatech_sale_cost_product/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -71,13 +71,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -97,7 +97,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -222,10 +222,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_currency/static/description/index.html
+++ b/deltatech_sale_currency/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -51,13 +51,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -77,7 +77,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -90,10 +90,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -106,10 +106,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -122,10 +122,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -138,10 +138,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -154,10 +154,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -170,10 +170,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -186,10 +186,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -202,10 +202,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_feedback/static/description/index.html
+++ b/deltatech_sale_feedback/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_invoice_status/static/description/index.html
+++ b/deltatech_sale_invoice_status/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_margin/static/description/index.html
+++ b/deltatech_sale_margin/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -149,13 +149,13 @@ note in the chatter;</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -175,7 +175,7 @@ note in the chatter;</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -188,10 +188,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -220,10 +220,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -236,10 +236,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -252,10 +252,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -268,10 +268,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -284,10 +284,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -300,10 +300,10 @@ note in the chatter;</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_multiple/static/description/index.html
+++ b/deltatech_sale_multiple/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -24,13 +24,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -50,7 +50,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -63,10 +63,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -79,10 +79,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_multiple_website/static/description/index.html
+++ b/deltatech_sale_multiple_website/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@ satisfies both rules. Variant changes refresh the displayed restrictions.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_pallet/static/description/index.html
+++ b/deltatech_sale_pallet/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -49,13 +49,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -75,7 +75,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_pallet_website/static/description/index.html
+++ b/deltatech_sale_pallet_website/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -50,13 +50,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -76,7 +76,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -89,10 +89,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -105,10 +105,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_payment/static/description/index.html
+++ b/deltatech_sale_payment/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_phone/static/description/index.html
+++ b/deltatech_sale_phone/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_picking_status/static/description/index.html
+++ b/deltatech_sale_picking_status/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -38,13 +38,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -64,7 +64,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -77,10 +77,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -93,10 +93,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_purchase/static/description/index.html
+++ b/deltatech_sale_purchase/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -65,13 +65,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -91,7 +91,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -216,10 +216,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_purchase_requisition/static/description/index.html
+++ b/deltatech_sale_purchase_requisition/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -36,13 +36,13 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -62,7 +62,7 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -75,10 +75,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Replenish negative stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Replenish negative stock from other location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Replenish negative stock from other location</p>
         </div>
       </a>
     </div>
@@ -91,10 +91,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price Category </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price List: Bronze Silver and Gold in product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price List: Bronze Silver and Gold in product</p>
         </div>
       </a>
     </div>
@@ -107,10 +107,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Promissory Note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage Promissory Note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage Promissory Note</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale Qty Available</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Quantity Available</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Quantity Available</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No Negative Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Negative stocks are not allowed</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Negative stocks are not allowed</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@ purchasing approach in Odoo, without introducing purchase agreements.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_qty_available/static/description/index.html
+++ b/deltatech_sale_qty_available/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Replenish negative stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Replenish negative stock from other location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Replenish negative stock from other location</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price Category </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price List: Bronze Silver and Gold in product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price List: Bronze Silver and Gold in product</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Promissory Note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage Promissory Note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage Promissory Note</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale &#8594; Purchase RFQ (Alternative Purchase Orders)</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No Negative Stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Negative stocks are not allowed</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Negative stocks are not allowed</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_report/static/description/index.html
+++ b/deltatech_sale_report/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Ledger</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;"></span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;"></span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Ledger</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Ledger</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_return_cause/static/description/index.html
+++ b/deltatech_sale_return_cause/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -28,13 +28,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -54,7 +54,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -67,10 +67,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -83,10 +83,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_stage/static/description/index.html
+++ b/deltatech_sale_stage/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -49,13 +49,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -75,7 +75,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_team/static/description/index.html
+++ b/deltatech_sale_team/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_transfer/static/description/index.html
+++ b/deltatech_sale_transfer/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@ available</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@ available</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@ available</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_sale_xls/static/description/index.html
+++ b/deltatech_sale_xls/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_saleorder_pickup_list/static/description/index.html
+++ b/deltatech_saleorder_pickup_list/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_saleorder_search/static/description/index.html
+++ b/deltatech_saleorder_search/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product List</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sale</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sale</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Define products lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Define products lists</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_secondary_uom/static/description/index.html
+++ b/deltatech_secondary_uom/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -72,13 +72,13 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -98,7 +98,7 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -111,10 +111,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Map</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory/Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory/Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Visual warehouse map: navigate locations by hierarchy (levels, lines, racks, shelves, cells)</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Visual warehouse map: navigate locations by hierarchy (levels, lines, racks, shelves, cells)</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -191,10 +191,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -207,10 +207,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -223,10 +223,10 @@ or any code reading <code class="border rounded px-2" style="font-family:ui-mono
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_sms/static/description/index.html
+++ b/deltatech_sms/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -37,13 +37,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -63,7 +63,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -76,10 +76,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Line Counter</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Extra Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Extra Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Count lines of code in selected modules</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Count lines of code in selected modules</p>
         </div>
       </a>
     </div>
@@ -92,10 +92,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -108,10 +108,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_sms_sale/static/description/index.html
+++ b/deltatech_sms_sale/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -27,13 +27,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -53,7 +53,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -66,10 +66,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -82,10 +82,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -98,10 +98,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -114,10 +114,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -130,10 +130,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -146,10 +146,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -162,10 +162,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -178,10 +178,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_account/static/description/index.html
+++ b/deltatech_stock_account/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -27,13 +27,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -53,7 +53,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -66,10 +66,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -82,10 +82,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -98,10 +98,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -114,10 +114,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -130,10 +130,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -146,10 +146,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -162,10 +162,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -178,10 +178,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_analytic/static/description/index.html
+++ b/deltatech_stock_analytic/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -60,13 +60,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -86,7 +86,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -99,10 +99,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -115,10 +115,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -131,10 +131,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -147,10 +147,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -163,10 +163,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -179,10 +179,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -195,10 +195,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -211,10 +211,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_close/static/description/index.html
+++ b/deltatech_stock_close/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -53,13 +53,13 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -79,7 +79,7 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -92,10 +92,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -108,10 +108,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@ It helps maintain inventory accuracy by allowing users to mark stock move valuat
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_count_zero/static/description/index.html
+++ b/deltatech_stock_count_zero/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -29,13 +29,13 @@ This is useful during physical inventory, where items not found must be explicit
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -55,7 +55,7 @@ This is useful during physical inventory, where items not found must be explicit
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -68,10 +68,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -84,10 +84,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -100,10 +100,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -116,10 +116,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Warehouse Arrangement</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manages warehouse locations, parallel to standard Odoo locations</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manages warehouse locations, parallel to standard Odoo locations</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@ This is useful during physical inventory, where items not found must be explicit
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_delivery/static/description/index.html
+++ b/deltatech_stock_delivery/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Business process handover document</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Business process handover document</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Business process handover document</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Declaration of Conformity</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Declaration of Conformity</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Declaration of Conformity</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit - Record Type</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage multiple record types</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage multiple record types</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_inventory/static/description/index.html
+++ b/deltatech_stock_inventory/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -139,13 +139,13 @@ is updated with the price from the inventory lines.</li>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -165,7 +165,7 @@ is updated with the price from the inventory lines.</li>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -178,10 +178,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -194,10 +194,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -210,10 +210,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -226,10 +226,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -242,10 +242,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -258,10 +258,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -274,10 +274,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -290,10 +290,10 @@ is updated with the price from the inventory lines.</li>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory Product Display</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Adds product display button on sales and invoices to see the stock of the products in the order</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_inventory_product_display/static/description/index.html
+++ b/deltatech_stock_inventory_product_display/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_negative/static/description/index.html
+++ b/deltatech_stock_negative/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -57,13 +57,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -83,7 +83,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Replenish negative stock</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Replenish negative stock from other location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Replenish negative stock from other location</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price Category </span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price List: Bronze Silver and Gold in product</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price List: Bronze Silver and Gold in product</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Promissory Note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage Promissory Note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage Promissory Note</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale &#8594; Purchase RFQ (Alternative Purchase Orders)</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Create Purchase RFQ(s) from Sales Quotations and link them back to the quote.</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Sale Qty Available</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules/Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules/Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Quantity Available</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Quantity Available</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -208,10 +208,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_orderpoint_multiple/static/description/index.html
+++ b/deltatech_stock_orderpoint_multiple/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Catalog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">This module helps to print the catalog of the multi products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">This module helps to print the catalog of the multi products</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Reordering Limit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Custom reordering limits for products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Custom reordering limits for products</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenishment Explain</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Picking Activity Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Tracks activities and changes on stock pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Tracks activities and changes on stock pickings</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Transfer Product to Product</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Helps to transfer x quantity of product A and replace it with product B</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Helps to transfer x quantity of product A and replace it with product B</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@ rotunje&#537;te direct la un multiplu al acestei valori; altfel comportamentul n
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_picking_activity_report/static/description/index.html
+++ b/deltatech_stock_picking_activity_report/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -24,13 +24,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -50,7 +50,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -63,10 +63,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Catalog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">This module helps to print the catalog of the multi products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">This module helps to print the catalog of the multi products</p>
         </div>
       </a>
     </div>
@@ -79,10 +79,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Reordering Limit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Custom reordering limits for products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Custom reordering limits for products</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenishment Explain</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Orderpoint Qty Multiple</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Transfer Product to Product</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Helps to transfer x quantity of product A and replace it with product B</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Helps to transfer x quantity of product A and replace it with product B</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_removal_priority/static/description/index.html
+++ b/deltatech_stock_removal_priority/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -71,13 +71,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -97,7 +97,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -222,10 +222,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_report/static/description/index.html
+++ b/deltatech_stock_report/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_stock_reseller/static/description/index.html
+++ b/deltatech_stock_reseller/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Disable Fuzzy Search</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable Fuzzy Search</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable Fuzzy Search</p>
         </div>
       </a>
     </div>

--- a/deltatech_tc/static/description/index.html
+++ b/deltatech_tc/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -282,13 +282,13 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -308,7 +308,7 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -321,10 +321,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cron Monitor Webhook</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Run cron jobs from webhook</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Run cron jobs from webhook</p>
         </div>
       </a>
     </div>
@@ -337,10 +337,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RPC Audit Log</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Log XML-RPC / JSON-RPC calls with the real client IP</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Log XML-RPC / JSON-RPC calls with the real client IP</p>
         </div>
       </a>
     </div>
@@ -353,10 +353,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">DeltaTech Transport Change</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Export configuration changes to CSV and manage transport through Git</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Export configuration changes to CSV and manage transport through Git</p>
         </div>
       </a>
     </div>
@@ -369,10 +369,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -385,10 +385,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -401,10 +401,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -417,10 +417,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -433,10 +433,10 @@ DUKIntegrator) to activate additional job types. They appear automatically in th
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_team_logo/static/description/index.html
+++ b/deltatech_team_logo/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -39,13 +39,13 @@ standard (logo-ul firmei).</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -65,7 +65,7 @@ standard (logo-ul firmei).</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -78,10 +78,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -94,10 +94,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@ standard (logo-ul firmei).</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/deltatech_test_system/static/description/index.html
+++ b/deltatech_test_system/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -50,13 +50,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -76,7 +76,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -89,10 +89,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -105,10 +105,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Watermark</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Watermark field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Watermark field</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_transfer_product_to_product/static/description/index.html
+++ b/deltatech_transfer_product_to_product/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Catalog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">This module helps to print the catalog of the multi products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">This module helps to print the catalog of the multi products</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Reordering Limit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Custom reordering limits for products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Custom reordering limits for products</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Replenishment Explain</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Explain how and why a reordering rule reached its forecast and to-order quantity, and flag visibility/horizon stockout&#8230;</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SO</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Orderpoint Qty Multiple</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restore the &#x27;Multiple Quantity&#x27; rounding on reordering rules removed in Odoo 19</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Picking Activity Report</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Tracks activities and changes on stock pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Tracks activities and changes on stock pickings</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>

--- a/deltatech_transport_change/static/description/index.html
+++ b/deltatech_transport_change/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Cron Monitor Webhook</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Run cron jobs from webhook</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Run cron jobs from webhook</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">RPC Audit Log</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Log XML-RPC / JSON-RPC calls with the real client IP</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Log XML-RPC / JSON-RPC calls with the real client IP</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">CB</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Terrabit Connect - Base</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Technical</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Technical</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the&#8230;</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Base for Terrabit Connect: station registry, outbound job queue, REST endpoints (X-Station-Key) and HTTP calls into the&#8230;</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>

--- a/deltatech_vendor_stock/static/description/index.html
+++ b/deltatech_vendor_stock/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -24,13 +24,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -50,7 +50,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -63,10 +63,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -79,10 +79,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>

--- a/deltatech_warehouse_access/static/description/index.html
+++ b/deltatech_warehouse_access/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Delivery Status</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Carrier status on picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Carrier status on picking</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Drop Shipping</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Delivery address in picking</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Delivery address in picking</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict picking validation to a certain security group</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict picking validation to a certain security group</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Validation Restrict Entry Exit</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">You can&#x27;t create entry/exit picking if there are no purchase/sale atached</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Picking Split</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Picking Manual Backorder</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Picking Manual Backorder</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Auto Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Automate internal transfer from transit location</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Automate internal transfer from transit location</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Stock Close</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Close stock operations at date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Close stock operations at date</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SI</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Inventory</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Warehouse</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Warehouse</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Inventory Old Method</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Inventory Old Method</p>
         </div>
       </a>
     </div>

--- a/deltatech_warehouse_arrangement/static/description/index.html
+++ b/deltatech_warehouse_arrangement/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Auto Reorder Rule</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Auto create reorder rule</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Auto create reorder rule</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">BT</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Batch Transfer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch transfer improvements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch transfer improvements</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Picking Service Lines</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Service lines in pickings</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Service lines in pickings</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Product Labels</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Print Labels on Products</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Print Labels on Products</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RN</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech reception_note</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Batch reception note</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Batch reception note</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Raport PRN</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Raport PRN</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Raport PRN</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech stock count zero</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Stock</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Stock</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set inventory line to 0 when empty count is requested</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set inventory line to 0 when empty count is requested</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>

--- a/deltatech_warehouse_map/static/description/index.html
+++ b/deltatech_warehouse_map/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -65,13 +65,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -91,7 +91,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Product Secondary UoM</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Inventory/Inventory</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Inventory/Inventory</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Product specific conversion factors between units of measure (SAP MARM style)</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Product specific conversion factors between units of measure (SAP MARM style)</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -216,10 +216,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>

--- a/deltatech_warranty/static/description/index.html
+++ b/deltatech_warranty/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Discount Policy</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Bring back Odoo 17 discount policy</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Bring back Odoo 17 discount policy</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">FS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Fast Sale</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Vanzare rapida</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Vanzare rapida</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Facturare livrari</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Facturare livrari</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">IP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Invoice Pickings Automatically</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate invoice automatically from picking after validation</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate invoice automatically from picking after validation</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Currency Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Price list currency</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Price list currency</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PL</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Price List Line Viewer</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Creates a list view for the lines of a price list for search and management</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Creates a list view for the lines of a price list for search and management</p>
         </div>
       </a>
     </div>

--- a/deltatech_watermark/static/description/index.html
+++ b/deltatech_watermark/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -77,13 +77,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -103,7 +103,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -116,10 +116,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -132,10 +132,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">MF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Markdown Field</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">WYSIWYG markdown widget storing raw Markdown in a Text field</p>
         </div>
       </a>
     </div>
@@ -148,10 +148,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NQ</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">No quick_create</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Disable quick_create</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Disable quick_create</p>
         </div>
       </a>
     </div>
@@ -164,10 +164,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">NS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Notification Sound</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Notification Sound</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Notification Sound</p>
         </div>
       </a>
     </div>
@@ -180,10 +180,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Partner Merge in Bulk</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Merge partners duplicated on the same VAT number, in bulk, in minutes instead of hours</p>
         </div>
       </a>
     </div>
@@ -196,10 +196,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">RR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech - Restrict Reports Access</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Restrict Sales Analysis and Invoice Analysis reports by group: own records, all records, or no access.</p>
         </div>
       </a>
     </div>
@@ -212,10 +212,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">TS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Test System</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Set system status: test or production</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Set system status: test or production</p>
         </div>
       </a>
     </div>
@@ -228,10 +228,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_blog/static/description/index.html
+++ b/deltatech_website_blog/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -24,13 +24,13 @@ publication date are ordered by descending record ID.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -50,7 +50,7 @@ publication date are ordered by descending record ID.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -63,10 +63,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -79,10 +79,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@ publication date are ordered by descending record ID.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_breadcrumb/static/description/index.html
+++ b/deltatech_website_breadcrumb/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website City</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website/Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website/Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">City extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">City extension</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Sale Cost Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website/Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website/Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Prevent adding to cart if price is lower than cost price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Prevent adding to cart if price is lower than cost price</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_category/static/description/index.html
+++ b/deltatech_website_category/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -84,13 +84,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -110,7 +110,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -123,10 +123,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -219,10 +219,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -235,10 +235,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_checkout_confirm/static/description/index.html
+++ b/deltatech_website_checkout_confirm/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -55,13 +55,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -81,7 +81,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -94,10 +94,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -110,10 +110,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -126,10 +126,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -142,10 +142,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -158,10 +158,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -174,10 +174,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_city/static/description/index.html
+++ b/deltatech_website_city/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -81,13 +81,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -107,7 +107,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Category Breadcrumb</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website/Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website/Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension Category Breadcrumb</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension Category Breadcrumb</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Sale Cost Price</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website/Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website/Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Prevent adding to cart if price is lower than cost price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Prevent adding to cart if price is lower than cost price</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -200,10 +200,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -216,10 +216,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -232,10 +232,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_country/static/description/index.html
+++ b/deltatech_website_country/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -74,13 +74,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -100,7 +100,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -209,10 +209,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -225,10 +225,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_delivery_address/static/description/index.html
+++ b/deltatech_website_delivery_address/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_delivery_and_payment/static/description/index.html
+++ b/deltatech_website_delivery_and_payment/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -25,13 +25,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -51,7 +51,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -64,10 +64,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -80,10 +80,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -96,10 +96,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_disable_fuzzy_search/static/description/index.html
+++ b/deltatech_website_disable_fuzzy_search/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_fixed_price/static/description/index.html
+++ b/deltatech_website_fixed_price/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WF</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website Floating Widgets</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Floating widgets on the right side of the website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Floating widgets on the right side of the website</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_floating_widgets/static/description/index.html
+++ b/deltatech_website_floating_widgets/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -24,13 +24,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -50,7 +50,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -63,10 +63,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -79,10 +79,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_pager_guard/static/description/index.html
+++ b/deltatech_website_pager_guard/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -66,13 +66,13 @@ never rendered.</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -92,7 +92,7 @@ never rendered.</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -105,10 +105,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -121,10 +121,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -137,10 +137,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -153,10 +153,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -169,10 +169,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -185,10 +185,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -201,10 +201,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -217,10 +217,10 @@ never rendered.</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_phone_validation/static/description/index.html
+++ b/deltatech_website_phone_validation/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -52,13 +52,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -78,7 +78,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -91,10 +91,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -107,10 +107,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -123,10 +123,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -139,10 +139,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -155,10 +155,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -171,10 +171,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -187,10 +187,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -203,10 +203,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_price_without_tax/static/description/index.html
+++ b/deltatech_website_price_without_tax/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_product_code/static/description/index.html
+++ b/deltatech_website_product_code/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -135,13 +135,13 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -161,7 +161,7 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -174,10 +174,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -190,10 +190,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -206,10 +206,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -222,10 +222,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -238,10 +238,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -254,10 +254,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -270,10 +270,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -286,10 +286,10 @@ of a spaced code such as <code class="border rounded px-2" style="font-family:ui
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_product_placeholder/static/description/index.html
+++ b/deltatech_website_product_placeholder/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@ Optimizes website performance by serving a single static or configurable URL for
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@ Optimizes website performance by serving a single static or configurable URL for
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@ Optimizes website performance by serving a single static or configurable URL for
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_product_url_image/static/description/index.html
+++ b/deltatech_website_product_url_image/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -30,13 +30,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -56,7 +56,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -69,10 +69,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -85,10 +85,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_attribute_filter/static/description/index.html
+++ b/deltatech_website_sale_attribute_filter/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -56,13 +56,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -82,7 +82,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -95,10 +95,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -111,10 +111,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -127,10 +127,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -143,10 +143,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -159,10 +159,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -175,10 +175,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -191,10 +191,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -207,10 +207,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_attributes/static/description/index.html
+++ b/deltatech_website_sale_attributes/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -54,13 +54,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -80,7 +80,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -93,10 +93,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -109,10 +109,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -125,10 +125,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -141,10 +141,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -157,10 +157,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -173,10 +173,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -189,10 +189,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -205,10 +205,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_cost_price/static/description/index.html
+++ b/deltatech_website_sale_cost_price/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -42,13 +42,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -68,7 +68,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Category Breadcrumb</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website/Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website/Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension Category Breadcrumb</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension Category Breadcrumb</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website City</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website/Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website/Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">City extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">City extension</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -193,10 +193,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_portal/static/description/index.html
+++ b/deltatech_website_sale_portal/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -47,13 +47,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -73,7 +73,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -198,10 +198,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_sort/static/description/index.html
+++ b/deltatech_website_sale_sort/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -32,13 +32,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -58,7 +58,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -71,10 +71,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -87,10 +87,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -103,10 +103,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -119,10 +119,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -135,10 +135,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -151,10 +151,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -167,10 +167,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -183,10 +183,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_status/static/description/index.html
+++ b/deltatech_website_sale_status/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -62,13 +62,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -88,7 +88,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -101,10 +101,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -117,10 +117,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -133,10 +133,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -149,10 +149,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -165,10 +165,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -181,10 +181,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -197,10 +197,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -213,10 +213,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_sale_wishlist/static/description/index.html
+++ b/deltatech_website_sale_wishlist/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -53,13 +53,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -79,7 +79,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -92,10 +92,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -108,10 +108,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_searchbar/static/description/index.html
+++ b/deltatech_website_searchbar/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -69,13 +69,13 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -95,7 +95,7 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -108,10 +108,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -220,10 +220,10 @@ can be adjusted directly in <code class="border rounded px-2" style="font-family
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_short_description/static/description/index.html
+++ b/deltatech_website_short_description/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -31,13 +31,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -57,7 +57,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -70,10 +70,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -86,10 +86,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -102,10 +102,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -118,10 +118,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -134,10 +134,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -150,10 +150,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -166,10 +166,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -182,10 +182,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_stock_availability/static/description/index.html
+++ b/deltatech_website_stock_availability/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -57,13 +57,13 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -83,7 +83,7 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -96,10 +96,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -112,10 +112,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -128,10 +128,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -144,10 +144,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -160,10 +160,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -176,10 +176,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -192,10 +192,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -208,10 +208,10 @@ produs, num&#259;rul de zile de siguran&#539;&#259; &#537;i num&#259;rul de zile
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_vat_validation/static/description/index.html
+++ b/deltatech_website_vat_validation/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -53,13 +53,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -79,7 +79,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -92,10 +92,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -108,10 +108,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -124,10 +124,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -140,10 +140,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -156,10 +156,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -172,10 +172,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -188,10 +188,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -204,10 +204,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>

--- a/deltatech_website_warehouse_stock/static/description/index.html
+++ b/deltatech_website_warehouse_stock/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -33,13 +33,13 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -59,7 +59,7 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -72,10 +72,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Website alternative code</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Show alternative code in website</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Show alternative code in website</p>
         </div>
       </a>
     </div>
@@ -88,10 +88,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">WS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Web Site Blog</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Sort blog posts by publication date</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Sort blog posts by publication date</p>
         </div>
       </a>
     </div>
@@ -104,10 +104,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Product Category</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Public category</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Public category</p>
         </div>
       </a>
     </div>
@@ -120,10 +120,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Checkout Confirm Order</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -136,10 +136,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Country</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce extension</p>
         </div>
       </a>
     </div>
@@ -152,10 +152,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Delivery Address</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Default delivery address</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Default delivery address</p>
         </div>
       </a>
     </div>
@@ -168,10 +168,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Delivery and Payment</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">eCommerce Delivery and Payment constrains</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">eCommerce Delivery and Payment constrains</p>
         </div>
       </a>
     </div>
@@ -184,10 +184,10 @@ The module has been updated to follow Odoo 19 standards and best practices:</p>
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">ED</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">eCommerce Display Fixed Price As Discount</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Website</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Website</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Display the cut off price for fixed pricelist rule if the price is lower than the list price</p>
         </div>
       </a>
     </div>

--- a/deltatech_widget_fontawesome/static/description/index.html
+++ b/deltatech_widget_fontawesome/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -26,13 +26,13 @@
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -52,7 +52,7 @@
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -65,10 +65,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner Restriction</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Transition module: merged into Deltatech Generic Partner</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Transition module: merged into Deltatech Generic Partner</p>
         </div>
       </a>
     </div>
@@ -81,10 +81,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LV</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">List View Select Text</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">List View Select Text</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">List View Select Text</p>
         </div>
       </a>
     </div>
@@ -97,10 +97,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">LD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Logistic Documents</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Logistic Documents</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Logistic Documents</p>
         </div>
       </a>
     </div>
@@ -113,10 +113,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GS</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Generate/Select lot</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generate/Select lot</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generate/Select lot</p>
         </div>
       </a>
     </div>
@@ -129,10 +129,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">GP</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Generic Partner</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic partner for anonymous customers, with accounting restrictions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic partner for anonymous customers, with accounting restrictions</p>
         </div>
       </a>
     </div>
@@ -145,10 +145,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Account Extension</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Stock Account Extension</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Stock Account Extension</p>
         </div>
       </a>
     </div>
@@ -161,10 +161,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Reports</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report with positions from picking lists</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report with positions from picking lists</p>
         </div>
       </a>
     </div>
@@ -177,10 +177,10 @@
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">SR</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Stock Report Reseller</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Generic Modules</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Generic Modules</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Report report reseller</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Report report reseller</p>
         </div>
       </a>
     </div>

--- a/deltatech_widget_many2one_badge/static/description/index.html
+++ b/deltatech_widget_many2one_badge/static/description/index.html
@@ -1,4 +1,4 @@
-<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;">
+<div class="mx-auto px-3" style="max-width:1100px;font-family:'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif;color:#212529;font-weight:400;">
 <!-- tb-gen v1 -->
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:#006F42;">
   <span class="d-inline-block rounded-pill fw-bold text-uppercase mb-4"
@@ -206,13 +206,13 @@ class Priority(models.Model):
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">350+</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Modules published on Odoo Apps</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Modules published on Odoo Apps</div>
     </div>
   </div>
   <div class="col-md-6">
     <div class="border rounded-3 p-4 h-100">
       <div class="fw-bold" style="font-size:2.2rem;color:#006F42;line-height:1;">Silver</div>
-      <div class="mt-2" style="font-size:0.9rem;color:#55606b;">Odoo Partner &mdash; implementation &amp; support</div>
+      <div class="mt-2" style="font-size:0.9rem;color:#3d4752;">Odoo Partner &mdash; implementation &amp; support</div>
     </div>
   </div>
 </div>
@@ -232,7 +232,7 @@ class Priority(models.Model):
 
 <section class="rounded-4 p-4 mb-3 border">
   <h2 class="text-center fw-bold mb-1" style="font-size:24px;border:none;">More apps by Terrabit</h2>
-  <p class="text-center mb-4" style="color:#55606b;">Other modules from the same publisher, built to work together.
+  <p class="text-center mb-4" style="color:#3d4752;">Other modules from the same publisher, built to work together.
     <a href="https://apps.odoo.com/apps/browse?author=Terrabit" target="_blank" rel="noopener"
        class="fw-semibold" style="color:#006F42;">All apps &rarr;</a></p>
   <div class="row g-3">
@@ -245,10 +245,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">DE</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Tools</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Tools</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Generic module</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Generic module</p>
         </div>
       </a>
     </div>
@@ -261,10 +261,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account</p>
         </div>
       </a>
     </div>
@@ -277,10 +277,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Account Analytic</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Analytic lines enhancements</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Analytic lines enhancements</p>
         </div>
       </a>
     </div>
@@ -293,10 +293,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">UD</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech UBL despatch advice</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Accounting &amp; Finance</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Accounting &amp; Finance</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Deltatech Account UBL despatch advice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Deltatech Account UBL despatch advice</p>
         </div>
       </a>
     </div>
@@ -309,10 +309,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">EC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Edit Currency Rate</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Edit the currency rate on the invoice</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Edit the currency rate on the invoice</p>
         </div>
       </a>
     </div>
@@ -325,10 +325,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AC</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Deltatech Actions</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Other</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Other</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Cleaning and other actions</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Cleaning and other actions</p>
         </div>
       </a>
     </div>
@@ -341,10 +341,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">AM</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Agreement Management</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Services/Agreement</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Services/Agreement</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Manage agreements numbers, date, state</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Manage agreements numbers, date, state</p>
         </div>
       </a>
     </div>
@@ -357,10 +357,10 @@ class Priority(models.Model):
                   style="width:40px;height:40px;line-height:40px;font-size:14px;background-color:#006F42;">PA</span>
             <span>
               <span class="d-block fw-semibold" style="font-size:14px;line-height:1.2;">Products Alternative</span>
-              <span class="d-block" style="font-size:11px;color:#55606b;">Sales</span>
+              <span class="d-block" style="font-size:11px;color:#3d4752;">Sales</span>
             </span>
           </div>
-          <p class="mb-0" style="font-size:12px;color:#55606b;">Alternative product codes</p>
+          <p class="mb-0" style="font-size:12px;color:#3d4752;">Alternative product codes</p>
         </div>
       </a>
     </div>

--- a/scripts/tb_gen_index.py
+++ b/scripts/tb_gen_index.py
@@ -76,7 +76,7 @@ TB = {
     "company": "Terrabit Solutions SRL",
     "apps_author": "Terrabit",  # filtru author pe apps.odoo.com
     "body": "#212529",  # culoarea de corp, vezi BODY/MUTED mai jos
-    "muted": "#55606b",
+    "muted": "#3d4752",  # gri-inchis: ~9.5:1 pe alb, lizibil si la 11-12px
 }
 
 FONT = "'Segoe UI','Avenir Next','Helvetica Neue',Arial,sans-serif"
@@ -103,7 +103,10 @@ TABS = [
 BODY = TB["body"]
 MUTED = TB["muted"]
 
-WRAP_OPEN = f'<div class="mx-auto px-3" style="max-width:1100px;font-family:{FONT};color:{BODY};">'
+# `font-weight:400` e obligatoriu: store-ul pune descrierea într-un `.oe_styling_v8`
+# care forțează `font-weight:300`. Moștenit, textul mic (cross-sell, stats, note) iese
+# subțire și pare gri-decolorat, chiar dacă `color` inline e corect.
+WRAP_OPEN = f'<div class="mx-auto px-3" style="max-width:1100px;font-family:{FONT};color:{BODY};font-weight:400;">'
 
 HERO = """%(marker)s
 <div class="text-white text-center rounded-4 shadow px-4 py-5 mt-2 mb-4" style="background-color:%(primary)s;">


### PR DESCRIPTION
## Problema

Pe apps.odoo.com, blocul „More apps by Terrabit" (și celelalte texte secundare din
descriere) apăreau gri-decolorate și greu de citit.

Diagnostic pe pagina live (`apps.odoo.com/apps/modules/19.0/deltatech_calendar_caldav`):
culoarea **era** cea corectă — `getComputedStyle` dă `rgb(85,96,107)` = exact `#55606b`-ul
nostru inline, nimic nu îl suprascrie. Vinovat era `font-weight`: store-ul randează
descrierea într-un `<div class="oe_styling_v8">` care forțează `font-weight:300` (regulă
dintr-un stylesheet cross-origin, invizibilă când enumeri `document.styleSheets`).
Wrapperul nostru moștenea 300, iar la 11–12px textul iese subțire și *pare* decolorat.
`PANEL` avea deja `font-weight:400` — de-asta doar taburile de descriere arătau bine.

## Modificări

- `font-weight:400` explicit pe `WRAP_OPEN` în `scripts/tb_gen_index.py`; se moștenește
  în tot conținutul nostru (hero, taburi, stats, support, cross-sell). Verificat prin
  injecție pe pagina live: subtitlul, categoria și summary trec toate la 400.
- `TB["muted"]` întunecat de la `#55606b` (6.4:1 pe alb) la `#3d4752` (~9.5:1), păstrând
  distincția față de negrul titlurilor (`#212529`).
- `static/description/index.html` regenerate pentru modulele suitei.

Modificarea e strict de prezentare — niciun fișier Python de modul, XML sau manifest atins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)