### PR TITLE
[IMP] deltatech_gln: hand the GLN values over to the standard field

### DIFF
--- a/deltatech_gln/README.rst
+++ b/deltatech_gln/README.rst
@@ -65,6 +65,21 @@ Usage
 .. contents::
    :local:
 
+Changelog
+=========
+
+19.0.1.1.0
+----------
+
+- Hand the ``gln`` values over to the standard field
+  ``global_location_number`` (module ``account_add_gln``, auto-installed
+  with ``account``), which now ships the same data. Only empty target
+  values are filled, so a correction made on the standard side is never
+  overwritten and the migration is safe to re-run; partners holding two
+  different values are reported in the log instead. This module is on
+  its way out — the copy makes anything reading the standard field see
+  the full picture in the meantime.
+
 Bug Tracker
 ===========
 

--- a/deltatech_gln/__manifest__.py
+++ b/deltatech_gln/__manifest__.py
@@ -5,7 +5,7 @@
 {
     "name": "Deltatech Partner GLN ",
     "summary": "Partner Global Location Number",
-    "version": "19.0.1.0.0",
+    "version": "19.0.1.1.0",
     "author": "Terrabit,Dorin Hongu",
     "website": "https://www.terrabit.ro",
     "category": "Administration",

--- a/deltatech_gln/migrations/19.0.1.1.0/post-migration.py
+++ b/deltatech_gln/migrations/19.0.1.1.0/post-migration.py
@@ -1,0 +1,64 @@
+# ©  2026 Deltatech
+# See README.rst file on addons root folder for license details
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def migrate(cr, version):
+    """Hand this module's `gln` values over to the standard field.
+
+    Odoo now ships the same data as `res.partner.global_location_number`
+    (module `account_add_gln`, auto-installed with `account`), so this module's
+    `gln` is on its way out. Until it is removed, the two fields drift: on a
+    real database only part of the partners had been copied over by hand, and
+    the ones left behind were the commercial entities — the parent companies
+    that carry the customer references — so anything reading the standard field
+    silently saw a partner without a GLN.
+
+    Only empty target values are filled: a value already in the standard field
+    is never overwritten, so this is safe to re-run and cannot lose a
+    correction made on the standard side.
+    """
+    cr.execute(
+        """
+        SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'res_partner' AND column_name = 'global_location_number'
+        """
+    )
+    if not cr.fetchone():
+        # `account_add_gln` is not installed (no `account` on this database):
+        # there is no standard field to hand the values over to.
+        _logger.info("deltatech_gln: standard field global_location_number absent, nothing to consolidate.")
+        return
+
+    cr.execute(
+        """
+        UPDATE res_partner
+           SET global_location_number = gln
+         WHERE gln IS NOT NULL
+           AND gln <> ''
+           AND (global_location_number IS NULL OR global_location_number = '')
+        """
+    )
+    filled = cr.rowcount
+
+    cr.execute(
+        """
+        SELECT count(*) FROM res_partner
+         WHERE gln IS NOT NULL AND gln <> ''
+           AND global_location_number IS NOT NULL AND global_location_number <> ''
+           AND btrim(gln) <> btrim(global_location_number)
+        """
+    )
+    conflicts = cr.fetchone()[0]
+
+    _logger.info("deltatech_gln: %s partner(s) got their GLN copied to the standard field.", filled)
+    if conflicts:
+        _logger.warning(
+            "deltatech_gln: %s partner(s) hold a different value in `gln` and in "
+            "`global_location_number`. The standard field was left untouched for them — "
+            "decide which value is right before this module is removed.",
+            conflicts,
+        )

--- a/deltatech_gln/readme/HISTORY.md
+++ b/deltatech_gln/readme/HISTORY.md
@@ -1,0 +1,9 @@
+## 19.0.1.1.0
+
+- Hand the `gln` values over to the standard field `global_location_number`
+  (module `account_add_gln`, auto-installed with `account`), which now ships the
+  same data. Only empty target values are filled, so a correction made on the
+  standard side is never overwritten and the migration is safe to re-run;
+  partners holding two different values are reported in the log instead.
+  This module is on its way out — the copy makes anything reading the standard
+  field see the full picture in the meantime.


### PR DESCRIPTION
## De ce

`deltatech_gln` e învechit: Odoo livrează aceeași dată ca `res.partner.global_location_number`, prin `account_add_gln` (`depends: ['account']`, `auto_install: True`). Instalarea ambelor produce chiar avertizarea „Two fields (global_location_number, gln) of res.partner() have the same label: GLN".

Până la retragerea modulului, cele două câmpuri **divergă tăcut** — și divergența nu e inofensivă. Pe producția Romchim (verificat 11.09.2026):

| | parteneri |
|---|---|
| cu `gln` (câmpul acestui modul) | 142 |
| cu `global_location_number` (standard) | 129 |
| cu ambele | 127 |
| **cu ambele, valori diferite** | **0** |
| **doar cu `gln`** | **15** |

Cei 15 rămași în urmă erau tocmai **AUCHAN ROMÂNIA SA, CARREFOUR ROMANIA SA și METRO CASH & CARRY** — entitățile comerciale principale, cele care poartă referințele de client. Orice cod care citește câmpul standard îi vedea ca parteneri fără GLN.

## Ce face

Post-migration care copiază `gln` → `global_location_number` **doar unde ținta e goală**. Nu suprascrie niciodată o valoare existentă, deci o corecție făcută pe partea standardului supraviețuiește și migrarea e sigură la re-rulare. Partenerii care țin două valori diferite sunt raportați în log, nu atinși.

Dacă `account_add_gln` lipsește (bază fără `account`), migrarea iese fără efect — verifică întâi coloana în `information_schema`.

## Verificat

Pe o copie a bazei Romchim, cu SQL-ul migrării: **21 de parteneri completați, 0 conflicte**. O euristică de migrare care citește câmpul standard trece astfel de la 100 la 145 de rânduri prinse — exact cât prindea câmpul vechi.

## Legat

Perechea obligatorie: terrabit-solutions/bitshop#2820, care folosește câmpul standard pentru a identifica retailerii la migrarea referințelor de client. **Cele două trebuie merge-uite împreună, înainte de orice deploy la Romchim** — altfel euristica rulează pe date neconsolidate și prinde 100 în loc de 145.

## Rămâne de făcut

Retragerea efectivă a modulului: `deltatech_edi` și `deltatech_edinet` citesc încă `gln` în ~6 locuri (`_get_edi_partner`, `import_sale_edinet_lines`, căutarea `ShipToParty`) — toată rezolvarea partenerului EDI. PR separat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)