### PR TITLE
[FIX] deltatech_stock_inventory: accepta data de numarare la aplicarea ajustarii

### DIFF
--- a/deltatech_stock_inventory/__manifest__.py
+++ b/deltatech_stock_inventory/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Stock Inventory",
     "summary": "Inventory Old Method",
-    "version": "19.0.2.7.4",
+    "version": "19.0.2.7.5",
     "author": "Terrabit, Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Warehouse",

--- a/deltatech_stock_inventory/models/stock_quant.py
+++ b/deltatech_stock_inventory/models/stock_quant.py
@@ -62,7 +62,7 @@ class StockQuant(models.Model):
         self.inventory_line_id = False
         return super().action_set_inventory_quantity_to_zero()
 
-    def action_apply_inventory(self):
+    def action_apply_inventory(self, date=None):
         for quant in self:
             if (
                 not self.env.user.has_group("deltatech_stock_inventory.group_view_inventory_button")
@@ -76,7 +76,10 @@ class StockQuant(models.Model):
         #         quant.product_id.product_tmpl_id.write({"is_inventory_ok": True})
 
         inventory = self.filtered(lambda q: q.inventory_quantity_set).create_inventory_lines()
-        res = super(StockQuant, self.with_context(apply_inventory=True)).action_apply_inventory()
+        if inventory and date:
+            # Data de numărare din wizard datează mișcările; documentul trebuie să o urmeze
+            inventory.date = date
+        res = super(StockQuant, self.with_context(apply_inventory=True)).action_apply_inventory(date)
         for quant in self:
             quant.last_inventory_date = fields.Date.today()
             inventor_line = quant.inventory_line_id
@@ -84,8 +87,7 @@ class StockQuant(models.Model):
                 inventor_line.write({"is_ok": True})
 
         if inventory:
-            date = inventory.date
-            values = {"date": date, "state": "done"}
+            values = {"date": inventory.date, "state": "done"}
             if inventory.name in ("/", self.env._("New")):
                 sequence = self.env.ref("deltatech_stock_inventory.sequence_inventory_doc")
                 if sequence:

--- a/deltatech_stock_inventory/tests/__init__.py
+++ b/deltatech_stock_inventory/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_product_methods
 from . import test_stock_inventory_methods_extra
 from . import test_compute_warehouse_stocks
 from . import test_inventory_note
+from . import test_quant_apply_counting_date

--- a/deltatech_stock_inventory/tests/test_quant_apply_counting_date.py
+++ b/deltatech_stock_inventory/tests/test_quant_apply_counting_date.py
@@ -1,0 +1,54 @@
+# ©  2015-2026 Deltatech
+#              Dorin Hongu <dhongu(@)gmail(.)com>
+# See README.rst file on addons root folder for license details
+
+from odoo import fields
+from odoo.tests.common import TransactionCase
+
+
+class TestQuantApplyCountingDate(TransactionCase):
+    """Ajustarea aplicata din wizardul standard trimite data de numarare pozitional
+    catre stock.quant.action_apply_inventory; overrideul nostru trebuie sa o accepte."""
+
+    def setUp(self):
+        super().setUp()
+        self.env.user.group_ids |= self.env.ref("deltatech_stock_inventory.group_view_inventory_button")
+        self.location = self.env["stock.location"].create({"name": "Counting Date Loc", "usage": "internal"})
+        self.product = self.env["product.product"].create(
+            {"name": "Counting Date Product", "is_storable": True, "standard_price": 7.0}
+        )
+        self.quant = (
+            self.env["stock.quant"]
+            .with_context(inventory_mode=True)
+            .create(
+                {
+                    "product_id": self.product.id,
+                    "location_id": self.location.id,
+                    "inventory_quantity": 3.0,
+                }
+            )
+        )
+
+    def test_apply_from_wizard_with_counting_date(self):
+        counting_date = fields.Datetime.to_datetime("2026-01-15 08:00:00")
+        wizard = self.env["stock.inventory.adjustment.name"].create(
+            {
+                "quant_ids": [(6, 0, self.quant.ids)],
+                "inventory_adjustment_name": "Inventar test",
+                "counting_date": counting_date,
+            }
+        )
+        wizard.action_apply()
+
+        self.assertEqual(self.quant.quantity, 3.0)
+        inventory = self.env["stock.inventory"].search([("name", "=", "Inventar test")], limit=1)
+        self.assertTrue(inventory, "Ajustarea trebuie sa genereze documentul de inventar")
+        self.assertEqual(inventory.state, "done")
+        # Documentul si mișcarile poarta data de numarare, nu data de azi
+        self.assertEqual(inventory.date, counting_date)
+        move = self.env["stock.move"].search([("product_id", "=", self.product.id), ("state", "=", "done")], limit=1)
+        self.assertEqual(move.date, counting_date)
+
+    def test_apply_without_date_still_works(self):
+        self.quant.with_context(inventory_mode=True).action_apply_inventory()
+        self.assertEqual(self.quant.quantity, 3.0)


### PR DESCRIPTION
## Problema

`stock.inventory.adjustment.name.action_apply()` din standardul 19 apelează `quants.action_apply_inventory(self.counting_date)` — cu data **pozițional**. Overrideul nostru din `models/stock_quant.py` era declarat `def action_apply_inventory(self)`, deci fluxul standard „Apply" din ecranul de inventar fizic crăpa:

```
TypeError: StockQuant.action_apply_inventory() takes 1 positional argument but 2 were given
```

Semnătura standard e `action_apply_inventory(self, date=None)` încă de la deschiderea seriei; noi n-am urmat-o.

## Ce face PR-ul

- semnătura acceptă `date=None` și o trimite mai departe la `super()`;
- data de numărare se scrie și pe documentul `stock.inventory` generat — fără asta, fix-ul de semnătură ar fi lăsat mișcările pe `counting_date`, iar documentul pe data de azi;
- am scos shadowingul lui `date` din blocul de finalizare, care ascundea parametrul;
- test de regresie `tests/test_quant_apply_counting_date.py`, care trece prin wizardul standard și verifică cantitatea aplicată, data documentului și data mișcării.

## Verificare

- **înainte de fix**: testul nou dă `TypeError`, 2 erori din 2 teste;
- **după fix**: `0 failed, 0 error(s) of 2 tests`;
- suita completă a modulului: 34 teste, 1 eșec — `TestComputeWarehouseStocks.test_compute_warehouse_stocks_single_and_multi`, confirmat preexistent (picase identic cu modificările stashuite), ține de starea bazei locale `test19`;
- `pre-commit` verde pe fișierele atinse.

Același tipar exista și în `dakai_restrict_inventory_adjustments` din proiectul mdtrade, reparat separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)